### PR TITLE
fix(dns): cycle Fake-IP selection in both directions

### DIFF
--- a/src/app/update/key.rs
+++ b/src/app/update/key.rs
@@ -692,10 +692,16 @@ pub(super) fn handle_dns_settings(model: &mut Model, key: KeyEvent) -> Vec<Effec
             model.dns_strategy_draft = Some(base.prev());
         }
         KeyCode::Char('l') | KeyCode::Right if on_fakeip => {
-            model.dns_fakeip_draft = Some(true);
+            let current = model
+                .dns_fakeip_draft
+                .unwrap_or(model.config.settings.dns.fakeip_enabled);
+            model.dns_fakeip_draft = Some(!current);
         }
         KeyCode::Char('h') | KeyCode::Left if on_fakeip => {
-            model.dns_fakeip_draft = Some(false);
+            let current = model
+                .dns_fakeip_draft
+                .unwrap_or(model.config.settings.dns.fakeip_enabled);
+            model.dns_fakeip_draft = Some(!current);
         }
         KeyCode::Enter => {
             let Some(item) = DnsSettingsItem::from_index(model.dns_selected) else {
@@ -1251,6 +1257,25 @@ mod tests {
         handle_dns_settings(&mut model, key('h'));
         handle_dns_settings(&mut model, enter());
         assert!(!model.config.settings.dns.fakeip_enabled);
+    }
+
+    #[test]
+    fn dns_settings_fakeip_cycles_in_both_directions() {
+        let mut model = with_dns_overlay();
+        model.dns_selected = DnsSettingsItem::ALL
+            .iter()
+            .position(|i| *i == DnsSettingsItem::ToggleFakeIp)
+            .unwrap();
+
+        handle_dns_settings(&mut model, key('l'));
+        assert_eq!(model.dns_fakeip_draft, Some(true));
+        handle_dns_settings(&mut model, KeyEvent::from(KeyCode::Right));
+        assert_eq!(model.dns_fakeip_draft, Some(false));
+
+        handle_dns_settings(&mut model, key('h'));
+        assert_eq!(model.dns_fakeip_draft, Some(true));
+        handle_dns_settings(&mut model, KeyEvent::from(KeyCode::Left));
+        assert_eq!(model.dns_fakeip_draft, Some(false));
     }
 
     #[test]


### PR DESCRIPTION
  ## Summary

  Makes Fake-IP selection in the DNS settings overlay cyclic.

  Both h/l and ←/→ now toggle the draft value between on and off on
  every press instead of assigning a fixed value based on direction.

  ## Changes

  - Cycle Fake-IP draft state in both directions
  - Add tests for repeated cycling with Vim keys and arrow keys