### PR TITLE
fix(tests): hold ENV_LOCK in runner tests that resolve the temp config path

### DIFF
--- a/src/singbox/runner.rs
+++ b/src/singbox/runner.rs
@@ -169,6 +169,9 @@ mod tests {
 
     #[test]
     fn write_config_creates_valid_json() {
+        // temp_singbox_config_path() reads XDG_RUNTIME_DIR, which other tests
+        // point at short-lived tempdirs — hold ENV_LOCK so the path stays valid.
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
         let profile = Profile::new_vless(
             "Test".to_string(),
             "1.2.3.4".to_string(),
@@ -245,6 +248,8 @@ mod tests {
     /// when the binary is not on PATH so CI without sing-box stays green.
     #[test]
     fn check_config_accepts_a_minimal_profile() {
+        // Same XDG_RUNTIME_DIR dependency as write_config_creates_valid_json.
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
         if Command::new("sh")
             .args(["-c", "command -v sing-box >/dev/null 2>&1"])
             .status()


### PR DESCRIPTION
`temp_singbox_config_path()` reads `XDG_RUNTIME_DIR`, which the `ipc.rs` tests pin to short-lived tempdirs while holding `ENV_LOCK`. Two runner tests (`write_config_creates_valid_json`, `check_config_accepts_a_minimal_profile`) resolved that path without taking the lock, so under parallel test execution they can pick up an ipc test's tempdir that gets deleted before the file is read back — observed as:

```
sing-box rejected a minimal vless profile: read config at /tmp/.tmpXXXXXX/kvn-tui-singbox.json: no such file or directory
```

The race is scheduling-dependent, so it surfaces as a rare flake. Holding `ENV_LOCK` in both tests serializes them against the env mutators, matching the convention used elsewhere in the suite.