### PR TITLE
feat(dns): make Fake-IP selection draft-based

### DIFF
--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -156,6 +156,9 @@ pub struct Model {
     /// Pending DNS strategy preview while the DNS overlay is open. Set by
     /// `h`/`l` on the Strategy row, committed by Enter, discarded by Esc.
     pub dns_strategy_draft: Option<DnsStrategy>,
+    /// Pending Fake-IP preview while the DNS overlay is open. Set by `h`/`l`
+    /// on the Fake-IP row, committed by Enter, discarded by Esc.
+    pub dns_fakeip_draft: Option<bool>,
     /// Cursor position inside the service routing overlay (index into
     /// `RoutedService::ALL`).
     pub service_routing_selected: usize,
@@ -314,6 +317,7 @@ impl Model {
             geo_region_selected: 0,
             dns_selected: 0,
             dns_strategy_draft: None,
+            dns_fakeip_draft: None,
             service_routing_selected: 0,
             service_routing_draft: None,
             pending_service_reconnect: false,
@@ -381,6 +385,7 @@ impl Model {
             geo_region_selected: 0,
             dns_selected: 0,
             dns_strategy_draft: None,
+            dns_fakeip_draft: None,
             service_routing_selected: 0,
             service_routing_draft: None,
             pending_service_reconnect: false,
@@ -578,6 +583,7 @@ impl Model {
             geo_region_selected: 0,
             dns_selected: 0,
             dns_strategy_draft: None,
+            dns_fakeip_draft: None,
             service_routing_selected: 0,
             service_routing_draft: None,
             pending_service_reconnect: false,

--- a/src/app/msg.rs
+++ b/src/app/msg.rs
@@ -229,6 +229,8 @@ pub struct StateSnapshot {
     #[serde(default)]
     pub dns_strategy_draft: Option<DnsStrategy>,
     #[serde(default)]
+    pub dns_fakeip_draft: Option<bool>,
+    #[serde(default)]
     pub theme_selected: usize,
     #[serde(default)]
     pub theme_draft: Option<String>,

--- a/src/app/update/key.rs
+++ b/src/app/update/key.rs
@@ -190,6 +190,7 @@ pub(super) fn handle_sources(model: &mut Model, key: KeyEvent) -> Vec<Effect> {
             model.overlay = Overlay::DnsSettings;
             model.dns_selected = 0;
             model.dns_strategy_draft = None;
+            model.dns_fakeip_draft = None;
         }
         KeyCode::Char('S') => {
             model.overlay = Overlay::ServiceRouting;
@@ -665,6 +666,8 @@ pub(super) fn handle_dns_settings(model: &mut Model, key: KeyEvent) -> Vec<Effec
     let len = DnsSettingsItem::ALL.len();
     let on_strategy =
         DnsSettingsItem::from_index(model.dns_selected) == Some(DnsSettingsItem::CycleStrategy);
+    let on_fakeip =
+        DnsSettingsItem::from_index(model.dns_selected) == Some(DnsSettingsItem::ToggleFakeIp);
     match key.code {
         KeyCode::Char('j') | KeyCode::Down => {
             crate::ui::nav::select_next(&mut model.dns_selected, len);
@@ -688,6 +691,12 @@ pub(super) fn handle_dns_settings(model: &mut Model, key: KeyEvent) -> Vec<Effec
                 .unwrap_or_else(|| model.config.settings.dns.strategy.clone());
             model.dns_strategy_draft = Some(base.prev());
         }
+        KeyCode::Char('l') | KeyCode::Right if on_fakeip => {
+            model.dns_fakeip_draft = Some(true);
+        }
+        KeyCode::Char('h') | KeyCode::Left if on_fakeip => {
+            model.dns_fakeip_draft = Some(false);
+        }
         KeyCode::Enter => {
             let Some(item) = DnsSettingsItem::from_index(model.dns_selected) else {
                 return vec![];
@@ -697,6 +706,7 @@ pub(super) fn handle_dns_settings(model: &mut Model, key: KeyEvent) -> Vec<Effec
         KeyCode::Char('q') | KeyCode::Esc => {
             model.overlay = Overlay::None;
             model.dns_strategy_draft = None;
+            model.dns_fakeip_draft = None;
         }
         _ => {}
     }
@@ -819,7 +829,12 @@ fn apply_dns_item(model: &mut Model, item: DnsSettingsItem) -> Vec<Effect> {
             );
         }
         DnsSettingsItem::ToggleFakeIp => {
-            let enabled = !model.config.settings.dns.fakeip_enabled;
+            let Some(enabled) = model.dns_fakeip_draft.take() else {
+                return effects;
+            };
+            if enabled == model.config.settings.dns.fakeip_enabled {
+                return effects;
+            }
             model.config.settings.dns.fakeip_enabled = enabled;
             if enabled
                 && !model
@@ -1213,9 +1228,12 @@ mod tests {
             .position(|i| *i == DnsSettingsItem::ToggleFakeIp)
             .unwrap();
         assert!(!model.config.settings.dns.fakeip_enabled);
+        handle_dns_settings(&mut model, key('l'));
+        assert_eq!(model.dns_fakeip_draft, Some(true));
         handle_dns_settings(&mut model, enter());
         assert!(model.config.settings.dns.fakeip_enabled);
         assert!(model.config.settings.dns.fakeip_server().is_some());
+        assert!(model.dns_fakeip_draft.is_none());
     }
 
     #[test]
@@ -1225,10 +1243,12 @@ mod tests {
             .iter()
             .position(|i| *i == DnsSettingsItem::ToggleFakeIp)
             .unwrap();
-        // First toggle on.
+        // Select and commit on.
+        handle_dns_settings(&mut model, key('l'));
         handle_dns_settings(&mut model, enter());
         assert!(model.config.settings.dns.fakeip_enabled);
-        // Second toggle off.
+        // Select and commit off.
+        handle_dns_settings(&mut model, key('h'));
         handle_dns_settings(&mut model, enter());
         assert!(!model.config.settings.dns.fakeip_enabled);
     }
@@ -1242,6 +1262,7 @@ mod tests {
             .iter()
             .position(|i| *i == DnsSettingsItem::ToggleFakeIp)
             .unwrap();
+        handle_dns_settings(&mut model, key('l'));
         handle_dns_settings(&mut model, enter());
         assert_eq!(model.config.settings.dns.strategy, DnsStrategy::PreferIpv4);
         assert_eq!(model.config.settings.dns_strategy, DnsStrategy::PreferIpv4);
@@ -1255,10 +1276,12 @@ mod tests {
             .position(|i| *i == DnsSettingsItem::CycleStrategy)
             .unwrap();
         model.dns_strategy_draft = Some(DnsStrategy::OnlyIpv6);
+        model.dns_fakeip_draft = Some(true);
         let effects = handle_dns_settings(&mut model, esc());
         assert!(effects.is_empty());
         assert_eq!(model.overlay, Overlay::None);
         assert!(model.dns_strategy_draft.is_none());
+        assert!(model.dns_fakeip_draft.is_none());
     }
 
     #[test]
@@ -1374,11 +1397,13 @@ mod tests {
         let mut model = model_with_profiles(vec![]);
         model.dns_selected = 4;
         model.dns_strategy_draft = Some(DnsStrategy::OnlyIpv6);
+        model.dns_fakeip_draft = Some(true);
         let effects = handle_sources(&mut model, key('D'));
         assert!(effects.is_empty());
         assert_eq!(model.overlay, Overlay::DnsSettings);
         assert_eq!(model.dns_selected, 0);
         assert!(model.dns_strategy_draft.is_none());
+        assert!(model.dns_fakeip_draft.is_none());
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -637,6 +637,7 @@ fn build_snapshot(model: &Model) -> StateSnapshot {
         geo_region_selected: model.geo_region_selected,
         dns_selected: model.dns_selected,
         dns_strategy_draft: model.dns_strategy_draft.clone(),
+        dns_fakeip_draft: model.dns_fakeip_draft,
         theme_selected: model.theme_selected,
         theme_draft: model.theme_draft.clone(),
         service_routing_selected: model.service_routing_selected,

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -234,6 +234,7 @@ mod tests {
             geo_region_selected: 0,
             dns_selected: 0,
             dns_strategy_draft: None,
+            dns_fakeip_draft: None,
             theme_selected: 0,
             theme_draft: None,
             service_routing_selected: 0,

--- a/src/tui_client.rs
+++ b/src/tui_client.rs
@@ -266,6 +266,7 @@ fn apply_snapshot(model: &mut Model, snapshot: crate::app::msg::StateSnapshot) {
     model.geo_region_selected = snapshot.geo_region_selected;
     model.dns_selected = snapshot.dns_selected;
     model.dns_strategy_draft = snapshot.dns_strategy_draft;
+    model.dns_fakeip_draft = snapshot.dns_fakeip_draft;
     model.theme_selected = snapshot.theme_selected;
     model.theme_draft = snapshot.theme_draft.clone();
     model.service_routing_selected = snapshot.service_routing_selected;

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -315,7 +315,16 @@ fn draw_dns_settings(frame: &mut Frame, model: &Model, area: Rect) {
     } else {
         format!("Strategy: ‹ {} ›", dns.strategy.as_str())
     };
-    let fakeip_label = format!("Fake-IP: {}", if dns.fakeip_enabled { "on" } else { "off" });
+    let fakeip = model.dns_fakeip_draft.unwrap_or(dns.fakeip_enabled);
+    let fakeip_label = format!(
+        "Fake-IP: ‹ {} ›{}",
+        if fakeip { "on" } else { "off" },
+        if model.dns_fakeip_draft.is_some() && fakeip != dns.fakeip_enabled {
+            " *"
+        } else {
+            ""
+        }
+    );
     let labels: Vec<String> = vec![
         "Preset: Cloudflare DoH (1.1.1.1)".to_string(),
         "Preset: Google DoT (8.8.8.8)".to_string(),

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_dns_settings_overlay_fakeip_on_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_dns_settings_overlay_fakeip_on_snapshot.snap
@@ -16,7 +16,7 @@ expression: "snapshot_terminal(&model, 80, 24)"
 │               │          Preset: Quad9 DoH (9.9.9.9)         │               │
 │               │        Preset: System resolver (local)       │               │
 │               │           Strategy: ‹ prefer_ipv4 ›          │               │
-│               │                 > Fake-IP: on                │               │
+│               │               > Fake-IP: ‹ on ›              │               │
 │               │                                              │               │
 │               │    j/k navigate, Enter confirm, Esc cancel   │               │
 │               └──────────────────────────────────────────────┘               │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_dns_settings_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_dns_settings_overlay_snapshot.snap
@@ -16,7 +16,7 @@ expression: "snapshot_terminal(&model, 80, 24)"
 │               │          Preset: Quad9 DoH (9.9.9.9)         │               │
 │               │        Preset: System resolver (local)       │               │
 │               │          > Strategy: ‹ prefer_ipv4 ›         │               │
-│               │                 Fake-IP: off                 │               │
+│               │               Fake-IP: ‹ off ›               │               │
 │               │                                              │               │
 │               │    j/k navigate, Enter confirm, Esc cancel   │               │
 │               └──────────────────────────────────────────────┘               │


### PR DESCRIPTION
Preview Fake-IP changes with h/l and arrow keys, then commit the selected value on Enter or discard the draft with Esc.

Carry the Fake-IP draft through daemon state snapshots so the TUI preview stays synchronized, and update reducer and UI snapshot coverage for the new interaction.