### PR TITLE
fix(runtime): harden sing-box lifecycle and log parsing

### DIFF
--- a/src/app/effect.rs
+++ b/src/app/effect.rs
@@ -10,6 +10,10 @@ pub enum Effect {
         attempt_id: u64,
     },
     Disconnect,
+    /// Revoke temporary endpoint/DNS exceptions after sing-box exits without
+    /// going through the normal disconnect path. The kill switch itself stays
+    /// enabled.
+    RevokeKillSwitchExceptions,
     DownloadGeo,
     DownloadGeoIfMissing,
     /// Fetch rule-sets for enabled service routes if absent. Emitted after a

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -280,31 +280,36 @@ impl Model {
         };
         let default_selected = 0;
 
-        // Detect a background session left by a previous "hide" (q) action.
-        let background = crate::services::waybar::detect_background_session();
-        if background.is_none() {
-            // Reset state to disconnected on startup in case of previous crash.
-            crate::services::waybar::clear_state();
-        }
+        // A live PID in state.json can only be left by a crashed daemon: q
+        // detaches the TUI but deliberately leaves the daemon itself running.
+        // Stop the orphan before a normal auto-connect can launch a competing
+        // sing-box instance for the same TUN and API ports.
+        let stale_cleanup_failed = match crate::services::waybar::cleanup_stale_session() {
+            Ok(stale_pid) => {
+                if let Some(pid) = stale_pid {
+                    tracing::warn!("Stopped stale sing-box process {pid} during crash recovery");
+                }
+                crate::services::waybar::clear_state();
+                false
+            }
+            Err(e) => {
+                let msg = format!("Failed to clean up stale VPN process: {e:#}");
+                tracing::error!("{msg}");
+                startup_error = Some(match startup_error.take() {
+                    Some(previous) => format!("{previous}; {msg}"),
+                    None => msg,
+                });
+                true
+            }
+        };
 
-        let (mut connection, selected, mut status, bg_pid, bg_id) =
-            if let Some((pid, profile_id, ref profile_name)) = background {
-                let idx = config
-                    .profiles
-                    .iter()
-                    .position(|p| p.id == profile_id)
-                    .unwrap_or(0);
-                (
-                    ConnectionState::Connected,
-                    row_for_profile(&config, idx),
-                    AppStatus::Info(format!("Connected to {} (background)", profile_name)),
-                    Some(pid),
-                    Some(profile_id),
-                )
-            } else {
-                let (c, s, st) = Self::resolve_startup_state(&config, default_selected);
-                (c, s, st, None, None)
-            };
+        let (mut connection, selected, mut status) =
+            Self::resolve_startup_state(&config, default_selected);
+        if stale_cleanup_failed {
+            // Never launch a second sing-box while the stale process may still
+            // own the TUN interface or Clash API port.
+            connection = ConnectionState::Idle;
+        }
 
         // Block auto-connect until the user has picked a geo region.
         if config.settings.geo_routing.current_region.is_none() {
@@ -330,8 +335,8 @@ impl Model {
             config,
             selected,
             status: AppStatus::Info(String::new()),
-            singbox_pid: bg_pid,
-            active_profile_id: bg_id,
+            singbox_pid: None,
+            active_profile_id: None,
             connecting_profile_id,
             connect_attempt_id: u64::from(connecting_profile_id.is_some()),
             kill_switch_pending: None,

--- a/src/app/msg.rs
+++ b/src/app/msg.rs
@@ -65,6 +65,14 @@ pub enum Msg {
         attempt_id: u64,
         error: IpcError,
     },
+    /// The managed sing-box child exited after passing its initial readiness
+    /// check. Bound to the connection generation so a late notification from
+    /// an old process cannot tear down a newer connection.
+    SingBoxExited {
+        attempt_id: u64,
+        code: Option<i32>,
+        signal: Option<i32>,
+    },
     /// A service rule-set download pass finished (files may still be missing
     /// if individual downloads failed — absence degrades to "no rule for
     /// that service"). Consumed by the reducer to run the reconnect that a

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -174,6 +174,42 @@ pub fn update(model: &mut Model, msg: Msg) -> Vec<Effect> {
             );
             effects
         }
+        Msg::SingBoxExited {
+            attempt_id,
+            code,
+            signal,
+        } => {
+            if attempt_id != model.connect_attempt_id {
+                return vec![];
+            }
+            // Invalidate any Connected/traffic reply that was already queued
+            // by the worker for the process that just exited.
+            model.connect_attempt_id = model.connect_attempt_id.wrapping_add(1);
+            model.connection = ConnectionState::Idle;
+            model.connecting_profile_id = None;
+            model.singbox_pid = None;
+            model.active_profile_id = None;
+            model.traffic = TrafficStats::default();
+            model.last_traffic_sample_at_ms = 0;
+            model.traffic_request_id = 0;
+            model.last_traffic_response_id = 0;
+            model.last_traffic_fetch_at = None;
+
+            let reason = match (code, signal) {
+                (Some(code), _) => format!("sing-box exited unexpectedly (code {code})"),
+                (None, Some(signal)) => {
+                    format!("sing-box terminated unexpectedly (signal {signal})")
+                }
+                (None, None) => "sing-box exited unexpectedly".to_string(),
+            };
+            let mut effects = vec![
+                Effect::WriteState,
+                Effect::RevokeKillSwitchExceptions,
+                Effect::BroadcastState,
+            ];
+            push_status(&mut effects, model, AppStatus::Error(reason));
+            effects
+        }
 
         Msg::Resize => {
             model.needs_redraw = true;
@@ -2207,6 +2243,102 @@ mod tests {
         assert_eq!(model.connection, ConnectionState::Connected);
         assert_eq!(model.active_profile_id, Some(profile_id));
         assert_eq!(model.singbox_pid, Some(42));
+    }
+
+    #[test]
+    fn singbox_exit_clears_connection_and_invalidates_attempt() {
+        let profile_id = Uuid::new_v4();
+        let mut model = Model::test_new(crate::config::profile::Config::default());
+        model.connection = ConnectionState::Connected;
+        model.connect_attempt_id = 7;
+        model.connecting_profile_id = Some(profile_id);
+        model.active_profile_id = Some(profile_id);
+        model.singbox_pid = Some(99);
+        model.traffic.up_total = 123;
+        model.traffic_request_id = 4;
+        model.last_traffic_response_id = 3;
+
+        let effects = update(
+            &mut model,
+            Msg::SingBoxExited {
+                attempt_id: 7,
+                code: Some(17),
+                signal: None,
+            },
+        );
+
+        assert_eq!(model.connection, ConnectionState::Idle);
+        assert_eq!(model.connect_attempt_id, 8);
+        assert_eq!(model.connecting_profile_id, None);
+        assert_eq!(model.active_profile_id, None);
+        assert_eq!(model.singbox_pid, None);
+        assert_eq!(model.traffic, TrafficStats::default());
+        assert_eq!(model.traffic_request_id, 0);
+        assert_eq!(model.last_traffic_response_id, 0);
+        assert_eq!(
+            model.status.text(),
+            "sing-box exited unexpectedly (code 17)"
+        );
+        assert_eq!(
+            effects,
+            vec![
+                Effect::WriteState,
+                Effect::RevokeKillSwitchExceptions,
+                Effect::BroadcastState,
+                app_log_error("sing-box exited unexpectedly (code 17)"),
+            ]
+        );
+        assert!(
+            !effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::Connect { .. }))
+        );
+    }
+
+    #[test]
+    fn singbox_exit_reports_signal() {
+        let mut model = Model::test_new(crate::config::profile::Config::default());
+        model.connection = ConnectionState::ConnectPending;
+        model.connect_attempt_id = 3;
+
+        update(
+            &mut model,
+            Msg::SingBoxExited {
+                attempt_id: 3,
+                code: None,
+                signal: Some(9),
+            },
+        );
+
+        assert_eq!(
+            model.status.text(),
+            "sing-box terminated unexpectedly (signal 9)"
+        );
+    }
+
+    #[test]
+    fn stale_singbox_exit_does_not_override_newer_connection() {
+        let profile_id = Uuid::new_v4();
+        let mut model = Model::test_new(crate::config::profile::Config::default());
+        model.connection = ConnectionState::Connected;
+        model.connect_attempt_id = 8;
+        model.active_profile_id = Some(profile_id);
+        model.singbox_pid = Some(100);
+
+        let effects = update(
+            &mut model,
+            Msg::SingBoxExited {
+                attempt_id: 7,
+                code: Some(1),
+                signal: None,
+            },
+        );
+
+        assert!(effects.is_empty());
+        assert_eq!(model.connection, ConnectionState::Connected);
+        assert_eq!(model.connect_attempt_id, 8);
+        assert_eq!(model.active_profile_id, Some(profile_id));
+        assert_eq!(model.singbox_pid, Some(100));
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,7 +1,7 @@
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::mpsc::{Sender, channel};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -24,7 +24,6 @@ pub fn run(mut model: Model) -> Result<()> {
     let (tx, rx) = channel::<Msg>();
     let ipc_server = IpcServer::bind(tx.clone())?;
 
-    spawn_ticker(tx.clone());
     spawn_suspend_watcher(tx.clone());
     if let Err(e) = spawn_signal_handler(tx.clone()) {
         tracing::warn!("Failed to install signal handler: {e}");
@@ -36,6 +35,7 @@ pub fn run(mut model: Model) -> Result<()> {
         attempt_id: model.connect_attempt_id,
         handle: None,
     }));
+    spawn_ticker(tx.clone(), Arc::downgrade(&process_slot));
     let connect_coordinator = Arc::new(Mutex::new(()));
 
     let result = run_loop(
@@ -257,6 +257,16 @@ fn execute_daemon_effect(
                 && let Err(e) = crate::services::killswitch::revoke()
             {
                 tracing::warn!("Failed to flush kill switch handshake set: {}", e);
+            }
+        }
+        Effect::RevokeKillSwitchExceptions => {
+            if model.config.settings.kill_switch
+                && let Err(e) = crate::services::killswitch::revoke()
+            {
+                tracing::warn!(
+                    "Failed to flush kill switch handshake set after sing-box exit: {}",
+                    e
+                );
             }
         }
         Effect::DownloadGeo => {
@@ -753,15 +763,44 @@ fn build_snapshot(model: &Model) -> StateSnapshot {
     }
 }
 
-fn spawn_ticker(tx: Sender<Msg>) {
+fn spawn_ticker(tx: Sender<Msg>, process_slot: Weak<Mutex<ProcessSlot>>) {
     thread::spawn(move || {
         loop {
             thread::sleep(Duration::from_millis(250));
+            let Some(process_slot) = process_slot.upgrade() else {
+                break;
+            };
+            if let Some(msg) = poll_process_exit(&process_slot)
+                && tx.send(msg).is_err()
+            {
+                break;
+            }
             if tx.send(Msg::Tick).is_err() {
                 break;
             }
         }
     });
+}
+
+fn poll_process_exit(process_slot: &Arc<Mutex<ProcessSlot>>) -> Option<Msg> {
+    use std::os::unix::process::ExitStatusExt;
+
+    let mut slot = lock_process_slot(process_slot);
+    let status = match slot.handle.as_mut()?.try_wait() {
+        Ok(Some(status)) => status,
+        Ok(None) => return None,
+        Err(e) => {
+            tracing::warn!("Failed to monitor sing-box process: {e:#}");
+            return None;
+        }
+    };
+    let attempt_id = slot.attempt_id;
+    slot.handle.take();
+    Some(Msg::SingBoxExited {
+        attempt_id,
+        code: status.code(),
+        signal: status.signal(),
+    })
 }
 
 /// Lock the sing-box process slot, recovering from poisoned-mutex state.
@@ -805,8 +844,11 @@ fn spawn_signal_handler(tx: Sender<Msg>) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::handshake_protocols;
+    use super::{ProcessSlot, handshake_protocols, lock_process_slot, poll_process_exit};
+    use crate::app::msg::Msg;
     use crate::config::profile::Protocol;
+    use crate::singbox::process_handle::ProcessHandle;
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn handshake_protocols_match_outbound_transports() {
@@ -829,5 +871,46 @@ mod tests {
         ] {
             assert_eq!(handshake_protocols(protocol), &["tcp"]);
         }
+    }
+
+    #[test]
+    fn process_poll_reports_exit_once_and_removes_handle() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let child = std::process::Command::new("sh")
+            .args(["-c", "exit 7"])
+            .spawn()
+            .unwrap();
+        let slot = Arc::new(Mutex::new(ProcessSlot {
+            attempt_id: 42,
+            handle: Some(ProcessHandle::new(child)),
+        }));
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let msg = loop {
+            if let Some(msg) = poll_process_exit(&slot) {
+                break msg;
+            }
+            assert!(std::time::Instant::now() < deadline, "child did not exit");
+            std::thread::yield_now();
+        };
+
+        assert!(matches!(
+            msg,
+            Msg::SingBoxExited {
+                attempt_id: 42,
+                code: Some(7),
+                signal: None,
+            }
+        ));
+        assert!(lock_process_slot(&slot).handle.is_none());
+        assert!(poll_process_exit(&slot).is_none());
+    }
+
+    #[test]
+    fn process_poll_ignores_intentionally_removed_handle() {
+        let slot = Arc::new(Mutex::new(ProcessSlot {
+            attempt_id: 1,
+            handle: None,
+        }));
+        assert!(poll_process_exit(&slot).is_none());
     }
 }

--- a/src/services/log_tailer.rs
+++ b/src/services/log_tailer.rs
@@ -67,13 +67,14 @@ impl LogTailer {
                     if line.trim().is_empty() {
                         continue;
                     }
-                    let ts = parse_timestamp(&line);
-                    let formatted = if let Some(dt) = ts {
-                        format!("{} {}{}", tag, dt.format("%H:%M:%S"), &line[25..])
+                    let parsed = parse_timestamp(&line);
+                    let formatted = if let Some((dt, prefix_len)) = parsed {
+                        let remainder = line.get(prefix_len..).unwrap_or_default();
+                        format!("{} {}{}", tag, dt.format("%H:%M:%S"), remainder)
                     } else {
                         format!("{} {}", tag, line)
                     };
-                    let sort_key = ts.unwrap_or_else(|| {
+                    let sort_key = parsed.map(|(dt, _)| dt).unwrap_or_else(|| {
                         FixedOffset::east_opt(0)
                             .unwrap()
                             .from_utc_datetime(&Local::now().naive_local())
@@ -92,20 +93,21 @@ impl LogTailer {
 }
 
 /// Parse a sing-box style timestamp from the start of a line.
-/// Returns `None` if no timestamp is found.
-fn parse_timestamp(line: &str) -> Option<DateTime<FixedOffset>> {
-    if line.len() >= 25 {
-        let prefix = &line[..25];
-        if let Ok(dt) = DateTime::parse_from_str(prefix, "%z %Y-%m-%d %H:%M:%S") {
-            return Some(dt);
-        }
-        // Try with milliseconds: +0300 2026-06-09 21:28:34.123
-        if line.len() >= 29 {
-            let prefix_ms = &line[..29];
-            if let Ok(dt) = DateTime::parse_from_str(prefix_ms, "%z %Y-%m-%d %H:%M:%S%.3f") {
-                return Some(dt);
-            }
-        }
+/// Returns the parsed value and the byte length of the timestamp prefix.
+fn parse_timestamp(line: &str) -> Option<(DateTime<FixedOffset>, usize)> {
+    // Try the longer form first. Its first 25 bytes are also a valid seconds
+    // timestamp, so reversing this order would leave `.123` in the rendered
+    // message. `str::get` makes malformed Unicode boundaries a normal miss
+    // instead of a slicing panic.
+    if let Some(prefix) = line.get(..29)
+        && let Ok(dt) = DateTime::parse_from_str(prefix, "%z %Y-%m-%d %H:%M:%S%.3f")
+    {
+        return Some((dt, 29));
+    }
+    if let Some(prefix) = line.get(..25)
+        && let Ok(dt) = DateTime::parse_from_str(prefix, "%z %Y-%m-%d %H:%M:%S")
+    {
+        return Some((dt, 25));
     }
     None
 }
@@ -206,25 +208,50 @@ mod tests {
     fn parse_timestamp_valid() {
         use chrono::Datelike;
         let line = "+0300 2026-06-09 21:28:34 INFO hello";
-        let dt = parse_timestamp(line).unwrap();
+        let (dt, prefix_len) = parse_timestamp(line).unwrap();
         assert_eq!(dt.year(), 2026);
         assert_eq!(dt.month(), 6);
         assert_eq!(dt.day(), 9);
+        assert_eq!(prefix_len, 25);
     }
 
     #[test]
     fn parse_timestamp_from_real_singbox_line() {
         use chrono::Timelike;
         let line = "+0300 2026-06-10 09:35:55 DEBUG [4216981911 0ms] router: match[1] inbound=tun-in port=53 => hijack-dns";
-        let dt = parse_timestamp(line).unwrap();
+        let (dt, prefix_len) = parse_timestamp(line).unwrap();
         assert_eq!(dt.hour(), 9);
         assert_eq!(dt.minute(), 35);
         assert_eq!(dt.second(), 55);
+        assert_eq!(prefix_len, 25);
     }
 
     #[test]
     fn parse_timestamp_returns_none_for_malformed() {
         let line = "some random text without timestamp";
         assert!(parse_timestamp(line).is_none());
+    }
+
+    #[test]
+    fn tail_handles_unicode_crossing_timestamp_byte_boundary() {
+        let mut temp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(temp, "aaaaaaaaaaaaaaaaaaaaaaaaé message").unwrap();
+        let path = temp.path().to_path_buf();
+
+        let mut tailer = LogTailer::test_new(vec![(path, "[sb]")]);
+        assert_eq!(
+            tailer.tail(),
+            vec!["[sb] aaaaaaaaaaaaaaaaaaaaaaaaé message"]
+        );
+    }
+
+    #[test]
+    fn tail_strips_millisecond_timestamp_without_leaving_fraction() {
+        let mut temp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(temp, "+0300 2026-06-09 21:28:34.123 INFO hello").unwrap();
+        let path = temp.path().to_path_buf();
+
+        let mut tailer = LogTailer::test_new(vec![(path, "[sb]")]);
+        assert_eq!(tailer.tail(), vec!["[sb] 21:28:34 INFO hello"]);
     }
 }

--- a/src/services/waybar.rs
+++ b/src/services/waybar.rs
@@ -1,4 +1,7 @@
 use crate::app::model::{AppState, Model};
+use anyhow::{Context, Result};
+use std::os::unix::fs::MetadataExt;
+use std::time::{Duration, Instant};
 
 /// Write current connection state to the state JSON file.
 pub fn write_state(model: &Model) {
@@ -66,20 +69,78 @@ pub fn read_state() -> AppState {
     read_state_from(&path)
 }
 
-/// Check whether a background sing-box session is still alive.
+/// Stop a sing-box process left behind by a crashed daemon.
 ///
-/// Returns `(pid, active_profile_id, profile_name)` if a valid session exists.
-pub fn detect_background_session() -> Option<(u32, uuid::Uuid, String)> {
+/// A healthy daemon retains the child handle and keeps running when the TUI
+/// detaches, so finding a live PID in `state.json` during daemon startup means
+/// the previous daemon died. The new daemon cannot safely manage that process
+/// as a `Child`; terminate it before applying the normal auto-connect policy.
+pub fn cleanup_stale_session() -> Result<Option<u32>> {
     let state = read_state();
-    let pid = state.singbox_pid?;
+    let Some(pid) = state.singbox_pid else {
+        return Ok(None);
+    };
     if !is_singbox_alive(pid) {
-        return None;
+        return Ok(None);
     }
-    let id = state
-        .active_profile_id
-        .and_then(|s| uuid::Uuid::parse_str(&s).ok())?;
-    let name = state.profile_name.unwrap_or_else(|| "unknown".to_string());
-    Some((pid, id, name))
+
+    let proc_dir = std::path::PathBuf::from(format!("/proc/{pid}"));
+    let owner = match std::fs::metadata(&proc_dir) {
+        Ok(metadata) => metadata.uid(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(e).with_context(|| format!("Failed to inspect stale sing-box PID {pid}"));
+        }
+    };
+    // SAFETY: getuid has no preconditions and does not dereference pointers.
+    #[allow(unsafe_code)]
+    let current_uid = unsafe { libc::getuid() };
+    anyhow::ensure!(
+        owner == current_uid,
+        "Refusing to stop stale sing-box PID {pid}: owned by UID {owner}, current UID is {current_uid}"
+    );
+
+    signal_process(pid, libc::SIGTERM)?;
+    if wait_until_stopped(pid, Duration::from_secs(1)) {
+        return Ok(Some(pid));
+    }
+
+    // Re-check identity before escalating so a rapidly reused PID cannot make
+    // us signal an unrelated process.
+    anyhow::ensure!(
+        is_singbox_alive(pid),
+        "Stale sing-box PID {pid} changed identity while stopping"
+    );
+    signal_process(pid, libc::SIGKILL)?;
+    anyhow::ensure!(
+        wait_until_stopped(pid, Duration::from_secs(1)),
+        "Stale sing-box PID {pid} did not stop"
+    );
+    Ok(Some(pid))
+}
+
+fn signal_process(pid: u32, signal: i32) -> Result<()> {
+    let pid = i32::try_from(pid).context("sing-box PID exceeds i32")?;
+    // SAFETY: kill does not dereference pointers. PID ownership and process
+    // identity are checked immediately before this helper is called.
+    #[allow(unsafe_code)]
+    let result = unsafe { libc::kill(pid, signal) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error()).context("Failed to signal stale sing-box process")
+    }
+}
+
+fn wait_until_stopped(pid: u32, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if !is_singbox_alive(pid) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    !is_singbox_alive(pid)
 }
 
 /// Print waybar status JSON to stdout.
@@ -108,8 +169,24 @@ pub fn is_singbox_alive(pid: u32) -> bool {
     // blocks read_link on /proc/{pid}/exe for processes with file
     // capabilities (cap_net_admin,cap_net_raw=ep) even for the owning user.
     let comm = std::path::PathBuf::from(format!("/proc/{pid}/comm"));
-    std::fs::read_to_string(&comm)
+    let named_singbox = std::fs::read_to_string(&comm)
         .map(|name| name.trim() == "sing-box")
+        .unwrap_or(false);
+    if !named_singbox {
+        return false;
+    }
+
+    // A terminated child remains in /proc as a zombie until its parent reaps
+    // it. It no longer owns the TUN or routes and must not be reported as a
+    // live VPN session during monitoring or crash recovery.
+    let status = std::path::PathBuf::from(format!("/proc/{pid}/status"));
+    std::fs::read_to_string(status)
+        .map(|contents| {
+            !contents
+                .lines()
+                .find(|line| line.starts_with("State:"))
+                .is_some_and(|line| line.split_whitespace().nth(1) == Some("Z"))
+        })
         .unwrap_or(false)
 }
 
@@ -203,6 +280,36 @@ mod tests {
     #[test]
     fn is_singbox_alive_false_for_systemd() {
         assert!(!is_singbox_alive(1));
+    }
+
+    #[test]
+    fn cleanup_stale_session_stops_owned_singbox_process() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let config = tempfile::tempdir().unwrap();
+        let _config = crate::test_helpers::EnvVarGuard::set("XDG_CONFIG_HOME", config.path());
+        crate::paths::ensure_config_dirs().unwrap();
+
+        let executable = config.path().join("sing-box");
+        std::fs::copy("/usr/bin/sleep", &executable).unwrap();
+        let mut child = std::process::Command::new(&executable)
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let pid = child.id();
+        write_state_to(
+            &AppState {
+                connected: true,
+                profile_name: Some("Stale".into()),
+                active_profile_id: Some("550e8400-e29b-41d4-a716-446655440000".to_string()),
+                singbox_pid: Some(pid),
+            },
+            crate::paths::state_json_path(),
+        )
+        .unwrap();
+
+        assert_eq!(cleanup_stale_session().unwrap(), Some(pid));
+        child.wait().unwrap();
+        assert!(!is_singbox_alive(pid));
     }
 
     #[test]

--- a/src/services/waybar.rs
+++ b/src/services/waybar.rs
@@ -296,6 +296,14 @@ mod tests {
             .spawn()
             .unwrap();
         let pid = child.id();
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while !is_singbox_alive(pid) && Instant::now() < deadline {
+            std::thread::yield_now();
+        }
+        assert!(
+            is_singbox_alive(pid),
+            "spawned sing-box test process was not visible in /proc"
+        );
         write_state_to(
             &AppState {
                 connected: true,

--- a/src/singbox/process_handle.rs
+++ b/src/singbox/process_handle.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use std::process::ExitStatus;
 
 pub struct ProcessHandle {
     child: std::process::Child,
@@ -9,6 +10,14 @@ impl ProcessHandle {
     pub fn new(child: std::process::Child) -> Self {
         let pid = child.id();
         Self { child, pid }
+    }
+
+    /// Check whether the child has exited without blocking. A returned status
+    /// means the OS process has also been reaped by `Child::try_wait`.
+    pub fn try_wait(&mut self) -> Result<Option<ExitStatus>> {
+        self.child
+            .try_wait()
+            .context("Failed to check sing-box process status")
     }
 
     pub fn kill_and_wait(&mut self) -> Result<()> {
@@ -40,5 +49,24 @@ mod tests {
         let mut handle = ProcessHandle::new(child);
         assert_eq!(handle.pid, pid);
         handle.kill_and_wait().unwrap();
+    }
+
+    #[test]
+    fn try_wait_reports_natural_exit() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let child = std::process::Command::new("sh")
+            .args(["-c", "exit 7"])
+            .spawn()
+            .unwrap();
+        let mut handle = ProcessHandle::new(child);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let status = loop {
+            if let Some(status) = handle.try_wait().unwrap() {
+                break status;
+            }
+            assert!(std::time::Instant::now() < deadline, "child did not exit");
+            std::thread::yield_now();
+        };
+        assert_eq!(status.code(), Some(7));
     }
 }


### PR DESCRIPTION
## Summary

Hardens the `sing-box` process lifecycle and log parsing so the daemon correctly recovers from unexpected exits and stale processes left after a crash.

## Changes

- Added non-blocking monitoring of the managed `sing-box` child process.
- Introduced `Msg::SingBoxExited`, carrying the connection attempt ID, exit code, and Unix signal.
- Reset connection, profile, PID, and traffic state when `sing-box` exits unexpectedly.
- Ignore delayed exit notifications from older connection attempts so they cannot tear down a newer connection.
- Persist and broadcast the disconnected state after an unexpected exit.
- Revoke temporary kill-switch endpoint and DNS exceptions while keeping the kill switch enabled.
- Detect and terminate an orphaned `sing-box` process during daemon startup before auto-connect starts another instance.
- Verify stale-process ownership before sending signals.
- Attempt graceful termination with `SIGTERM`, then fall back to `SIGKILL` after a timeout.
- Treat zombie processes as stopped during state recovery and Waybar status checks.
- Parse both second- and millisecond-precision log timestamps safely.
- Avoid panics caused by slicing UTF-8 strings at invalid byte boundaries.
- Strip millisecond timestamp fractions correctly from rendered log lines.
