### PR TITLE
fix(runtime): guard asynchronous state updates

### DIFF
--- a/src/app/effect.rs
+++ b/src/app/effect.rs
@@ -7,6 +7,7 @@ pub enum Effect {
     Connect {
         profile: Profile,
         settings: Settings,
+        attempt_id: u64,
     },
     Disconnect,
     DownloadGeo,
@@ -31,13 +32,11 @@ pub enum Effect {
     ApplyKillSwitch {
         enabled: bool,
     },
-    /// Ask the daemon to scrape the Clash API once. Carries the previous
-    /// sample so the daemon's blocking fetcher thread can post back raw
-    /// totals, and the pure-layer reducer computes the rate from the delta.
+    /// Ask the daemon to scrape the Clash API once. IDs bind the asynchronous
+    /// reply to the current connection and order overlapping requests.
     FetchTrafficStats {
-        prev_up_total: u64,
-        prev_down_total: u64,
-        prev_sampled_at_ms: u64,
+        attempt_id: u64,
+        request_id: u64,
     },
     /// Test a profile's reachability and measure latency via a temporary
     /// sing-box SOCKS5 inbound. Result is sent back as `Msg::TestResult`.

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -153,6 +153,14 @@ pub struct Model {
     /// Explicit target for a queued connection attempt. This must never be
     /// inferred from `selected`, which is only the UI cursor.
     pub connecting_profile_id: Option<Uuid>,
+    /// Monotonic token identifying the only connection attempt whose result
+    /// may still mutate the model. Incremented for every queued connection
+    /// and invalidated by the daemon on disconnect.
+    pub connect_attempt_id: u64,
+    /// Desired kill-switch state while the privileged helper is running.
+    /// Prevents repeated `K` presses from launching concurrent systemd/nft
+    /// operations whose replies could arrive out of order.
+    pub kill_switch_pending: Option<bool>,
     pub routing_selected: usize,
     pub geo_region_selected: usize,
     pub dns_selected: usize,
@@ -197,6 +205,11 @@ pub struct Model {
     /// epoch. Used by the pure reducer to compute rate deltas. Set to 0
     /// when there is no prior sample.
     pub last_traffic_sample_at_ms: u64,
+    /// Monotonic ID assigned to the next Clash API poll for this connection.
+    pub traffic_request_id: u64,
+    /// Newest traffic response accepted by the reducer. Older replies from
+    /// overlapping workers are ignored instead of rolling counters back.
+    pub last_traffic_response_id: u64,
     /// When the daemon last issued an `Effect::FetchTrafficStats`. Used by
     /// `handle_tick` to throttle Clash-API polling to ~1 Hz. Not serialized —
     /// clients don't need it.
@@ -320,6 +333,8 @@ impl Model {
             singbox_pid: bg_pid,
             active_profile_id: bg_id,
             connecting_profile_id,
+            connect_attempt_id: u64::from(connecting_profile_id.is_some()),
+            kill_switch_pending: None,
             routing_selected: 0,
             geo_region_selected: 0,
             dns_selected: 0,
@@ -340,6 +355,8 @@ impl Model {
             geo_last_attempt_at: None,
             traffic: TrafficStats::default(),
             last_traffic_sample_at_ms: 0,
+            traffic_request_id: 0,
+            last_traffic_response_id: 0,
             last_traffic_fetch_at: None,
             theme: Theme::legacy(),
             theme_selected: 0,
@@ -389,6 +406,8 @@ impl Model {
             singbox_pid: None,
             active_profile_id: None,
             connecting_profile_id: None,
+            connect_attempt_id: 0,
+            kill_switch_pending: None,
             routing_selected: 0,
             geo_region_selected: 0,
             dns_selected: 0,
@@ -409,6 +428,8 @@ impl Model {
             geo_last_attempt_at: None,
             traffic: TrafficStats::default(),
             last_traffic_sample_at_ms: 0,
+            traffic_request_id: 0,
+            last_traffic_response_id: 0,
             last_traffic_fetch_at: None,
             theme: Theme::legacy(),
             theme_selected: 0,
@@ -617,6 +638,8 @@ impl Model {
             singbox_pid: None,
             active_profile_id: None,
             connecting_profile_id: None,
+            connect_attempt_id: 0,
+            kill_switch_pending: None,
             routing_selected: 0,
             geo_region_selected: 0,
             dns_selected: 0,
@@ -637,6 +660,8 @@ impl Model {
             geo_last_attempt_at: None,
             traffic: TrafficStats::default(),
             last_traffic_sample_at_ms: 0,
+            traffic_request_id: 0,
+            last_traffic_response_id: 0,
             last_traffic_fetch_at: None,
             theme: Theme::legacy(),
             theme_selected: 0,

--- a/src/app/msg.rs
+++ b/src/app/msg.rs
@@ -55,12 +55,16 @@ pub enum Msg {
     SystemResumed,
     Connected {
         pid: u32,
+        attempt_id: u64,
         /// The profile that actually connected. Carried through the connect
         /// flow because the cursor may have moved since the connect was
         /// issued — attribution must not depend on the selection.
         profile_id: Uuid,
     },
-    ConnectFailed(IpcError),
+    ConnectFailed {
+        attempt_id: u64,
+        error: IpcError,
+    },
     /// A service rule-set download pass finished (files may still be missing
     /// if individual downloads failed — absence degrades to "no rule for
     /// that service"). Consumed by the reducer to run the reconnect that a
@@ -83,6 +87,8 @@ pub enum Msg {
     /// timestamped so the pure-layer can compute a per-second rate against
     /// the previous sample stored in `Model::traffic`.
     TrafficStatsUpdated {
+        attempt_id: u64,
+        request_id: u64,
         up_total: u64,
         down_total: u64,
         conn_count: usize,

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -56,7 +56,14 @@ pub fn update(model: &mut Model, msg: Msg) -> Vec<Effect> {
                 vec![]
             }
         }
-        Msg::Connected { pid, profile_id } => {
+        Msg::Connected {
+            pid,
+            profile_id,
+            attempt_id,
+        } => {
+            if attempt_id != model.connect_attempt_id {
+                return vec![];
+            }
             model.singbox_pid = Some(pid);
             model.connection = ConnectionState::Connected;
             model.connecting_profile_id = None;
@@ -65,6 +72,8 @@ pub fn update(model: &mut Model, msg: Msg) -> Vec<Effect> {
             // first delta is computed against zero rather than a stale value.
             model.traffic = TrafficStats::default();
             model.last_traffic_sample_at_ms = 0;
+            model.traffic_request_id = 0;
+            model.last_traffic_response_id = 0;
             model.last_traffic_fetch_at = None;
             let mut effects = vec![Effect::WriteState];
             // The tunnel is up — fetch rule-sets for enabled service routes
@@ -144,17 +153,24 @@ pub fn update(model: &mut Model, msg: Msg) -> Vec<Effect> {
             }
             effects
         }
-        Msg::ConnectFailed(err) => {
+        Msg::ConnectFailed { attempt_id, error } => {
+            if attempt_id != model.connect_attempt_id {
+                return vec![];
+            }
             model.connection = ConnectionState::Idle;
             model.connecting_profile_id = None;
+            model.singbox_pid = None;
+            model.active_profile_id = None;
             model.traffic = TrafficStats::default();
             model.last_traffic_sample_at_ms = 0;
+            model.traffic_request_id = 0;
+            model.last_traffic_response_id = 0;
             model.last_traffic_fetch_at = None;
             let mut effects = vec![Effect::BroadcastState];
             push_status(
                 &mut effects,
                 model,
-                crate::app::model::AppStatus::Error(format!("Connection failed: {}", err)),
+                crate::app::model::AppStatus::Error(format!("Connection failed: {}", error)),
             );
             effects
         }
@@ -170,11 +186,21 @@ pub fn update(model: &mut Model, msg: Msg) -> Vec<Effect> {
             handle_kill_switch_applied(model, enabled, error)
         }
         Msg::TrafficStatsUpdated {
+            attempt_id,
+            request_id,
             up_total,
             down_total,
             conn_count,
             sampled_at_ms,
-        } => handle_traffic_stats_updated(model, up_total, down_total, conn_count, sampled_at_ms),
+        } => handle_traffic_stats_updated(
+            model,
+            attempt_id,
+            request_id,
+            up_total,
+            down_total,
+            conn_count,
+            sampled_at_ms,
+        ),
         Msg::ThemeChanged(theme) => {
             // Manual picker override wins: ignore Omarchy watcher events
             // unless the user has explicitly opted into auto-follow.
@@ -207,11 +233,19 @@ pub(crate) fn compute_rate(prev_total: u64, curr_total: u64, elapsed_ms: u64) ->
 
 fn handle_traffic_stats_updated(
     model: &mut Model,
+    attempt_id: u64,
+    request_id: u64,
     up_total: u64,
     down_total: u64,
     conn_count: usize,
     sampled_at_ms: u64,
 ) -> Vec<Effect> {
+    if model.connection != ConnectionState::Connected
+        || attempt_id != model.connect_attempt_id
+        || request_id <= model.last_traffic_response_id
+    {
+        return vec![];
+    }
     let prev_at_ms = model.last_traffic_sample_at_ms;
     // No prior sample yet — record totals but leave rates at zero. The next
     // tick produces the first instantaneous reading against this baseline.
@@ -232,6 +266,7 @@ fn handle_traffic_stats_updated(
         conn_count,
     };
     model.last_traffic_sample_at_ms = sampled_at_ms;
+    model.last_traffic_response_id = request_id;
     vec![Effect::BroadcastState]
 }
 
@@ -240,6 +275,10 @@ fn handle_kill_switch_applied(
     enabled: bool,
     error: Option<crate::app::msg::IpcError>,
 ) -> Vec<Effect> {
+    if model.kill_switch_pending != Some(enabled) {
+        return Vec::new();
+    }
+    model.kill_switch_pending = None;
     let mut effects = Vec::new();
     match error {
         None => {
@@ -298,24 +337,70 @@ fn handle_config_reloaded(
     result: Result<crate::config::profile::Config, crate::app::msg::IpcError>,
 ) -> Vec<Effect> {
     match result {
-        Ok(config) => {
+        Ok(mut config) => {
+            let old_settings = model.config.settings.clone();
+            let kill_switch_ignored = config.settings.kill_switch != old_settings.kill_switch;
+            // The persisted flag is not the source of truth for the live
+            // firewall. Only ApplyKillSwitch may change it after the helper
+            // succeeds, so an editor reload must not create config/systemd
+            // drift.
+            config.settings.kill_switch = old_settings.kill_switch;
+            let runtime_settings_changed =
+                connection_settings_changed(&old_settings, &config.settings);
+            let service_routes_changed = old_settings.geo_routing.service_routes
+                != config.settings.geo_routing.service_routes;
+            let active_profile_changed = model.active_profile_id.is_some_and(|id| {
+                profile_runtime_changed_for_id(&model.config.profiles, &config.profiles, id)
+            });
+            let connecting_profile_changed = model.connecting_profile_id.is_some_and(|id| {
+                profile_runtime_changed_for_id(&model.config.profiles, &config.profiles, id)
+            });
             let active_missing = model.connection == ConnectionState::Connected
                 && model
                     .active_profile_id
                     .is_some_and(|id| !config.profiles.iter().any(|profile| profile.id == id));
-            let connecting_missing = model.connection == ConnectionState::Connecting
-                && model
-                    .connecting_profile_id
-                    .is_some_and(|id| !config.profiles.iter().any(|profile| profile.id == id));
+            let connecting_missing = matches!(
+                model.connection,
+                ConnectionState::Connecting | ConnectionState::ConnectPending
+            ) && model
+                .connecting_profile_id
+                .is_some_and(|id| !config.profiles.iter().any(|profile| profile.id == id));
             let region_changed = model.config.settings.geo_routing.current_region
                 != config.settings.geo_routing.current_region;
             model.replace_config_preserving_selection(config);
             let mut effects = vec![Effect::BroadcastState];
-            if active_missing {
+            if active_missing || connecting_missing {
                 effects.push(Effect::Disconnect);
-            } else if connecting_missing {
-                model.connection = ConnectionState::Idle;
-                model.connecting_profile_id = None;
+            } else {
+                let runtime_changed = runtime_settings_changed
+                    || match model.connection {
+                        ConnectionState::Connected => active_profile_changed,
+                        ConnectionState::Connecting | ConnectionState::ConnectPending => {
+                            connecting_profile_changed
+                        }
+                        _ => false,
+                    };
+                if runtime_changed {
+                    match model.connection {
+                        ConnectionState::Connected if service_routes_changed => {
+                            model.pending_service_reconnect = true;
+                            effects.push(Effect::DownloadServiceRuleSetsIfMissing);
+                        }
+                        ConnectionState::Connected => {
+                            if let Some(id) = model.active_profile_id {
+                                queue_connect(model, id);
+                            }
+                        }
+                        ConnectionState::ConnectPending => {
+                            if let Some(id) = model.connecting_profile_id {
+                                queue_connect(model, id);
+                            }
+                        }
+                        // A queued attempt has not captured its Profile and
+                        // Settings yet; the next Tick reads the new config.
+                        ConnectionState::Connecting | ConnectionState::Idle => {}
+                    }
+                }
             }
             if region_changed {
                 model.geo_last_updated = None;
@@ -323,11 +408,27 @@ fn handle_config_reloaded(
                 model.geo_last_attempt_at = None;
                 effects.push(Effect::RefreshGeoLastUpdated);
             }
-            push_status(
-                &mut effects,
-                model,
-                AppStatus::Info("Profiles reloaded".into()),
-            );
+            let reconnecting = model.connection == ConnectionState::Connecting
+                && (active_profile_changed
+                    || connecting_profile_changed
+                    || runtime_settings_changed);
+            let status = if kill_switch_ignored && reconnecting {
+                "Kill switch edit ignored (use K); configuration changed — reconnecting"
+            } else if kill_switch_ignored
+                && model.pending_service_reconnect
+                && service_routes_changed
+            {
+                "Kill switch edit ignored (use K); configuration changed — updating rule-sets"
+            } else if kill_switch_ignored {
+                "Kill switch edit ignored — use K to change it"
+            } else if reconnecting {
+                "Configuration changed — reconnecting"
+            } else if model.pending_service_reconnect && service_routes_changed {
+                "Configuration changed — updating rule-sets"
+            } else {
+                "Profiles reloaded"
+            };
+            push_status(&mut effects, model, AppStatus::Info(status.into()));
             effects
         }
         Err(e) => {
@@ -342,6 +443,30 @@ fn handle_config_reloaded(
     }
 }
 
+fn profile_runtime_changed_for_id(old: &[Profile], new: &[Profile], id: Uuid) -> bool {
+    let old = old.iter().find(|profile| profile.id == id);
+    let new = new.iter().find(|profile| profile.id == id);
+    match (old, new) {
+        (Some(old), Some(new)) => profile_runtime_changed(old, new),
+        _ => false,
+    }
+}
+
+fn profile_runtime_changed(old: &Profile, new: &Profile) -> bool {
+    old.address != new.address || old.port != new.port || old.config != new.config
+}
+
+fn connection_settings_changed(
+    old: &crate::config::profile::Settings,
+    new: &crate::config::profile::Settings,
+) -> bool {
+    old.tun_interface != new.tun_interface
+        || old.dns != new.dns
+        || old.geo_routing.mode() != new.geo_routing.mode()
+        || old.geo_routing.service_routes != new.geo_routing.service_routes
+        || old.log_level != new.log_level
+}
+
 fn handle_tick(model: &mut Model) -> Vec<Effect> {
     let mut effects = Vec::new();
 
@@ -353,7 +478,7 @@ fn handle_tick(model: &mut Model) -> Vec<Effect> {
 
     // Connection handling
     if model.connection == ConnectionState::Connecting {
-        let profile = model.connecting_profile_id.take().and_then(|id| {
+        let profile = model.connecting_profile_id.and_then(|id| {
             model
                 .config
                 .profiles
@@ -363,9 +488,14 @@ fn handle_tick(model: &mut Model) -> Vec<Effect> {
         });
         if let Some(profile) = profile {
             let settings = model.config.settings.clone();
-            effects.push(Effect::Connect { profile, settings });
+            effects.push(Effect::Connect {
+                profile,
+                settings,
+                attempt_id: model.connect_attempt_id,
+            });
         } else {
             model.connection = ConnectionState::Idle;
+            model.connecting_profile_id = None;
             model.overlay = Overlay::None;
             effects.push(Effect::BroadcastState);
         }
@@ -392,10 +522,10 @@ fn handle_tick(model: &mut Model) -> Vec<Effect> {
         };
         if due {
             model.last_traffic_fetch_at = Some(now);
+            model.traffic_request_id = model.traffic_request_id.wrapping_add(1);
             effects.push(Effect::FetchTrafficStats {
-                prev_up_total: model.traffic.up_total,
-                prev_down_total: model.traffic.down_total,
-                prev_sampled_at_ms: model.last_traffic_sample_at_ms,
+                attempt_id: model.connect_attempt_id,
+                request_id: model.traffic_request_id,
             });
         }
     }
@@ -411,6 +541,7 @@ pub(super) fn queue_connect(model: &mut Model, profile_id: Uuid) -> bool {
         .any(|profile| profile.id == profile_id)
     {
         model.connecting_profile_id = Some(profile_id);
+        model.connect_attempt_id = model.connect_attempt_id.wrapping_add(1);
         model.connection = ConnectionState::Connecting;
         true
     } else {
@@ -579,6 +710,12 @@ fn handle_subscription_result(
     // Remember where the cursor is so we can restore it to the subscription
     // header after import (add_profile moves selection on every call).
     let saved_selected = model.selected;
+    let old_active_profile = model
+        .active_profile_id
+        .and_then(|id| model.config.profiles.iter().find(|p| p.id == id).cloned());
+    let old_connecting_profile = model
+        .connecting_profile_id
+        .and_then(|id| model.config.profiles.iter().find(|p| p.id == id).cloned());
 
     // Capture old dedup_key → UUID mapping before removing subscription profiles,
     // so we can reuse UUIDs for servers that survive the update.
@@ -590,19 +727,20 @@ fn handle_subscription_result(
         .map(|p| (p.dedup_key(), p.id))
         .collect();
 
-    if managed {
-        if let Some(sub) = model.config.subscriptions.iter_mut().find(|s| s.id == id) {
-            sub.last_updated = Some(Local::now());
-        }
-        // Replace previously imported profiles from this subscription.
-        model
-            .config
-            .profiles
-            .retain(|p| p.subscription_id != Some(id));
-    }
-
     let mut effects = match result {
         Ok(profiles) => {
+            if managed {
+                if let Some(sub) = model.config.subscriptions.iter_mut().find(|s| s.id == id) {
+                    sub.last_updated = Some(Local::now());
+                }
+                // Only replace the previous snapshot after the fetch and parse
+                // succeeded. A transient subscription error must leave the
+                // user's working profiles and update timestamp untouched.
+                model
+                    .config
+                    .profiles
+                    .retain(|p| p.subscription_id != Some(id));
+            }
             let mut imported = 0;
             for mut profile in profiles {
                 let key = profile.dedup_key();
@@ -666,9 +804,6 @@ fn handle_subscription_result(
         }
         Err(err) => {
             let mut effects = Vec::new();
-            if managed {
-                effects.push(Effect::SaveConfig);
-            }
             push_status(
                 &mut effects,
                 model,
@@ -678,12 +813,50 @@ fn handle_subscription_result(
         }
     };
 
-    // If the active profile was removed from the subscription, disconnect so the
-    // tunnel doesn't run against a profile that no longer exists.
-    if let Some(active_id) = model.active_profile_id
-        && !model.config.profiles.iter().any(|p| p.id == active_id)
-    {
+    // If either the active or in-flight profile was removed from the
+    // subscription, invalidate the attempt and stop any process it spawned.
+    let active_missing = model
+        .active_profile_id
+        .is_some_and(|id| !model.config.profiles.iter().any(|p| p.id == id));
+    let connecting_missing = matches!(
+        model.connection,
+        ConnectionState::Connecting | ConnectionState::ConnectPending
+    ) && model
+        .connecting_profile_id
+        .is_some_and(|id| !model.config.profiles.iter().any(|p| p.id == id));
+    if active_missing || connecting_missing {
         effects.push(Effect::Disconnect);
+    } else {
+        let active_changed = old_active_profile.as_ref().is_some_and(|old| {
+            model
+                .config
+                .profiles
+                .iter()
+                .find(|p| p.id == old.id)
+                .is_some_and(|new| profile_runtime_changed(old, new))
+        });
+        let connecting_changed = old_connecting_profile.as_ref().is_some_and(|old| {
+            model
+                .config
+                .profiles
+                .iter()
+                .find(|p| p.id == old.id)
+                .is_some_and(|new| profile_runtime_changed(old, new))
+        });
+        let reconnect_id = match model.connection {
+            ConnectionState::Connected if active_changed => model.active_profile_id,
+            ConnectionState::ConnectPending if connecting_changed => model.connecting_profile_id,
+            _ => None,
+        };
+        if let Some(id) = reconnect_id
+            && queue_connect(model, id)
+        {
+            push_status(
+                &mut effects,
+                model,
+                AppStatus::Info("Subscription changed — reconnecting".into()),
+            );
+        }
     }
 
     // Restore cursor to the subscription header (add_profile moves it on every
@@ -1045,13 +1218,220 @@ mod tests {
 
         let effects = update(&mut model, Msg::ConfigReloaded(Box::new(Ok(config))));
 
-        assert_eq!(model.connection, ConnectionState::Idle);
-        assert_eq!(model.connecting_profile_id, None);
+        assert_eq!(model.connection, ConnectionState::Connecting);
+        assert_eq!(model.connecting_profile_id, Some(profile_id));
+        assert!(effects.contains(&Effect::Disconnect));
         assert!(
             !effects
                 .iter()
                 .any(|effect| matches!(effect, Effect::Connect { .. }))
         );
+    }
+
+    #[test]
+    fn config_reload_disconnects_missing_connect_pending_profile() {
+        let profile = Profile::new_vless("A".into(), "1.1.1.1".into(), 443, "u1".into());
+        let profile_id = profile.id;
+        let mut model = model_with_profiles(vec![profile]);
+        assert!(queue_connect(&mut model, profile_id));
+        let connect_effects = handle_tick(&mut model);
+        assert!(
+            connect_effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::Connect { .. }))
+        );
+        model.connection = ConnectionState::ConnectPending;
+        let mut config = model.config.clone();
+        config.profiles.clear();
+
+        let effects = update(&mut model, Msg::ConfigReloaded(Box::new(Ok(config))));
+
+        assert_eq!(model.connecting_profile_id, Some(profile_id));
+        assert!(effects.contains(&Effect::Disconnect));
+    }
+
+    #[test]
+    fn config_reload_keeps_connect_pending_profile_with_same_id() {
+        let profile = Profile::new_vless("A".into(), "1.1.1.1".into(), 443, "u1".into());
+        let profile_id = profile.id;
+        let mut model = model_with_profiles(vec![profile]);
+        assert!(queue_connect(&mut model, profile_id));
+        model.connection = ConnectionState::ConnectPending;
+        let mut config = model.config.clone();
+        config.profiles[0].name = "A renamed".into();
+
+        let effects = update(&mut model, Msg::ConfigReloaded(Box::new(Ok(config))));
+
+        assert!(!effects.contains(&Effect::Disconnect));
+        assert_eq!(model.connecting_profile_id, Some(profile_id));
+    }
+
+    #[test]
+    fn config_reload_reconnects_changed_active_profile() {
+        let profile = Profile::new_vless("A".into(), "1.1.1.1".into(), 443, "u1".into());
+        let profile_id = profile.id;
+        let mut model = model_with_profiles(vec![profile]);
+        model.connection = ConnectionState::Connected;
+        model.active_profile_id = Some(profile_id);
+        let mut config = model.config.clone();
+        config.profiles[0].address = "2.2.2.2".into();
+
+        let effects = update(&mut model, Msg::ConfigReloaded(Box::new(Ok(config))));
+
+        assert_eq!(model.connection, ConnectionState::Connecting);
+        assert_eq!(model.connecting_profile_id, Some(profile_id));
+        assert_eq!(model.status.text(), "Configuration changed — reconnecting");
+        assert!(!effects.contains(&Effect::Disconnect));
+    }
+
+    #[test]
+    fn config_reload_does_not_reconnect_for_profile_metadata() {
+        let profile = Profile::new_vless("A".into(), "1.1.1.1".into(), 443, "u1".into());
+        let profile_id = profile.id;
+        let mut model = model_with_profiles(vec![profile]);
+        model.connection = ConnectionState::Connected;
+        model.active_profile_id = Some(profile_id);
+        let mut config = model.config.clone();
+        config.profiles[0].name = "Renamed".into();
+        config.profiles[0].tags.push("metadata".into());
+
+        let effects = update(&mut model, Msg::ConfigReloaded(Box::new(Ok(config))));
+
+        assert_eq!(model.connection, ConnectionState::Connected);
+        assert_eq!(model.connecting_profile_id, None);
+        assert_eq!(model.status.text(), "Profiles reloaded");
+        assert!(!effects.contains(&Effect::Disconnect));
+    }
+
+    #[test]
+    fn config_reload_reconnects_for_runtime_settings_only() {
+        let profile = Profile::new_vless("A".into(), "1.1.1.1".into(), 443, "u1".into());
+        let profile_id = profile.id;
+        let mut model = model_with_profiles(vec![profile]);
+        model.connection = ConnectionState::Connected;
+        model.active_profile_id = Some(profile_id);
+        let mut config = model.config.clone();
+        config.settings.tun_interface = "tun9".into();
+
+        update(&mut model, Msg::ConfigReloaded(Box::new(Ok(config))));
+
+        assert_eq!(model.connection, ConnectionState::Connecting);
+        assert_eq!(model.connecting_profile_id, Some(profile_id));
+    }
+
+    #[test]
+    fn connection_settings_comparison_covers_singbox_inputs() {
+        use crate::config::profile::{DnsStrategy, GeoRegion, RoutedService, ServiceRoute};
+
+        let original = crate::config::profile::Settings::default();
+        let mut changed = original.clone();
+        changed.dns.strategy = DnsStrategy::OnlyIpv6;
+        assert!(connection_settings_changed(&original, &changed));
+
+        let mut changed = original.clone();
+        changed.log_level = "debug".into();
+        assert!(connection_settings_changed(&original, &changed));
+
+        let mut changed = original.clone();
+        changed.geo_routing.set_region(GeoRegion::Ru);
+        changed
+            .geo_routing
+            .set_mode(crate::config::profile::RoutingMode::Only(GeoRegion::Ru));
+        assert!(connection_settings_changed(&original, &changed));
+
+        let mut changed = original.clone();
+        changed
+            .geo_routing
+            .service_routes
+            .insert(RoutedService::Steam, ServiceRoute::Proxy);
+        assert!(connection_settings_changed(&original, &changed));
+    }
+
+    #[test]
+    fn config_reload_ignores_ui_settings_and_external_kill_switch_value() {
+        let profile = Profile::new_vless("A".into(), "1.1.1.1".into(), 443, "u1".into());
+        let profile_id = profile.id;
+        let mut model = model_with_profiles(vec![profile]);
+        model.connection = ConnectionState::Connected;
+        model.active_profile_id = Some(profile_id);
+        let mut config = model.config.clone();
+        config.settings.theme = "gruvbox".into();
+        config.settings.auto_connect = !config.settings.auto_connect;
+        config.settings.kill_switch = !config.settings.kill_switch;
+
+        update(&mut model, Msg::ConfigReloaded(Box::new(Ok(config))));
+
+        assert_eq!(model.connection, ConnectionState::Connected);
+        assert!(!model.config.settings.kill_switch);
+        assert_eq!(
+            model.status.text(),
+            "Kill switch edit ignored — use K to change it"
+        );
+    }
+
+    #[test]
+    fn config_reload_reports_ignored_kill_switch_alongside_reconnect() {
+        let profile = Profile::new_vless("A".into(), "1.1.1.1".into(), 443, "u1".into());
+        let profile_id = profile.id;
+        let mut model = model_with_profiles(vec![profile]);
+        model.connection = ConnectionState::Connected;
+        model.active_profile_id = Some(profile_id);
+        let mut config = model.config.clone();
+        config.settings.kill_switch = true;
+        config.settings.tun_interface = "tun9".into();
+
+        let effects = update(&mut model, Msg::ConfigReloaded(Box::new(Ok(config))));
+
+        assert_eq!(model.connection, ConnectionState::Connecting);
+        assert!(!model.config.settings.kill_switch);
+        assert_eq!(
+            model.status.text(),
+            "Kill switch edit ignored (use K); configuration changed — reconnecting"
+        );
+        assert!(effects.contains(&app_log_info(
+            "Kill switch edit ignored (use K); configuration changed — reconnecting"
+        )));
+    }
+
+    #[test]
+    fn config_reload_requeues_changed_connect_pending_attempt() {
+        let profile = Profile::new_vless("A".into(), "1.1.1.1".into(), 443, "u1".into());
+        let profile_id = profile.id;
+        let mut model = model_with_profiles(vec![profile]);
+        assert!(queue_connect(&mut model, profile_id));
+        model.connection = ConnectionState::ConnectPending;
+        let old_attempt = model.connect_attempt_id;
+        let mut config = model.config.clone();
+        config.profiles[0].port = 8443;
+
+        update(&mut model, Msg::ConfigReloaded(Box::new(Ok(config))));
+
+        assert_eq!(model.connection, ConnectionState::Connecting);
+        assert_eq!(model.connect_attempt_id, old_attempt + 1);
+        assert_eq!(model.connecting_profile_id, Some(profile_id));
+    }
+
+    #[test]
+    fn config_reload_defers_service_route_reconnect_until_assets_ready() {
+        use crate::config::profile::{RoutedService, ServiceRoute};
+
+        let profile = Profile::new_vless("A".into(), "1.1.1.1".into(), 443, "u1".into());
+        let profile_id = profile.id;
+        let mut model = model_with_profiles(vec![profile]);
+        model.connection = ConnectionState::Connected;
+        model.active_profile_id = Some(profile_id);
+        let mut config = model.config.clone();
+        config
+            .settings
+            .geo_routing
+            .service_routes
+            .insert(RoutedService::Steam, ServiceRoute::Proxy);
+
+        let effects = update(&mut model, Msg::ConfigReloaded(Box::new(Ok(config))));
+
+        assert_eq!(model.connection, ConnectionState::Connected);
+        assert!(model.pending_service_reconnect);
+        assert!(effects.contains(&Effect::DownloadServiceRuleSetsIfMissing));
     }
 
     #[test]
@@ -1777,11 +2157,24 @@ mod tests {
     #[test]
     fn connect_failed_sets_status_error() {
         let mut model = Model::test_new(crate::config::profile::Config::default());
+        model.connection = ConnectionState::ConnectPending;
+        model.connect_attempt_id = 7;
+        model.singbox_pid = Some(99);
+        model.active_profile_id = Some(Uuid::new_v4());
+        model.traffic_request_id = 4;
+        model.last_traffic_response_id = 3;
         let effects = update(
             &mut model,
-            Msg::ConnectFailed(crate::app::msg::IpcError::new("timeout")),
+            Msg::ConnectFailed {
+                attempt_id: 7,
+                error: crate::app::msg::IpcError::new("timeout"),
+            },
         );
         assert_eq!(model.connection, ConnectionState::Idle);
+        assert_eq!(model.singbox_pid, None);
+        assert_eq!(model.active_profile_id, None);
+        assert_eq!(model.traffic_request_id, 0);
+        assert_eq!(model.last_traffic_response_id, 0);
         assert!(model.status.is_error());
         assert!(model.status.text().contains("Connection failed: timeout"));
         assert_eq!(
@@ -1791,6 +2184,71 @@ mod tests {
                 app_log_error("Connection failed: timeout")
             ]
         );
+    }
+
+    #[test]
+    fn stale_connect_failed_does_not_override_newer_connection() {
+        let profile_id = Uuid::new_v4();
+        let mut model = Model::test_new(crate::config::profile::Config::default());
+        model.connection = ConnectionState::Connected;
+        model.connect_attempt_id = 2;
+        model.active_profile_id = Some(profile_id);
+        model.singbox_pid = Some(42);
+
+        let effects = update(
+            &mut model,
+            Msg::ConnectFailed {
+                attempt_id: 1,
+                error: crate::app::msg::IpcError::new("old timeout"),
+            },
+        );
+
+        assert!(effects.is_empty());
+        assert_eq!(model.connection, ConnectionState::Connected);
+        assert_eq!(model.active_profile_id, Some(profile_id));
+        assert_eq!(model.singbox_pid, Some(42));
+    }
+
+    #[test]
+    fn stale_connected_does_not_override_newer_attempt() {
+        let mut model = Model::test_new(crate::config::profile::Config::default());
+        model.connection = ConnectionState::ConnectPending;
+        model.connect_attempt_id = 2;
+
+        let effects = update(
+            &mut model,
+            Msg::Connected {
+                pid: 42,
+                profile_id: Uuid::new_v4(),
+                attempt_id: 1,
+            },
+        );
+
+        assert!(effects.is_empty());
+        assert_eq!(model.connection, ConnectionState::ConnectPending);
+        assert_eq!(model.singbox_pid, None);
+        assert_eq!(model.active_profile_id, None);
+    }
+
+    #[test]
+    fn queued_connect_carries_new_attempt_id() {
+        let mut model = model_with_profiles(vec![Profile::new_vless(
+            "A".into(),
+            "1.1.1.1".into(),
+            443,
+            "u1".into(),
+        )]);
+        let profile_id = model.config.profiles[0].id;
+
+        assert!(queue_connect(&mut model, profile_id));
+        assert_eq!(model.connect_attempt_id, 1);
+        let effects = handle_tick(&mut model);
+
+        assert_eq!(model.connecting_profile_id, Some(profile_id));
+        assert!(matches!(
+            effects.as_slice(),
+            [Effect::Connect { attempt_id: 1, .. }]
+        ));
     }
 
     #[test]
@@ -1816,6 +2274,7 @@ mod tests {
             Msg::Connected {
                 pid: 12345,
                 profile_id: id,
+                attempt_id: 0,
             },
         );
         assert_eq!(model.connection, ConnectionState::Connected);
@@ -1857,6 +2316,7 @@ mod tests {
             Msg::Connected {
                 pid: 1,
                 profile_id: a_id,
+                attempt_id: 0,
             },
         );
         assert_eq!(model.active_profile_id, Some(a_id));
@@ -1923,6 +2383,7 @@ mod tests {
             Msg::Connected {
                 pid: 1,
                 profile_id: uuid::Uuid::new_v4(),
+                attempt_id: 0,
             },
         );
         assert!(
@@ -1943,6 +2404,7 @@ mod tests {
             Msg::Connected {
                 pid: 1,
                 profile_id: uuid::Uuid::new_v4(),
+                attempt_id: 0,
             },
         );
         assert!(effects.contains(&Effect::DownloadServiceRuleSetsIfMissing));
@@ -1961,6 +2423,7 @@ mod tests {
             Msg::Connected {
                 pid: 1,
                 profile_id: uuid::Uuid::new_v4(),
+                attempt_id: 0,
             },
         );
         assert!(!effects.contains(&Effect::DownloadServiceRuleSetsIfMissing));
@@ -2050,6 +2513,7 @@ mod tests {
             Msg::Connected {
                 pid: 12345,
                 profile_id: id,
+                attempt_id: 0,
             },
         );
         assert_eq!(model.connection, ConnectionState::Connected);
@@ -2096,6 +2560,7 @@ mod tests {
         let effects = handle_sources(&mut model, key('K'));
         // Bool is NOT flipped synchronously — it waits for KillSwitchApplied.
         assert!(!model.config.settings.kill_switch);
+        assert_eq!(model.kill_switch_pending, Some(true));
         assert!(model.status.text().contains("enabling"));
         assert_eq!(
             effects,
@@ -2107,8 +2572,23 @@ mod tests {
     }
 
     #[test]
+    fn repeated_kill_switch_toggle_is_ignored_while_pending() {
+        let mut model = model_with_profiles(vec![]);
+        let first = handle_sources(&mut model, key('K'));
+        let status = model.status.clone();
+
+        let second = handle_sources(&mut model, key('K'));
+
+        assert!(first.contains(&Effect::ApplyKillSwitch { enabled: true }));
+        assert!(second.is_empty());
+        assert_eq!(model.kill_switch_pending, Some(true));
+        assert_eq!(model.status, status);
+    }
+
+    #[test]
     fn kill_switch_applied_success_flips_and_saves() {
         let mut model = model_with_profiles(vec![]);
+        model.kill_switch_pending = Some(true);
         let effects = update(
             &mut model,
             Msg::KillSwitchApplied {
@@ -2117,6 +2597,7 @@ mod tests {
             },
         );
         assert!(model.config.settings.kill_switch);
+        assert_eq!(model.kill_switch_pending, None);
         assert!(model.status.text().contains("enabled"));
         assert_eq!(
             effects,
@@ -2131,6 +2612,7 @@ mod tests {
     #[test]
     fn kill_switch_applied_error_keeps_bool_unchanged() {
         let mut model = model_with_profiles(vec![]);
+        model.kill_switch_pending = Some(true);
         let effects = update(
             &mut model,
             Msg::KillSwitchApplied {
@@ -2139,8 +2621,40 @@ mod tests {
             },
         );
         assert!(!model.config.settings.kill_switch);
+        assert_eq!(model.kill_switch_pending, None);
         assert!(model.status.text().contains("helper missing"));
         assert!(!effects.iter().any(|e| matches!(e, Effect::SaveConfig)));
+    }
+
+    #[test]
+    fn stale_kill_switch_result_is_ignored() {
+        let mut model = model_with_profiles(vec![]);
+        model.kill_switch_pending = Some(true);
+        let status = model.status.clone();
+
+        let effects = update(
+            &mut model,
+            Msg::KillSwitchApplied {
+                enabled: false,
+                error: None,
+            },
+        );
+
+        assert!(effects.is_empty());
+        assert!(!model.config.settings.kill_switch);
+        assert_eq!(model.kill_switch_pending, Some(true));
+        assert_eq!(model.status, status);
+    }
+
+    #[test]
+    fn kill_switch_disable_uses_pending_false() {
+        let mut model = model_with_profiles(vec![]);
+        model.config.settings.kill_switch = true;
+
+        let effects = handle_sources(&mut model, key('K'));
+
+        assert_eq!(model.kill_switch_pending, Some(false));
+        assert!(effects.contains(&Effect::ApplyKillSwitch { enabled: false }));
     }
 
     #[test]
@@ -2387,15 +2901,38 @@ mod tests {
 
     #[test]
     fn subscription_fetched_error_logs_failure() {
-        let mut model = model_with_profiles(vec![]);
+        let sub_id = Uuid::new_v4();
+        let mut existing = Profile::new_vless(
+            "Existing".to_string(),
+            "1.1.1.1".to_string(),
+            443,
+            "u1".to_string(),
+        );
+        existing.subscription_id = Some(sub_id);
+        let existing_id = existing.id;
+        let last_updated = Local::now() - chrono::Duration::try_hours(2).unwrap();
+        let mut model = model_with_profiles(vec![existing]);
+        model.config.subscriptions.push(Subscription {
+            id: sub_id,
+            name: "Sub".to_string(),
+            url: "http://example.com/sub".to_string(),
+            auto_update: SubscriptionAutoUpdate::Every1h,
+            last_updated: Some(last_updated),
+        });
 
         let effects = handle_subscription_result(
             &mut model,
-            Uuid::nil(),
+            sub_id,
             Err(crate::app::msg::IpcError::new("network down")),
         );
 
         assert!(!model.subscription_fetching);
+        assert_eq!(model.config.profiles.len(), 1);
+        assert_eq!(model.config.profiles[0].id, existing_id);
+        assert_eq!(
+            model.config.subscriptions[0].last_updated,
+            Some(last_updated)
+        );
         assert_eq!(
             effects,
             vec![app_log_error("Subscription failed: network down")]
@@ -2522,6 +3059,71 @@ mod tests {
         assert_eq!(model.config.profiles.len(), 1);
         assert_eq!(model.config.profiles[0].id, old_profile_id);
         assert_eq!(model.active_profile_id, Some(old_profile_id));
+    }
+
+    #[test]
+    fn subscription_fetched_reconnects_changed_active_profile() {
+        let sub_id = Uuid::new_v4();
+        let mut existing = Profile::new_vless(
+            "Server".to_string(),
+            "1.1.1.1".to_string(),
+            443,
+            "same-uuid".to_string(),
+        );
+        existing.subscription_id = Some(sub_id);
+        let old_profile_id = existing.id;
+        let mut model = model_with_profiles(vec![existing]);
+        model.config.subscriptions.push(Subscription {
+            id: sub_id,
+            name: "Sub".into(),
+            url: "http://example.com/sub".into(),
+            auto_update: SubscriptionAutoUpdate::Off,
+            last_updated: None,
+        });
+        model.connection = ConnectionState::Connected;
+        model.active_profile_id = Some(old_profile_id);
+        let mut updated = Profile::new_vless(
+            "Server".to_string(),
+            "1.1.1.1".to_string(),
+            443,
+            "same-uuid".to_string(),
+        );
+        if let crate::config::profile::ProtocolConfig::Vless(config) = &mut updated.config {
+            config.flow = Some(crate::config::profile::Flow::XtlsRprxVision);
+        }
+
+        let effects = handle_subscription_result(&mut model, sub_id, Ok(vec![updated]));
+
+        assert_eq!(model.connection, ConnectionState::Connecting);
+        assert_eq!(model.connecting_profile_id, Some(old_profile_id));
+        assert!(effects.contains(&app_log_info("Subscription changed — reconnecting")));
+    }
+
+    #[test]
+    fn subscription_update_disconnects_when_connecting_profile_is_removed() {
+        let sub_id = Uuid::new_v4();
+        let mut existing = Profile::new_vless(
+            "Server".to_string(),
+            "1.1.1.1".to_string(),
+            443,
+            "old-uuid".to_string(),
+        );
+        existing.subscription_id = Some(sub_id);
+        let profile_id = existing.id;
+        let mut model = model_with_profiles(vec![existing]);
+        model.config.subscriptions.push(Subscription {
+            id: sub_id,
+            name: "Sub".into(),
+            url: "http://example.com/sub".into(),
+            auto_update: SubscriptionAutoUpdate::Off,
+            last_updated: None,
+        });
+        assert!(queue_connect(&mut model, profile_id));
+        model.connection = ConnectionState::ConnectPending;
+
+        let effects = handle_subscription_result(&mut model, sub_id, Ok(vec![]));
+
+        assert!(effects.contains(&Effect::Disconnect));
     }
 
     #[test]
@@ -2772,7 +3374,8 @@ mod tests {
     #[test]
     fn traffic_stats_updated_first_sample_records_zero_rate() {
         let mut model = model_with_profiles(vec![]);
-        let effects = handle_traffic_stats_updated(&mut model, 10_000, 50_000, 3, 1_000);
+        model.connection = ConnectionState::Connected;
+        let effects = handle_traffic_stats_updated(&mut model, 0, 1, 10_000, 50_000, 3, 1_000);
         assert_eq!(model.traffic.up_total, 10_000);
         assert_eq!(model.traffic.down_total, 50_000);
         assert_eq!(model.traffic.conn_count, 3);
@@ -2780,16 +3383,18 @@ mod tests {
         assert_eq!(model.traffic.up_rate_bps, 0);
         assert_eq!(model.traffic.down_rate_bps, 0);
         assert_eq!(model.last_traffic_sample_at_ms, 1_000);
+        assert_eq!(model.last_traffic_response_id, 1);
         assert_eq!(effects, vec![Effect::BroadcastState]);
     }
 
     #[test]
     fn traffic_stats_updated_second_sample_computes_rate() {
         let mut model = model_with_profiles(vec![]);
+        model.connection = ConnectionState::Connected;
         // Prime with a first sample.
-        handle_traffic_stats_updated(&mut model, 0, 0, 0, 1_000);
+        handle_traffic_stats_updated(&mut model, 0, 1, 0, 0, 0, 1_000);
         // 5000 ↑ + 12000 ↓ over 1 second.
-        let effects = handle_traffic_stats_updated(&mut model, 5_000, 12_000, 7, 2_000);
+        let effects = handle_traffic_stats_updated(&mut model, 0, 2, 5_000, 12_000, 7, 2_000);
         assert_eq!(model.traffic.up_rate_bps, 5_000);
         assert_eq!(model.traffic.down_rate_bps, 12_000);
         assert_eq!(model.traffic.conn_count, 7);
@@ -2799,9 +3404,10 @@ mod tests {
     #[test]
     fn traffic_stats_updated_handles_singbox_restart() {
         let mut model = model_with_profiles(vec![]);
-        handle_traffic_stats_updated(&mut model, 10_000, 50_000, 5, 1_000);
+        model.connection = ConnectionState::Connected;
+        handle_traffic_stats_updated(&mut model, 0, 1, 10_000, 50_000, 5, 1_000);
         // sing-box restarts → counters reset, but we still get a sample.
-        handle_traffic_stats_updated(&mut model, 100, 200, 1, 2_000);
+        handle_traffic_stats_updated(&mut model, 0, 2, 100, 200, 1, 2_000);
         // Rate saturates to 0 for this transition sample.
         assert_eq!(model.traffic.up_rate_bps, 0);
         assert_eq!(model.traffic.down_rate_bps, 0);
@@ -2820,15 +3426,53 @@ mod tests {
             effects.iter().any(|e| matches!(
                 e,
                 Effect::FetchTrafficStats {
-                    prev_up_total: 0,
-                    prev_down_total: 0,
-                    prev_sampled_at_ms: 0,
+                    attempt_id: 0,
+                    request_id: 1,
                 }
             )),
             "expected Effect::FetchTrafficStats, got {:?}",
             effects
         );
         assert!(model.last_traffic_fetch_at.is_some());
+        assert_eq!(model.traffic_request_id, 1);
+    }
+
+    #[test]
+    fn traffic_stats_ignore_previous_connection_attempt() {
+        let mut model = model_with_profiles(vec![]);
+        model.connection = ConnectionState::Connected;
+        model.connect_attempt_id = 2;
+
+        let effects = handle_traffic_stats_updated(&mut model, 1, 1, 10, 20, 3, 1_000);
+
+        assert!(effects.is_empty());
+        assert_eq!(model.traffic, TrafficStats::default());
+        assert_eq!(model.last_traffic_response_id, 0);
+    }
+
+    #[test]
+    fn traffic_stats_ignore_response_when_not_connected() {
+        let mut model = model_with_profiles(vec![]);
+
+        let effects = handle_traffic_stats_updated(&mut model, 0, 1, 10, 20, 3, 1_000);
+
+        assert!(effects.is_empty());
+        assert_eq!(model.traffic, TrafficStats::default());
+    }
+
+    #[test]
+    fn traffic_stats_do_not_roll_back_on_out_of_order_response() {
+        let mut model = model_with_profiles(vec![]);
+        model.connection = ConnectionState::Connected;
+        handle_traffic_stats_updated(&mut model, 0, 2, 200, 400, 4, 2_000);
+
+        let effects = handle_traffic_stats_updated(&mut model, 0, 1, 100, 200, 2, 1_000);
+
+        assert!(effects.is_empty());
+        assert_eq!(model.traffic.up_total, 200);
+        assert_eq!(model.traffic.down_total, 400);
+        assert_eq!(model.last_traffic_sample_at_ms, 2_000);
+        assert_eq!(model.last_traffic_response_id, 2);
     }
 
     #[test]
@@ -2875,17 +3519,22 @@ mod tests {
         model.traffic.up_rate_bps = 100;
         model.last_traffic_sample_at_ms = 1_000;
         model.last_traffic_fetch_at = Some(Instant::now());
+        model.traffic_request_id = 4;
+        model.last_traffic_response_id = 3;
         let id = model.config.profiles[0].id;
         let _ = update(
             &mut model,
             Msg::Connected {
                 pid: 1234,
                 profile_id: id,
+                attempt_id: 0,
             },
         );
         assert_eq!(model.traffic, TrafficStats::default());
         assert_eq!(model.last_traffic_sample_at_ms, 0);
         assert!(model.last_traffic_fetch_at.is_none());
+        assert_eq!(model.traffic_request_id, 0);
+        assert_eq!(model.last_traffic_response_id, 0);
     }
 
     /// `t` opens the theme picker overlay and positions the cursor on the

--- a/src/app/update/key.rs
+++ b/src/app/update/key.rs
@@ -82,7 +82,7 @@ pub(super) fn handle_sources(model: &mut Model, key: KeyEvent) -> Vec<Effect> {
         KeyCode::Char('d')
             if model.selected_profile().is_some() || model.selected_subscription().is_some() =>
         {
-            if is_active_connection_affected(model) {
+            if is_connection_affected(model) {
                 let mut effects = vec![];
                 push_status(
                     &mut effects,
@@ -182,7 +182,11 @@ pub(super) fn handle_sources(model: &mut Model, key: KeyEvent) -> Vec<Effect> {
             return effects;
         }
         KeyCode::Char('K') => {
+            if model.kill_switch_pending.is_some() {
+                return effects;
+            }
             let new_val = !model.config.settings.kill_switch;
+            model.kill_switch_pending = Some(new_val);
             push_status(
                 &mut effects,
                 model,
@@ -325,6 +329,16 @@ pub(super) fn handle_update_key(model: &mut Model) -> Vec<Effect> {
 pub(super) fn handle_confirm_delete(model: &mut Model, key: KeyEvent) -> Vec<Effect> {
     match key.code {
         KeyCode::Char('y') | KeyCode::Enter => {
+            if is_connection_affected(model) {
+                model.overlay = Overlay::None;
+                let mut effects = vec![];
+                push_status(
+                    &mut effects,
+                    model,
+                    AppStatus::Error("Disconnect before deleting".into()),
+                );
+                return effects;
+            }
             model.overlay = Overlay::None;
             let row = model.selected_row();
             match row {
@@ -1027,16 +1041,18 @@ fn replace_preset(
     *final_server = new_final.to_string();
 }
 
-fn is_active_connection_affected(model: &Model) -> bool {
-    let Some(active_id) = model.active_profile_id else {
+fn is_connection_affected(model: &Model) -> bool {
+    let affected =
+        |id| model.active_profile_id == Some(id) || model.connecting_profile_id == Some(id);
+    if model.active_profile_id.is_none() && model.connecting_profile_id.is_none() {
         return false;
-    };
+    }
     use crate::app::model::SourceRow;
     match model.selected_row() {
         Some(SourceRow::StandaloneProfile(_)) | Some(SourceRow::SubscriptionProfile { .. }) => {
             model
                 .selected_profile()
-                .map(|p| p.id == active_id)
+                .map(|p| affected(p.id))
                 .unwrap_or(false)
         }
         Some(SourceRow::SubscriptionHeader(_)) => model
@@ -1046,7 +1062,7 @@ fn is_active_connection_affected(model: &Model) -> bool {
                     .config
                     .profiles
                     .iter()
-                    .any(|p| p.subscription_id == Some(sub.id) && p.id == active_id)
+                    .any(|p| p.subscription_id == Some(sub.id) && affected(p.id))
             })
             .unwrap_or(false),
         _ => false,
@@ -1400,6 +1416,44 @@ mod tests {
         let _ = handle_sources(&mut model, key('d'));
         assert_eq!(model.overlay, Overlay::None);
         assert!(model.status.is_error());
+    }
+
+    #[test]
+    fn sources_d_blocked_when_connecting_profile_selected() {
+        let mut model = model_with_profiles(vec![Profile::new_vless(
+            "A".into(),
+            "1.1.1.1".into(),
+            443,
+            "u".into(),
+        )]);
+        model.connection = ConnectionState::ConnectPending;
+        model.connecting_profile_id = Some(model.config.profiles[0].id);
+
+        let effects = handle_sources(&mut model, key('d'));
+
+        assert_eq!(model.overlay, Overlay::None);
+        assert!(model.status.text().contains("Disconnect before"));
+        assert!(!effects.contains(&Effect::SaveConfig));
+    }
+
+    #[test]
+    fn confirm_delete_rechecks_connection_target() {
+        let mut model = model_with_profiles(vec![Profile::new_vless(
+            "A".into(),
+            "1.1.1.1".into(),
+            443,
+            "u".into(),
+        )]);
+        model.overlay = Overlay::ConfirmDelete;
+        model.connection = ConnectionState::ConnectPending;
+        model.connecting_profile_id = Some(model.config.profiles[0].id);
+
+        let effects = handle_confirm_delete(&mut model, enter());
+
+        assert_eq!(model.config.profiles.len(), 1);
+        assert_eq!(model.overlay, Overlay::None);
+        assert!(model.status.text().contains("Disconnect before"));
+        assert!(!effects.contains(&Effect::SaveConfig));
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -14,6 +14,11 @@ use crate::app::update::update;
 use crate::ipc::{IpcServer, cleanup_socket};
 use crate::singbox::process_handle::ProcessHandle;
 
+struct ProcessSlot {
+    attempt_id: u64,
+    handle: Option<ProcessHandle>,
+}
+
 /// Run the daemon main loop.
 pub fn run(mut model: Model) -> Result<()> {
     let (tx, rx) = channel::<Msg>();
@@ -27,12 +32,26 @@ pub fn run(mut model: Model) -> Result<()> {
 
     reconcile_kill_switch_state(&mut model);
 
-    let process_slot = Arc::new(Mutex::new(None));
+    let process_slot = Arc::new(Mutex::new(ProcessSlot {
+        attempt_id: model.connect_attempt_id,
+        handle: None,
+    }));
+    let connect_coordinator = Arc::new(Mutex::new(()));
 
-    let result = run_loop(&mut model, rx, &tx, process_slot.clone(), &ipc_server);
+    let result = run_loop(
+        &mut model,
+        rx,
+        &tx,
+        process_slot.clone(),
+        connect_coordinator.clone(),
+        &ipc_server,
+    );
 
     // Cleanup
-    if let Some(mut handle) = lock_process_slot(&process_slot).take()
+    let _coordinator = connect_coordinator
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    if let Some(mut handle) = lock_process_slot(&process_slot).handle.take()
         && let Err(e) = handle.kill_and_wait()
     {
         tracing::warn!("Failed to stop sing-box on exit: {}", e);
@@ -51,12 +70,17 @@ fn run_loop(
     model: &mut Model,
     rx: std::sync::mpsc::Receiver<Msg>,
     tx: &Sender<Msg>,
-    process_slot: Arc<Mutex<Option<ProcessHandle>>>,
+    process_slot: Arc<Mutex<ProcessSlot>>,
+    connect_coordinator: Arc<Mutex<()>>,
     ipc_server: &IpcServer,
 ) -> Result<()> {
     loop {
         let msg = rx.recv()?;
         let effects = update(model, msg);
+        // `queue_connect` advances the generation before the next Tick emits
+        // `Effect::Connect`. Publish that invalidation immediately so an old
+        // worker cannot install its process during the intervening 250 ms.
+        lock_process_slot(&process_slot).attempt_id = model.connect_attempt_id;
         let mut should_broadcast = false;
 
         for effect in &effects {
@@ -76,7 +100,7 @@ fn run_loop(
         }
 
         for effect in effects {
-            execute_daemon_effect(effect, tx, model, &process_slot)?;
+            execute_daemon_effect(effect, tx, model, &process_slot, &connect_coordinator)?;
         }
 
         if model.should_quit {
@@ -94,12 +118,21 @@ fn execute_daemon_effect(
     effect: Effect,
     tx: &Sender<Msg>,
     model: &mut Model,
-    process_slot: &Arc<Mutex<Option<ProcessHandle>>>,
+    process_slot: &Arc<Mutex<ProcessSlot>>,
+    connect_coordinator: &Arc<Mutex<()>>,
 ) -> Result<()> {
     match effect {
-        Effect::Connect { profile, settings } => {
-            model.connecting_profile_id = None;
-            if let Some(mut handle) = lock_process_slot(process_slot).take()
+        Effect::Connect {
+            profile,
+            settings,
+            attempt_id,
+        } => {
+            let previous = {
+                let mut slot = lock_process_slot(process_slot);
+                slot.attempt_id = attempt_id;
+                slot.handle.take()
+            };
+            if let Some(mut handle) = previous
                 && let Err(e) = handle.kill_and_wait()
             {
                 tracing::warn!("Failed to stop sing-box process: {}", e);
@@ -107,15 +140,26 @@ fn execute_daemon_effect(
             model.connection = ConnectionState::ConnectPending;
             let tx = tx.clone();
             let slot = process_slot.clone();
+            let coordinator = connect_coordinator.clone();
             let kill_switch = model.config.settings.kill_switch;
             let dns = settings.dns.clone();
             thread::spawn(move || {
+                let _coordinator = coordinator.lock().unwrap_or_else(|p| p.into_inner());
+                if !is_current_attempt(&slot, attempt_id) {
+                    return;
+                }
                 if kill_switch {
                     if let Err(e) = crate::services::killswitch::revoke() {
                         let err = crate::app::msg::IpcError::from(
                             e.context("failed to clear stale kill switch exceptions"),
                         );
-                        let _ = tx.send(Msg::ConnectFailed(err));
+                        let _ = tx.send(Msg::ConnectFailed {
+                            attempt_id,
+                            error: err,
+                        });
+                        return;
+                    }
+                    if !is_current_attempt(&slot, attempt_id) {
                         return;
                     }
                     if let Err(e) = open_handshake_window(&profile, &dns) {
@@ -128,17 +172,36 @@ fn execute_daemon_effect(
                         let err = crate::app::msg::IpcError::from(
                             e.context("kill switch handshake setup failed"),
                         );
-                        let _ = tx.send(Msg::ConnectFailed(err));
+                        let _ = tx.send(Msg::ConnectFailed {
+                            attempt_id,
+                            error: err,
+                        });
                         return;
                     }
+                }
+                if !is_current_attempt(&slot, attempt_id) {
+                    return;
                 }
                 match crate::singbox::runner::start(&profile, &settings) {
                     Ok(handle) => {
                         let pid = handle.pid;
-                        *lock_process_slot(&slot) = Some(handle);
+                        let stale_handle = {
+                            let mut slot = lock_process_slot(&slot);
+                            if slot.attempt_id == attempt_id {
+                                slot.handle = Some(handle);
+                                None
+                            } else {
+                                Some(handle)
+                            }
+                        };
+                        if let Some(mut handle) = stale_handle {
+                            let _ = handle.kill_and_wait();
+                            return;
+                        }
                         let _ = tx.send(Msg::Connected {
                             pid,
                             profile_id: profile.id,
+                            attempt_id,
                         });
                     }
                     Err(e) => {
@@ -150,13 +213,30 @@ fn execute_daemon_effect(
                                 cleanup_err
                             );
                         }
-                        let _ = tx.send(Msg::ConnectFailed(crate::app::msg::IpcError::from(e)));
+                        let _ = tx.send(Msg::ConnectFailed {
+                            attempt_id,
+                            error: crate::app::msg::IpcError::from(e),
+                        });
                     }
                 }
             });
         }
         Effect::Disconnect => {
-            if let Some(mut handle) = lock_process_slot(process_slot).take()
+            model.connect_attempt_id = model.connect_attempt_id.wrapping_add(1);
+            {
+                let mut slot = lock_process_slot(process_slot);
+                slot.attempt_id = model.connect_attempt_id;
+            }
+            // Wait for an in-flight setup to observe invalidation and stop
+            // before flushing its temporary kill-switch exceptions.
+            let _coordinator = connect_coordinator
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            let previous = {
+                let mut slot = lock_process_slot(process_slot);
+                slot.handle.take()
+            };
+            if let Some(mut handle) = previous
                 && let Err(e) = handle.kill_and_wait()
             {
                 tracing::warn!("Failed to stop sing-box process: {}", e);
@@ -167,6 +247,8 @@ fn execute_daemon_effect(
             model.singbox_pid = None;
             model.traffic = TrafficStats::default();
             model.last_traffic_sample_at_ms = 0;
+            model.traffic_request_id = 0;
+            model.last_traffic_response_id = 0;
             model.last_traffic_fetch_at = None;
             model.set_status(AppStatus::Info("Disconnected".into()));
             model.overlay = Overlay::None;
@@ -302,6 +384,8 @@ fn execute_daemon_effect(
         }
         Effect::BroadcastState => {}
         Effect::Quit => {
+            model.connect_attempt_id = model.connect_attempt_id.wrapping_add(1);
+            lock_process_slot(process_slot).attempt_id = model.connect_attempt_id;
             model.should_quit = true;
         }
         Effect::AppendAppLog { level, message } => {
@@ -325,13 +409,18 @@ fn execute_daemon_effect(
                 let _ = tx.send(Msg::KillSwitchApplied { enabled, error });
             });
         }
-        Effect::FetchTrafficStats { .. } => {
+        Effect::FetchTrafficStats {
+            attempt_id,
+            request_id,
+        } => {
             let tx = tx.clone();
             thread::spawn(
                 move || match crate::singbox::clash_api::fetch_connections() {
                     Ok(snap) => {
                         let sampled_at_ms = unix_now_ms();
                         let _ = tx.send(Msg::TrafficStatsUpdated {
+                            attempt_id,
+                            request_id,
                             up_total: snap.up_total,
                             down_total: snap.down_total,
                             conn_count: snap.conn_count,
@@ -682,10 +771,12 @@ fn spawn_ticker(tx: Sender<Msg>) {
 /// chance to kill sing-box on shutdown. The invariant we care about — an
 /// `Option<ProcessHandle>` — cannot be left half-written across an `unwind`
 /// boundary, so taking the inner guard is safe.
-fn lock_process_slot(
-    slot: &Arc<Mutex<Option<ProcessHandle>>>,
-) -> std::sync::MutexGuard<'_, Option<ProcessHandle>> {
+fn lock_process_slot(slot: &Arc<Mutex<ProcessSlot>>) -> std::sync::MutexGuard<'_, ProcessSlot> {
     slot.lock().unwrap_or_else(|p| p.into_inner())
+}
+
+fn is_current_attempt(slot: &Arc<Mutex<ProcessSlot>>, attempt_id: u64) -> bool {
+    lock_process_slot(slot).attempt_id == attempt_id
 }
 
 fn spawn_suspend_watcher(tx: Sender<Msg>) {

--- a/src/singbox/runner.rs
+++ b/src/singbox/runner.rs
@@ -178,6 +178,8 @@ mod tests {
         // temp_singbox_config_path() reads XDG_RUNTIME_DIR, which other tests
         // point at short-lived tempdirs — hold ENV_LOCK so the path stays valid.
         let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let runtime = tempfile::tempdir().unwrap();
+        let _runtime = crate::test_helpers::EnvVarGuard::set("XDG_RUNTIME_DIR", runtime.path());
         let profile = Profile::new_vless(
             "Test".to_string(),
             "1.2.3.4".to_string(),
@@ -287,6 +289,8 @@ mod tests {
     fn check_config_accepts_a_minimal_profile() {
         // Same XDG_RUNTIME_DIR dependency as write_config_creates_valid_json.
         let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let runtime = tempfile::tempdir().unwrap();
+        let _runtime = crate::test_helpers::EnvVarGuard::set("XDG_RUNTIME_DIR", runtime.path());
         if Command::new("sh")
             .args(["-c", "command -v sing-box >/dev/null 2>&1"])
             .status()

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,13 +1,61 @@
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::buffer::Buffer;
-use std::sync::Mutex;
+use std::convert::Infallible;
+use std::ffi::{OsStr, OsString};
+use std::sync::{Mutex, MutexGuard};
 
 use crate::app::model::Model;
 use crate::config::profile::{Config, Profile};
 
+/// Mutex that recovers after a test panics while holding the lock.
+///
+/// A failed environment-sensitive test must not turn every later test into a
+/// `PoisonError`. Returning an infallible `Result` preserves the familiar
+/// `ENV_LOCK.lock().unwrap()` call sites while making them poison-tolerant.
+pub struct RecoverableMutex(Mutex<()>);
+
+impl RecoverableMutex {
+    pub const fn new() -> Self {
+        Self(Mutex::new(()))
+    }
+
+    pub fn lock(&self) -> Result<MutexGuard<'_, ()>, Infallible> {
+        Ok(self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()))
+    }
+}
+
 /// Global lock for tests that mutate environment variables.
 /// Prevents race conditions when running tests in parallel.
-pub static ENV_LOCK: Mutex<()> = Mutex::new(());
+pub static ENV_LOCK: RecoverableMutex = RecoverableMutex::new();
+
+/// Restores an environment variable when an environment-sensitive test ends,
+/// including during panic unwinding.
+pub struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl EnvVarGuard {
+    pub fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+        let previous = std::env::var_os(key);
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        unsafe {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
 
 /// Convert a ratatui Buffer to a multi-line string for snapshot testing.
 pub fn buffer_to_string(buffer: &Buffer) -> String {


### PR DESCRIPTION
  ## Summary

  Improve daemon runtime consistency by guarding asynchronous results
  and reconciling configuration changes with the active connection.

  ## Changes

  - Add generation IDs to connection attempts so stale success and failure responses cannot overwrite newer state.
  - Order traffic-stat requests and ignore stale or out-of-order responses.
  - Preserve existing subscription profiles and timestamps when a refresh fails.
  - Reconnect when an active or pending profile changes after a subscription refresh.
  - Reconcile edited configuration with the running connection:
    - reconnect when runtime-relevant settings change;
    - disconnect when the active or pending profile is removed;
    - defer service-routing reconnects until rule-set downloads finish;
    - ignore direct edits to the live kill-switch flag.
  - Prevent overlapping kill-switch operations and ignore stale results.
   - Serialize connection setup with disconnect and daemon shutdown so stale attempts cannot install a sing-box process or race kill-switch handshake cleanup.
  - Make environment-dependent tests restore variables reliably and recover from poisoned locks.