### PR TITLE
fix(tui): restore keyboard input after closing editor

### DIFF
--- a/src/tui_client.rs
+++ b/src/tui_client.rs
@@ -5,7 +5,6 @@ pub(crate) mod theme_watch;
 
 use std::io::{self, IsTerminal, Write};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Sender, channel};
 use std::thread;
 use std::time::Duration;
@@ -102,7 +101,7 @@ pub fn run() -> Result<()> {
     model.theme = theme_watch::resolve_active(&model.config.settings.theme);
 
     let (tx, rx) = channel::<Msg>();
-    let event_reading_enabled = Arc::new(AtomicBool::new(true));
+    let event_reader_control = Arc::new(input::EventReaderControl::new());
     spawn_ticker(tx.clone());
     theme_watch::spawn_theme_watcher(tx.clone());
     client.spawn_reader(tx.clone())?;
@@ -112,7 +111,7 @@ pub fn run() -> Result<()> {
     let stdout = io::stdout();
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
-    input::spawn_event_reader(tx, event_reading_enabled.clone());
+    input::spawn_event_reader(tx, event_reader_control.clone());
 
     let mut log_tailer = LogTailer::new(vec![
         (crate::paths::app_log_path(), "[app]"),
@@ -125,7 +124,7 @@ pub fn run() -> Result<()> {
         rx,
         &mut client,
         &mut log_tailer,
-        event_reading_enabled,
+        event_reader_control,
     )
 }
 
@@ -135,7 +134,7 @@ fn run_loop(
     rx: std::sync::mpsc::Receiver<Msg>,
     client: &mut IpcClient,
     log_tailer: &mut LogTailer,
-    event_reading_enabled: Arc<AtomicBool>,
+    event_reader_control: Arc<input::EventReaderControl>,
 ) -> Result<()> {
     // Initial draw
     terminal.draw(|f| crate::ui::draw(f, model))?;
@@ -197,7 +196,11 @@ fn run_loop(
                         }
                     }
                     KeyCode::Char('e') => {
-                        event_reading_enabled.store(false, Ordering::Relaxed);
+                        anyhow::ensure!(
+                            event_reader_control.pause(),
+                            "Timed out while pausing terminal input for external editor"
+                        );
+                        input::disable_keyboard_protocol(terminal.backend_mut())?;
                         disable_raw_mode()?;
                         terminal.backend_mut().execute(LeaveAlternateScreen)?;
                         let result = self::editor::open_profiles_editor(
@@ -205,9 +208,10 @@ fn run_loop(
                         );
                         enable_raw_mode()?;
                         terminal.backend_mut().execute(EnterAlternateScreen)?;
+                        input::enable_keyboard_protocol(terminal.backend_mut())?;
                         terminal.clear()?;
                         input::discard_pending_input();
-                        event_reading_enabled.store(true, Ordering::Relaxed);
+                        event_reader_control.resume();
                         match result {
                             Ok(_) => {
                                 if let Ok(config) = crate::config::load_config() {

--- a/src/tui_client/editor.rs
+++ b/src/tui_client/editor.rs
@@ -1,14 +1,9 @@
 use std::env;
 use std::fs;
-use std::io::{self, stdout};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{Context, Result};
-use crossterm::ExecutableCommand;
-use crossterm::terminal::{
-    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
-};
 
 use crate::config::profile::Config;
 use crate::paths::profiles_path;
@@ -40,34 +35,6 @@ fn split_editor(editor: &str) -> (String, Vec<String>) {
     let mut parts = editor.split_whitespace().map(String::from);
     let program = parts.next().unwrap_or_else(|| "vi".to_string());
     (program, parts.collect())
-}
-
-/// RAII guard that restores terminal state when dropped.
-///
-/// On creation: leaves the alternate screen and disables raw mode.
-/// On drop: re-enters the alternate screen and re-enables raw mode.
-struct TerminalGuard;
-
-impl TerminalGuard {
-    fn new() -> io::Result<Self> {
-        disable_raw_mode().inspect_err(|e| {
-            tracing::warn!("Failed to disable raw mode: {}", e);
-        })?;
-        stdout().execute(LeaveAlternateScreen).inspect_err(|e| {
-            tracing::warn!("Failed to leave alternate screen: {}", e);
-        })?;
-        Ok(Self)
-    }
-}
-
-impl Drop for TerminalGuard {
-    fn drop(&mut self) {
-        let _ = stdout()
-            .execute(EnterAlternateScreen)
-            .inspect_err(|e| tracing::warn!("Failed to enter alternate screen: {}", e));
-        let _ =
-            enable_raw_mode().inspect_err(|e| tracing::warn!("Failed to enable raw mode: {}", e));
-    }
 }
 
 /// RAII guard for a config file backup.
@@ -209,8 +176,8 @@ fn editor_args(editor: &str, path: &Path, line: usize) -> Vec<String> {
 /// Open `profiles.json` in the user's preferred external editor.
 ///
 /// If `profile_index` is within bounds, the editor will be asked to jump to the
-/// line where that profile object starts. Terminal state is temporarily restored
-/// so the editor can take full control. A backup is created before editing; if
+/// line where that profile object starts. The caller must restore the terminal
+/// before invoking this function. A backup is created before editing; if
 /// the edited file contains invalid JSON, the backup is restored automatically
 /// and an error is returned. On success the parsed [`Config`] is returned so
 /// the application can reload.
@@ -222,8 +189,6 @@ pub fn open_profiles_editor(profile_index: usize) -> Result<Config> {
     ensure_profiles_file(&path)?;
 
     let mut backup = ConfigBackup::create(&path)?;
-
-    let _guard = TerminalGuard::new().context("Failed to restore terminal for external editor")?;
 
     let args = if let Some(line) = find_profile_line(&path, profile_index) {
         editor_args(&program, &path, line)

--- a/src/tui_client/input.rs
+++ b/src/tui_client/input.rs
@@ -29,6 +29,37 @@ pub(super) const POP_KEYBOARD_PROTOCOL: &str = "\x1b[<1u";
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 const ESCAPE_TIMEOUT: Duration = Duration::from_millis(30);
 
+pub(super) struct EventReaderControl {
+    reading_enabled: AtomicBool,
+    paused: AtomicBool,
+}
+
+impl EventReaderControl {
+    pub(super) fn new() -> Self {
+        Self {
+            reading_enabled: AtomicBool::new(true),
+            paused: AtomicBool::new(false),
+        }
+    }
+
+    /// Stop the reader and wait until it can no longer consume editor input.
+    pub(super) fn pause(&self) -> bool {
+        self.reading_enabled.store(false, Ordering::Release);
+        let deadline = Instant::now() + Duration::from_millis(250);
+        while !self.paused.load(Ordering::Acquire) {
+            if Instant::now() >= deadline {
+                return false;
+            }
+            thread::sleep(Duration::from_millis(1));
+        }
+        true
+    }
+
+    pub(super) fn resume(&self) {
+        self.reading_enabled.store(true, Ordering::Release);
+    }
+}
+
 pub(super) fn enable_keyboard_protocol(out: &mut impl Write) -> io::Result<()> {
     out.write_all(PUSH_KEYBOARD_PROTOCOL.as_bytes())?;
     out.flush()
@@ -39,7 +70,7 @@ pub(super) fn disable_keyboard_protocol(out: &mut impl Write) -> io::Result<()> 
     out.flush()
 }
 
-pub(super) fn spawn_event_reader(tx: Sender<Msg>, reading_enabled: Arc<AtomicBool>) {
+pub(super) fn spawn_event_reader(tx: Sender<Msg>, control: Arc<EventReaderControl>) {
     spawn_resize_reader(tx.clone());
     thread::spawn(move || {
         let mut decoder = Decoder::default();
@@ -47,10 +78,12 @@ pub(super) fn spawn_event_reader(tx: Sender<Msg>, reading_enabled: Arc<AtomicBoo
         let mut bytes = [0_u8; 64];
 
         loop {
-            if !reading_enabled.load(Ordering::Relaxed) {
+            if !control.reading_enabled.load(Ordering::Acquire) {
+                control.paused.store(true, Ordering::Release);
                 thread::sleep(POLL_INTERVAL);
                 continue;
             }
+            control.paused.store(false, Ordering::Release);
 
             match stdin_ready(POLL_INTERVAL) {
                 Ok(true) => match stdin.read(&mut bytes) {
@@ -399,6 +432,25 @@ fn event(code: KeyCode, modifiers: KeyModifiers, used: usize) -> ParseResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn event_reader_control_waits_for_pause_acknowledgement() {
+        let control = Arc::new(EventReaderControl::new());
+        let reader_control = control.clone();
+        let reader = thread::spawn(move || {
+            while reader_control.reading_enabled.load(Ordering::Acquire) {
+                thread::yield_now();
+            }
+            reader_control.paused.store(true, Ordering::Release);
+            while !reader_control.reading_enabled.load(Ordering::Acquire) {
+                thread::yield_now();
+            }
+        });
+
+        assert!(control.pause());
+        control.resume();
+        reader.join().unwrap();
+    }
 
     fn decode(input: &[u8]) -> KeyEvent {
         match parse_one(input, true) {


### PR DESCRIPTION
 ## Summary

  Fixes an intermittent issue where the TUI stopped responding to
  keyboard input after closing the external profiles editor.

  ## Changes

  - Centralize terminal state management in the TUI client
  - Remove duplicate raw mode and alternate screen handling from the
    editor module
  - Wait for the event reader to pause before launching the editor
  - Restore the Kitty keyboard protocol after returning to the TUI
  - Add a timeout to prevent indefinite hangs while pausing input
  - Add coverage for event-reader pause and resume synchronization