### PR TITLE
fix(tui): preserve selection after editing profiles

### DIFF
--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -529,6 +529,35 @@ impl Model {
         }
     }
 
+    /// Replace the config while keeping the cursor on the same source item.
+    /// If the selected item was removed, clamp the previous row to the new list.
+    pub fn replace_config_preserving_selection(&mut self, config: Config) {
+        let selected_row = self.selected;
+        let selected_profile_id = self.selected_profile().map(|profile| profile.id);
+        let selected_subscription_id = self.selected_subscription().map(|sub| sub.id);
+
+        self.config = config;
+        self.selected = selected_profile_id
+            .and_then(|id| {
+                self.config
+                    .profiles
+                    .iter()
+                    .position(|profile| profile.id == id)
+            })
+            .map(|idx| row_for_profile(&self.config, idx))
+            .or_else(|| {
+                selected_subscription_id
+                    .and_then(|id| {
+                        self.config
+                            .subscriptions
+                            .iter()
+                            .position(|sub| sub.id == id)
+                    })
+                    .map(|idx| row_for_subscription_header(&self.config, idx))
+            })
+            .unwrap_or_else(|| selected_row.min(self.source_rows().len().saturating_sub(1)));
+    }
+
     /// Remove the currently selected source item after confirmation.
     pub fn delete_selected(&mut self) {
         let rows = self.source_rows();

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -309,8 +309,7 @@ fn handle_config_reloaded(
                     .is_some_and(|id| !config.profiles.iter().any(|profile| profile.id == id));
             let region_changed = model.config.settings.geo_routing.current_region
                 != config.settings.geo_routing.current_region;
-            model.selected = crate::app::model::row_for_profile(&config, config.resolve_selected());
-            model.config = config;
+            model.replace_config_preserving_selection(config);
             let mut effects = vec![Effect::BroadcastState];
             if active_missing {
                 effects.push(Effect::Disconnect);
@@ -974,6 +973,34 @@ mod tests {
             effects,
             vec![Effect::BroadcastState, app_log_info("Profiles reloaded")]
         );
+    }
+
+    #[test]
+    fn config_reloaded_preserves_selected_profile() {
+        let mut model = model_with_profiles(vec![
+            Profile::new_vless(
+                "A".to_string(),
+                "1.1.1.1".to_string(),
+                443,
+                "u1".to_string(),
+            ),
+            Profile::new_vless(
+                "B".to_string(),
+                "2.2.2.2".to_string(),
+                443,
+                "u2".to_string(),
+            ),
+        ]);
+        model.selected = 1;
+        let selected_id = model.selected_profile().unwrap().id;
+        let mut config = model.config.clone();
+        config.profiles[1].name = "B edited".to_string();
+
+        update(&mut model, Msg::ConfigReloaded(Box::new(Ok(config))));
+
+        assert_eq!(model.selected, 1);
+        assert_eq!(model.selected_profile().unwrap().id, selected_id);
+        assert_eq!(model.selected_profile().unwrap().name, "B edited");
     }
 
     #[test]

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -1359,15 +1359,6 @@ impl Default for Config {
 }
 
 impl Config {
-    /// Resolve the selected profile index from `settings.default_profile`.
-    /// Returns the index of the default profile if it exists, otherwise `0`.
-    pub fn resolve_selected(&self) -> usize {
-        self.settings
-            .default_profile
-            .and_then(|id| self.profiles.iter().position(|p| p.id == id))
-            .unwrap_or(0)
-    }
-
     /// Validate semantic constraints that serde cannot enforce.
     ///
     /// Checks:

--- a/src/tui_client.rs
+++ b/src/tui_client.rs
@@ -215,11 +215,7 @@ fn run_loop(
                         match result {
                             Ok(_) => {
                                 if let Ok(config) = crate::config::load_config() {
-                                    model.selected = crate::app::model::row_for_profile(
-                                        &config,
-                                        config.resolve_selected(),
-                                    );
-                                    model.config = config;
+                                    model.replace_config_preserving_selection(config);
                                 }
                                 client.send(&IpcCommand::ReloadConfig)?;
                             }


### PR DESCRIPTION
 ## Summary

  Preserves the current TUI selection after closing the external
  profiles editor.

  Previously, reloading profiles.json reset the cursor to the first or
  default profile.

  ## Changes

  - Preserve selected profiles and subscriptions by UUID
  - Apply selection restoration in both the TUI client and daemon
  - Keep the nearest valid row when the selected item was removed
  - Remove the obsolete default-profile selection helper
  - Add coverage for preserving selection after configuration reload