### PR TITLE
feat(updates): unify automatic update scheduling

### DIFF
--- a/src/app/effect.rs
+++ b/src/app/effect.rs
@@ -20,7 +20,14 @@ pub enum Effect {
     /// successful connect so the download rides the freshly opened tunnel —
     /// pre-tunnel the source may be unreachable (kill switch or ISP blocks).
     DownloadServiceRuleSetsIfMissing,
+    RetryServiceRuleSets {
+        services: Vec<crate::config::profile::RoutedService>,
+    },
     RefreshGeoLastUpdated,
+    ClearGeoRetryState {
+        region: crate::config::profile::GeoRegion,
+    },
+    ResetGeoUpdateSchedules,
     WriteState,
     SaveConfig,
     UpdateSubscription {

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -190,6 +190,7 @@ pub struct Model {
     pub geo_updating: bool,
     pub subscription_fetching: bool,
     pub subscription_updates: HashSet<Uuid>,
+    pub automatic_subscription_updates: HashSet<Uuid>,
     pub needs_redraw: bool,
     pub should_quit: bool,
     pub geo_last_updated: Option<String>,
@@ -198,6 +199,12 @@ pub struct Model {
     /// Last check attempt in this daemon session. Prevents an overdue failed
     /// check from being retried on every 250 ms tick.
     pub geo_last_attempt_at: Option<DateTime<Local>>,
+    pub geo_retry_state: Option<crate::geo::GeoRetryState>,
+    pub geo_next_update: Option<chrono::NaiveDate>,
+    pub service_retry_states: HashMap<RoutedService, crate::geo::GeoRetryState>,
+    pub service_checked_at: HashMap<RoutedService, DateTime<Local>>,
+    pub service_next_updates: HashMap<RoutedService, chrono::NaiveDate>,
+    pub geo_automatic_update: bool,
     /// Latest traffic stats sample, applied either by the daemon (after a
     /// Clash-API fetch) or by the TUI client (from a `StateSnapshot`).
     pub traffic: TrafficStats,
@@ -326,8 +333,31 @@ impl Model {
             .current_region
             .unwrap_or(GeoRegion::Global);
         let geo_manager = crate::geo::GeoManager::new().ok();
+        if let Some(manager) = &geo_manager {
+            let _ = manager.ensure_update_schedules(
+                region,
+                &config.settings.geo_routing.enabled_services(),
+                config.settings.geo_routing.auto_update
+                    != crate::config::profile::GeoAutoUpdate::Off,
+            );
+        }
         let geo_last_updated = geo_manager.as_ref().and_then(|g| g.last_updated(region));
-        let geo_last_checked_at = geo_manager.and_then(|g| g.last_checked_at(region));
+        let geo_last_checked_at = geo_manager.as_ref().and_then(|g| g.last_checked_at(region));
+        let geo_retry_state = geo_manager.as_ref().and_then(|g| g.retry_state(region));
+        let geo_next_update = geo_manager
+            .as_ref()
+            .and_then(|g| g.region_next_update(region));
+        let service_retry_states = geo_manager
+            .as_ref()
+            .map(|g| g.service_retry_states())
+            .unwrap_or_default();
+        let service_checked_at = geo_manager
+            .as_ref()
+            .map(|g| g.service_checked_at())
+            .unwrap_or_default();
+        let service_next_updates = geo_manager
+            .map(|g| g.service_next_updates())
+            .unwrap_or_default();
 
         let mut model = Self {
             overlay: Overlay::None,
@@ -353,11 +383,18 @@ impl Model {
             geo_updating: false,
             subscription_fetching: false,
             subscription_updates: HashSet::new(),
+            automatic_subscription_updates: HashSet::new(),
             needs_redraw: false,
             should_quit: false,
             geo_last_updated,
             geo_last_checked_at,
             geo_last_attempt_at: None,
+            geo_retry_state,
+            geo_next_update,
+            service_retry_states,
+            service_checked_at,
+            service_next_updates,
+            geo_automatic_update: false,
             traffic: TrafficStats::default(),
             last_traffic_sample_at_ms: 0,
             traffic_request_id: 0,
@@ -399,8 +436,31 @@ impl Model {
             .current_region
             .unwrap_or(GeoRegion::Global);
         let geo_manager = crate::geo::GeoManager::new().ok();
+        if let Some(manager) = &geo_manager {
+            let _ = manager.ensure_update_schedules(
+                region,
+                &config.settings.geo_routing.enabled_services(),
+                config.settings.geo_routing.auto_update
+                    != crate::config::profile::GeoAutoUpdate::Off,
+            );
+        }
         let geo_last_updated = geo_manager.as_ref().and_then(|g| g.last_updated(region));
-        let geo_last_checked_at = geo_manager.and_then(|g| g.last_checked_at(region));
+        let geo_last_checked_at = geo_manager.as_ref().and_then(|g| g.last_checked_at(region));
+        let geo_retry_state = geo_manager.as_ref().and_then(|g| g.retry_state(region));
+        let geo_next_update = geo_manager
+            .as_ref()
+            .and_then(|g| g.region_next_update(region));
+        let service_retry_states = geo_manager
+            .as_ref()
+            .map(|g| g.service_retry_states())
+            .unwrap_or_default();
+        let service_checked_at = geo_manager
+            .as_ref()
+            .map(|g| g.service_checked_at())
+            .unwrap_or_default();
+        let service_next_updates = geo_manager
+            .map(|g| g.service_next_updates())
+            .unwrap_or_default();
 
         let mut model = Self {
             overlay: Overlay::None,
@@ -426,11 +486,18 @@ impl Model {
             geo_updating: false,
             subscription_fetching: false,
             subscription_updates: HashSet::new(),
+            automatic_subscription_updates: HashSet::new(),
             needs_redraw: false,
             should_quit: false,
             geo_last_updated,
             geo_last_checked_at,
             geo_last_attempt_at: None,
+            geo_retry_state,
+            geo_next_update,
+            service_retry_states,
+            service_checked_at,
+            service_next_updates,
+            geo_automatic_update: false,
             traffic: TrafficStats::default(),
             last_traffic_sample_at_ms: 0,
             traffic_request_id: 0,
@@ -658,11 +725,18 @@ impl Model {
             geo_updating: false,
             subscription_fetching: false,
             subscription_updates: HashSet::new(),
+            automatic_subscription_updates: HashSet::new(),
             needs_redraw: false,
             should_quit: false,
             geo_last_updated: None,
             geo_last_checked_at: None,
             geo_last_attempt_at: None,
+            geo_retry_state: None,
+            geo_next_update: None,
+            service_retry_states: HashMap::new(),
+            service_checked_at: HashMap::new(),
+            service_next_updates: HashMap::new(),
+            geo_automatic_update: false,
             traffic: TrafficStats::default(),
             last_traffic_sample_at_ms: 0,
             traffic_request_id: 0,

--- a/src/app/msg.rs
+++ b/src/app/msg.rs
@@ -51,6 +51,18 @@ pub enum Msg {
     GeoMetadataRefreshed {
         last_updated: Option<String>,
         last_checked_at: Option<chrono::DateTime<chrono::Local>>,
+        retry_state: Option<crate::geo::GeoRetryState>,
+        service_retry_states: std::collections::HashMap<
+            crate::config::profile::RoutedService,
+            crate::geo::GeoRetryState,
+        >,
+        service_checked_at: std::collections::HashMap<
+            crate::config::profile::RoutedService,
+            chrono::DateTime<chrono::Local>,
+        >,
+        next_update: Option<chrono::NaiveDate>,
+        service_next_updates:
+            std::collections::HashMap<crate::config::profile::RoutedService, chrono::NaiveDate>,
     },
     SystemResumed,
     Connected {
@@ -78,7 +90,18 @@ pub enum Msg {
     /// that service"). Consumed by the reducer to run the reconnect that a
     /// service-routing commit deferred until the rule-sets were fetched
     /// through the still-active tunnel (`Model::pending_service_reconnect`).
-    ServiceRuleSetsReady,
+    ServiceRuleSetsReady {
+        retry_states: std::collections::HashMap<
+            crate::config::profile::RoutedService,
+            crate::geo::GeoRetryState,
+        >,
+        checked_at: std::collections::HashMap<
+            crate::config::profile::RoutedService,
+            chrono::DateTime<chrono::Local>,
+        >,
+        next_updates:
+            std::collections::HashMap<crate::config::profile::RoutedService, chrono::NaiveDate>,
+    },
     SubscriptionFetched {
         id: Uuid,
         result: Result<Vec<crate::config::profile::Profile>, IpcError>,
@@ -121,11 +144,52 @@ pub enum GeoResult {
         parts: Vec<String>,
         last_updated: Option<String>,
         checked_at: chrono::DateTime<chrono::Local>,
+        retry_state: Option<crate::geo::GeoRetryState>,
+        service_retry_states: std::collections::HashMap<
+            crate::config::profile::RoutedService,
+            crate::geo::GeoRetryState,
+        >,
+        service_checked_at: std::collections::HashMap<
+            crate::config::profile::RoutedService,
+            chrono::DateTime<chrono::Local>,
+        >,
+        next_update: Option<chrono::NaiveDate>,
+        service_next_updates:
+            std::collections::HashMap<crate::config::profile::RoutedService, chrono::NaiveDate>,
+        warnings: Vec<String>,
     },
     UpToDate {
         checked_at: Option<chrono::DateTime<chrono::Local>>,
+        retry_state: Option<crate::geo::GeoRetryState>,
+        service_retry_states: std::collections::HashMap<
+            crate::config::profile::RoutedService,
+            crate::geo::GeoRetryState,
+        >,
+        service_checked_at: std::collections::HashMap<
+            crate::config::profile::RoutedService,
+            chrono::DateTime<chrono::Local>,
+        >,
+        next_update: Option<chrono::NaiveDate>,
+        service_next_updates:
+            std::collections::HashMap<crate::config::profile::RoutedService, chrono::NaiveDate>,
+        warnings: Vec<String>,
     },
-    Error(String),
+    Error {
+        message: String,
+        retry_state: Option<crate::geo::GeoRetryState>,
+        service_retry_states: std::collections::HashMap<
+            crate::config::profile::RoutedService,
+            crate::geo::GeoRetryState,
+        >,
+        service_checked_at: std::collections::HashMap<
+            crate::config::profile::RoutedService,
+            chrono::DateTime<chrono::Local>,
+        >,
+        next_update: Option<chrono::NaiveDate>,
+        service_next_updates:
+            std::collections::HashMap<crate::config::profile::RoutedService, chrono::NaiveDate>,
+        updated_parts: Vec<String>,
+    },
 }
 
 /// Commands sent from the TUI client to the daemon over the Unix socket.

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -523,9 +523,12 @@ fn connection_settings_changed(
 }
 
 fn handle_tick(model: &mut Model) -> Vec<Effect> {
+    handle_tick_at(model, Local::now())
+}
+
+fn handle_tick_at(model: &mut Model, now: chrono::DateTime<Local>) -> Vec<Effect> {
     let mut effects = Vec::new();
 
-    let now = Local::now();
     if geo_update_due(model, now) {
         model.geo_updating = true;
         model.geo_automatic_update = true;
@@ -575,7 +578,7 @@ fn handle_tick(model: &mut Model) -> Vec<Effect> {
     }
 
     // Auto-update subscriptions that are due.
-    effects.extend(check_due_subscriptions(model));
+    effects.extend(check_due_subscriptions_at(model, now));
 
     // Dispatch pending profile tests, max 4 concurrent.
     while model.testing_profiles.len() < 4 {
@@ -701,10 +704,6 @@ fn geo_update_due(model: &Model, now: chrono::DateTime<Local>) -> bool {
             },
             |date| now.date_naive() >= date,
         )
-}
-
-fn check_due_subscriptions(model: &mut Model) -> Vec<Effect> {
-    check_due_subscriptions_at(model, Local::now())
 }
 
 fn check_due_subscriptions_at(model: &mut Model, now: chrono::DateTime<Local>) -> Vec<Effect> {
@@ -1158,7 +1157,18 @@ mod tests {
     use super::*;
     use crate::config::profile::{GeoAutoUpdate, RoutingMode, SubscriptionAutoUpdate};
     use crate::test_helpers::*;
+    use chrono::Timelike;
     use crossterm::event::KeyCode;
+
+    fn after_update_window() -> chrono::DateTime<Local> {
+        Local::now()
+            .with_hour(9)
+            .unwrap()
+            .with_minute(0)
+            .unwrap()
+            .with_second(0)
+            .unwrap()
+    }
 
     fn app_log_info(message: &str) -> Effect {
         Effect::AppendAppLog {
@@ -2254,7 +2264,7 @@ mod tests {
         model.config.settings.geo_routing.set_region(GeoRegion::Ru);
         model.config.settings.geo_routing.auto_update = GeoAutoUpdate::Every1d;
 
-        let effects = handle_tick(&mut model);
+        let effects = handle_tick_at(&mut model, after_update_window());
 
         assert!(effects.contains(&Effect::DownloadGeo));
         assert!(model.geo_updating);
@@ -2266,7 +2276,7 @@ mod tests {
         let mut model = model_with_profiles(vec![]);
         model.config.settings.geo_routing.set_region(GeoRegion::Ru);
         model.config.settings.geo_routing.auto_update = GeoAutoUpdate::Every1d;
-        let now = Local::now();
+        let now = after_update_window();
         model.geo_last_checked_at = Some(now - chrono::Duration::try_hours(23).unwrap());
         assert!(!geo_update_due(&model, now));
 
@@ -2284,7 +2294,7 @@ mod tests {
         let mut model = model_with_profiles(vec![]);
         model.config.settings.geo_routing.set_region(GeoRegion::Ru);
         model.config.settings.geo_routing.auto_update = GeoAutoUpdate::Every1d;
-        let now = Local::now();
+        let now = after_update_window();
         model.geo_last_checked_at = Some(now - chrono::Duration::days(2));
         model.geo_retry_state = Some(crate::geo::GeoRetryState {
             consecutive_failures: 2,
@@ -2339,7 +2349,7 @@ mod tests {
             crate::config::profile::ServiceRoute::Proxy,
         );
 
-        let effects = handle_tick(&mut model);
+        let effects = handle_tick_at(&mut model, after_update_window());
         assert!(!effects.contains(&Effect::DownloadGeo));
         assert!(effects.contains(&Effect::RetryServiceRuleSets {
             services: vec![RoutedService::Telegram],
@@ -2378,7 +2388,7 @@ mod tests {
         model.config.settings.geo_routing.set_region(GeoRegion::Ru);
         model.config.settings.geo_routing.auto_update = GeoAutoUpdate::Every1d;
         model.config.settings.kill_switch = true;
-        let now = Local::now();
+        let now = after_update_window();
 
         model.connection = ConnectionState::Connecting;
         assert!(!geo_update_due(&model, now));
@@ -3834,7 +3844,7 @@ mod tests {
             retry_state: None,
         });
 
-        let effects = check_due_subscriptions(&mut model);
+        let effects = check_due_subscriptions_at(&mut model, after_update_window());
 
         assert_eq!(effects, vec![Effect::UpdateSubscription { id: sub_id }]);
         assert!(model.subscription_updates.contains(&sub_id));
@@ -3964,18 +3974,19 @@ mod tests {
             retry_state: None,
         });
         model.config.settings.kill_switch = true;
+        let now = after_update_window();
 
         model.connection = ConnectionState::Connecting;
-        assert!(check_due_subscriptions(&mut model).is_empty());
+        assert!(check_due_subscriptions_at(&mut model, now).is_empty());
         assert!(!model.subscription_updates.contains(&sub_id));
 
         model.connection = ConnectionState::ConnectPending;
-        assert!(check_due_subscriptions(&mut model).is_empty());
+        assert!(check_due_subscriptions_at(&mut model, now).is_empty());
         assert!(!model.subscription_updates.contains(&sub_id));
 
         model.connection = ConnectionState::Connected;
         assert_eq!(
-            check_due_subscriptions(&mut model),
+            check_due_subscriptions_at(&mut model, now),
             vec![Effect::UpdateSubscription { id: sub_id }]
         );
         assert!(model.subscription_updates.contains(&sub_id));
@@ -3984,18 +3995,19 @@ mod tests {
     #[test]
     fn non_due_subscriptions_are_skipped() {
         let sub_id = Uuid::new_v4();
+        let now = after_update_window();
         let mut model = model_with_profiles(vec![]);
         model.config.subscriptions.push(Subscription {
             id: sub_id,
             name: "Sub".to_string(),
             url: "http://example.com/sub".to_string(),
             auto_update: SubscriptionAutoUpdate::Every1d,
-            last_updated: Some(chrono::Local::now()),
+            last_updated: Some(now),
             next_auto_update: None,
             retry_state: None,
         });
 
-        let effects = check_due_subscriptions(&mut model);
+        let effects = check_due_subscriptions_at(&mut model, now);
 
         assert!(effects.is_empty());
         assert!(!model.subscription_updates.contains(&sub_id));

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -1,7 +1,9 @@
 use crate::app::effect::Effect;
 use crate::app::model::{AppStatus, ConnectionState, Model, Overlay, TrafficStats};
 use crate::app::msg::{GeoResult, Msg};
-use crate::config::profile::{GeoRegion, Profile, Subscription, SubscriptionAutoUpdate};
+use crate::config::profile::{
+    GeoRegion, Profile, RoutedService, Subscription, SubscriptionAutoUpdate,
+};
 use chrono::Local;
 use crossterm::event::KeyCode;
 #[cfg(test)]
@@ -33,10 +35,20 @@ pub fn update(model: &mut Model, msg: Msg) -> Vec<Effect> {
         Msg::GeoMetadataRefreshed {
             last_updated,
             last_checked_at,
+            retry_state,
+            service_retry_states,
+            service_checked_at,
+            next_update,
+            service_next_updates,
         } => {
             model.geo_last_updated = last_updated;
             model.geo_last_checked_at = last_checked_at;
             model.geo_last_attempt_at = None;
+            model.geo_retry_state = retry_state;
+            model.service_retry_states = service_retry_states;
+            model.service_checked_at = service_checked_at;
+            model.geo_next_update = next_update;
+            model.service_next_updates = service_next_updates;
             vec![Effect::BroadcastState]
         }
         Msg::SystemResumed => {
@@ -115,7 +127,14 @@ pub fn update(model: &mut Model, msg: Msg) -> Vec<Effect> {
             effects
         }
         Msg::SubscriptionFetched { id, result } => handle_subscription_result(model, id, result),
-        Msg::ServiceRuleSetsReady => {
+        Msg::ServiceRuleSetsReady {
+            retry_states,
+            checked_at,
+            next_updates,
+        } => {
+            model.service_retry_states = retry_states;
+            model.service_checked_at = checked_at;
+            model.service_next_updates = next_updates;
             // The post-connect backstop download also reports here; without
             // a pending commit there is nothing to do.
             if !model.pending_service_reconnect {
@@ -506,10 +525,28 @@ fn connection_settings_changed(
 fn handle_tick(model: &mut Model) -> Vec<Effect> {
     let mut effects = Vec::new();
 
-    if geo_update_due(model, Local::now()) {
+    let now = Local::now();
+    if geo_update_due(model, now) {
         model.geo_updating = true;
-        model.geo_last_attempt_at = Some(Local::now());
+        model.geo_automatic_update = true;
+        model.geo_last_attempt_at = Some(now);
         effects.push(Effect::DownloadGeo);
+    } else if !model.geo_updating && model.connection == ConnectionState::Connected {
+        let due_services: Vec<_> = model
+            .config
+            .settings
+            .geo_routing
+            .enabled_services()
+            .into_iter()
+            .filter(|service| service_update_due(model, *service, now))
+            .collect();
+        if !due_services.is_empty() {
+            model.geo_updating = true;
+            model.geo_automatic_update = true;
+            effects.push(Effect::RetryServiceRuleSets {
+                services: due_services,
+            });
+        }
     }
 
     // Connection handling
@@ -569,6 +606,39 @@ fn handle_tick(model: &mut Model) -> Vec<Effect> {
     effects
 }
 
+fn service_update_due(model: &Model, service: RoutedService, now: chrono::DateTime<Local>) -> bool {
+    if let Some(state) = model.service_retry_states.get(&service)
+        && (state.attempt_date.is_none() || state.attempt_date == Some(now.date_naive()))
+    {
+        return state.consecutive_failures < 5 && now >= state.retry_at;
+    }
+    model
+        .config
+        .settings
+        .geo_routing
+        .auto_update
+        .interval_minutes()
+        != 0
+        && now.time() >= chrono::NaiveTime::from_hms_opt(8, 0, 0).unwrap()
+        && model.service_next_updates.get(&service).map_or_else(
+            || {
+                model
+                    .service_checked_at
+                    .get(&service)
+                    .is_none_or(|checked| {
+                        now.signed_duration_since(*checked).num_minutes()
+                            >= model
+                                .config
+                                .settings
+                                .geo_routing
+                                .auto_update
+                                .interval_minutes() as i64
+                    })
+            },
+            |date| now.date_naive() >= *date,
+        )
+}
+
 pub(super) fn queue_connect(model: &mut Model, profile_id: Uuid) -> bool {
     if model
         .config
@@ -611,16 +681,33 @@ fn geo_update_due(model: &Model, now: chrono::DateTime<Local>) -> bool {
     if interval == 0 {
         return false;
     }
-    let reference = match (model.geo_last_checked_at, model.geo_last_attempt_at) {
-        (Some(checked), Some(attempt)) => Some(checked.max(attempt)),
-        (Some(checked), None) => Some(checked),
-        (None, Some(attempt)) => Some(attempt),
-        (None, None) => None,
-    };
-    reference.is_none_or(|last| now.signed_duration_since(last).num_minutes() >= interval as i64)
+    if let Some(retry) = model.geo_retry_state
+        && (retry.attempt_date.is_none() || retry.attempt_date == Some(now.date_naive()))
+    {
+        return retry.consecutive_failures < 5 && now >= retry.retry_at;
+    }
+    now.time() >= chrono::NaiveTime::from_hms_opt(8, 0, 0).unwrap()
+        && model.geo_next_update.map_or_else(
+            || {
+                let reference = match (model.geo_last_checked_at, model.geo_last_attempt_at) {
+                    (Some(checked), Some(attempt)) => Some(checked.max(attempt)),
+                    (Some(checked), None) => Some(checked),
+                    (None, Some(attempt)) => Some(attempt),
+                    (None, None) => None,
+                };
+                reference.is_none_or(|last| {
+                    now.signed_duration_since(last).num_minutes() >= interval as i64
+                })
+            },
+            |date| now.date_naive() >= date,
+        )
 }
 
 fn check_due_subscriptions(model: &mut Model) -> Vec<Effect> {
+    check_due_subscriptions_at(model, Local::now())
+}
+
+fn check_due_subscriptions_at(model: &mut Model, now: chrono::DateTime<Local>) -> Vec<Effect> {
     // Subscription fetches use ordinary application networking, so with the
     // kill switch active they must wait until sing-box has created the TUN.
     if model.config.settings.kill_switch && model.connection != ConnectionState::Connected {
@@ -628,7 +715,6 @@ fn check_due_subscriptions(model: &mut Model) -> Vec<Effect> {
     }
 
     let mut effects = Vec::new();
-    let now = Local::now();
     for sub in &model.config.subscriptions {
         let interval = sub.auto_update.interval_minutes();
         if interval == 0 {
@@ -637,15 +723,27 @@ fn check_due_subscriptions(model: &mut Model) -> Vec<Effect> {
         if model.subscription_updates.contains(&sub.id) {
             continue;
         }
-        let due = match sub.last_updated {
-            None => true,
-            Some(last) => {
-                let elapsed = now.signed_duration_since(last);
-                elapsed.num_minutes() >= interval as i64
+        let today = now.date_naive();
+        let after_window = now.time() >= chrono::NaiveTime::from_hms_opt(8, 0, 0).unwrap();
+        let due = match &sub.retry_state {
+            Some(state) if state.attempt_date.is_none() || state.attempt_date == Some(today) => {
+                state.consecutive_failures < 5 && now >= state.retry_at
+            }
+            _ => {
+                after_window
+                    && sub.next_auto_update.map_or_else(
+                        || {
+                            sub.last_updated.is_none_or(|last| {
+                                now.signed_duration_since(last).num_minutes() >= interval as i64
+                            })
+                        },
+                        |date| today >= date,
+                    )
             }
         };
         if due {
             model.subscription_updates.insert(sub.id);
+            model.automatic_subscription_updates.insert(sub.id);
             effects.push(Effect::UpdateSubscription { id: sub.id });
         }
     }
@@ -711,6 +809,8 @@ fn add_and_fetch_subscription(model: &mut Model, url: &str) -> Vec<Effect> {
         url: url.to_string(),
         auto_update: SubscriptionAutoUpdate::default(),
         last_updated: None,
+        next_auto_update: None,
+        retry_state: None,
     };
     model.config.subscriptions.push(sub);
     model.selected = crate::app::model::row_for_subscription_header(
@@ -737,7 +837,17 @@ fn handle_subscription_result(
     id: Uuid,
     result: Result<Vec<Profile>, crate::app::msg::IpcError>,
 ) -> Vec<Effect> {
+    handle_subscription_result_at(model, id, result, Local::now())
+}
+
+fn handle_subscription_result_at(
+    model: &mut Model,
+    id: Uuid,
+    result: Result<Vec<Profile>, crate::app::msg::IpcError>,
+    now: chrono::DateTime<Local>,
+) -> Vec<Effect> {
     let managed = !id.is_nil();
+    let automatic = model.automatic_subscription_updates.remove(&id);
     model.subscription_updates.remove(&id);
     if model.subscription_updates.is_empty() {
         model.subscription_fetching = false;
@@ -767,7 +877,10 @@ fn handle_subscription_result(
         Ok(profiles) => {
             if managed {
                 if let Some(sub) = model.config.subscriptions.iter_mut().find(|s| s.id == id) {
-                    sub.last_updated = Some(Local::now());
+                    sub.last_updated = Some(now);
+                    if automatic {
+                        sub.schedule_next_after_success(now);
+                    }
                 }
                 // Only replace the previous snapshot after the fetch and parse
                 // succeeded. A transient subscription error must leave the
@@ -839,7 +952,19 @@ fn handle_subscription_result(
             effects
         }
         Err(err) => {
-            let mut effects = Vec::new();
+            let mut effects = if managed {
+                if let Some(sub) = model.config.subscriptions.iter_mut().find(|s| s.id == id)
+                    && automatic
+                    && sub.auto_update != SubscriptionAutoUpdate::Off
+                {
+                    sub.record_fetch_failure(now);
+                    vec![Effect::SaveConfig]
+                } else {
+                    Vec::new()
+                }
+            } else {
+                Vec::new()
+            };
             push_status(
                 &mut effects,
                 model,
@@ -910,12 +1035,24 @@ fn handle_subscription_result(
 
 fn handle_geo_result(model: &mut Model, result: GeoResult) -> Vec<Effect> {
     model.geo_updating = false;
+    model.geo_automatic_update = false;
     let mut effects = match result {
         GeoResult::Updated {
             parts,
             last_updated,
             checked_at,
+            retry_state,
+            service_retry_states,
+            service_checked_at,
+            next_update,
+            service_next_updates,
+            warnings,
         } => {
+            model.geo_retry_state = retry_state;
+            model.service_retry_states = service_retry_states;
+            model.service_checked_at = service_checked_at;
+            model.geo_next_update = next_update;
+            model.service_next_updates = service_next_updates;
             model.geo_last_updated = last_updated;
             model.geo_last_checked_at = Some(checked_at);
             let mut log_effects = Vec::new();
@@ -927,11 +1064,18 @@ fn handle_geo_result(model: &mut Model, result: GeoResult) -> Vec<Effect> {
                 });
                 model.logs.push_back(text);
             }
-            push_status(
-                &mut log_effects,
-                model,
-                crate::app::model::AppStatus::Info("Geo databases updated".into()),
-            );
+            for warning in &warnings {
+                log_effects.push(Effect::AppendAppLog {
+                    level: "ERROR".to_string(),
+                    message: format!("Geo batch partial failure: {warning}"),
+                });
+            }
+            let status = if warnings.is_empty() {
+                AppStatus::Info("Geo databases updated".into())
+            } else {
+                AppStatus::Error(format!("Geo updated partially: {}", warnings.join("; ")))
+            };
+            push_status(&mut log_effects, model, status);
             if model.connection == ConnectionState::Connected
                 && let Some(active_id) = model.active_profile_id
                 && queue_connect(model, active_id)
@@ -942,23 +1086,66 @@ fn handle_geo_result(model: &mut Model, result: GeoResult) -> Vec<Effect> {
             }
             log_effects
         }
-        GeoResult::UpToDate { checked_at } => {
+        GeoResult::UpToDate {
+            checked_at,
+            retry_state,
+            service_retry_states,
+            service_checked_at,
+            next_update,
+            service_next_updates,
+            warnings,
+        } => {
+            model.geo_retry_state = retry_state;
+            model.service_retry_states = service_retry_states;
+            model.service_checked_at = service_checked_at;
+            model.geo_next_update = next_update;
+            model.service_next_updates = service_next_updates;
             model.geo_last_checked_at = checked_at;
             let mut effects = Vec::new();
-            push_status(
-                &mut effects,
-                model,
-                crate::app::model::AppStatus::Info("Geo databases are up to date".into()),
-            );
+            let status = if warnings.is_empty() {
+                AppStatus::Info("Geo databases are up to date".into())
+            } else {
+                AppStatus::Error(format!(
+                    "Service rule-set update failed: {}",
+                    warnings.join("; ")
+                ))
+            };
+            push_status(&mut effects, model, status);
             effects
         }
-        GeoResult::Error(err) => {
+        GeoResult::Error {
+            message,
+            retry_state,
+            service_retry_states,
+            service_checked_at,
+            next_update,
+            service_next_updates,
+            updated_parts,
+        } => {
+            model.geo_retry_state = retry_state;
+            model.service_retry_states = service_retry_states;
+            model.service_checked_at = service_checked_at;
+            model.geo_next_update = next_update;
+            model.service_next_updates = service_next_updates;
             let mut effects = Vec::new();
+            let has_updates = !updated_parts.is_empty();
             push_status(
                 &mut effects,
                 model,
-                crate::app::model::AppStatus::Error(err),
+                crate::app::model::AppStatus::Error(message),
             );
+            for part in updated_parts {
+                effects.push(Effect::AppendAppLog {
+                    level: "INFO".to_string(),
+                    message: format!("Updated: {part}"),
+                });
+            }
+            if has_updates
+                && model.connection == ConnectionState::Connected
+                && let Some(active_id) = model.active_profile_id
+            {
+                queue_connect(model, active_id);
+            }
             effects
         }
     };
@@ -1072,8 +1259,10 @@ mod tests {
             id: sub_id,
             name: "Sub".to_string(),
             url: "http://example.com".to_string(),
-            auto_update: SubscriptionAutoUpdate::Every1h,
+            auto_update: SubscriptionAutoUpdate::Every1d,
             last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
         });
         model.selected = 0; // subscription header
         let effects = handle_sources(&mut model, KeyEvent::from(KeyCode::Enter));
@@ -1092,8 +1281,10 @@ mod tests {
             id: sub_id,
             name: "Sub".to_string(),
             url: "http://example.com".to_string(),
-            auto_update: SubscriptionAutoUpdate::Every1h,
+            auto_update: SubscriptionAutoUpdate::Every1d,
             last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
         });
         model.selected = 0; // subscription header
         let effects = handle_sources(&mut model, KeyEvent::from(KeyCode::Enter));
@@ -1897,6 +2088,11 @@ mod tests {
             Msg::GeoMetadataRefreshed {
                 last_updated: Some("2026-06-15 08:00".to_string()),
                 last_checked_at: None,
+                retry_state: None,
+                service_retry_states: Default::default(),
+                service_checked_at: Default::default(),
+                next_update: None,
+                service_next_updates: Default::default(),
             },
         );
         assert_eq!(model.geo_last_updated, Some("2026-06-15 08:00".to_string()));
@@ -1904,7 +2100,29 @@ mod tests {
     }
 
     #[test]
-    fn normal_mode_u_blocked_for_global_region() {
+    fn normal_mode_u_in_global_updates_enabled_services() {
+        let mut model = model_with_profiles(vec![]);
+        model
+            .config
+            .settings
+            .geo_routing
+            .set_region(GeoRegion::Global);
+        model.config.settings.geo_routing.service_routes.insert(
+            RoutedService::Telegram,
+            crate::config::profile::ServiceRoute::Proxy,
+        );
+        model.connection = ConnectionState::Connected;
+
+        let effects = handle_sources(&mut model, key('u'));
+        assert!(model.geo_updating);
+        assert!(!effects.contains(&Effect::DownloadGeo));
+        assert!(effects.contains(&Effect::RetryServiceRuleSets {
+            services: vec![RoutedService::Telegram],
+        }));
+    }
+
+    #[test]
+    fn normal_mode_u_in_global_without_services_is_noop() {
         let mut model = model_with_profiles(vec![]);
         model
             .config
@@ -1915,7 +2133,7 @@ mod tests {
         let effects = handle_sources(&mut model, key('u'));
         assert!(!model.geo_updating);
         assert!(!effects.contains(&Effect::DownloadGeo));
-        assert!(model.status.text().contains("not available"));
+        assert!(model.status.text().contains("No enabled service"));
     }
 
     #[test]
@@ -1928,6 +2146,12 @@ mod tests {
                 parts: vec!["geoip".into()],
                 last_updated: Some("2026-05-31 13:41".to_string()),
                 checked_at: Local::now(),
+                retry_state: None,
+                service_retry_states: Default::default(),
+                service_checked_at: Default::default(),
+                next_update: None,
+                service_next_updates: Default::default(),
+                warnings: Vec::new(),
             }),
         );
         assert!(!model.geo_updating);
@@ -1957,6 +2181,12 @@ mod tests {
                 parts: vec!["geoip".into()],
                 last_updated: None,
                 checked_at: Local::now(),
+                retry_state: None,
+                service_retry_states: Default::default(),
+                service_checked_at: Default::default(),
+                next_update: None,
+                service_next_updates: Default::default(),
+                warnings: Vec::new(),
             }),
         );
 
@@ -1971,6 +2201,12 @@ mod tests {
             &mut model,
             Msg::GeoUpdated(GeoResult::UpToDate {
                 checked_at: Some(Local::now()),
+                retry_state: None,
+                service_retry_states: Default::default(),
+                service_checked_at: Default::default(),
+                next_update: None,
+                service_next_updates: Default::default(),
+                warnings: Vec::new(),
             }),
         );
         assert!(!model.geo_updating);
@@ -1987,11 +2223,25 @@ mod tests {
     fn geo_result_error_broadcasts_state() {
         let mut model = model_with_profiles(vec![]);
         model.geo_updating = true;
+        let retry_state = crate::geo::GeoRetryState {
+            consecutive_failures: 1,
+            retry_at: Local::now() + chrono::Duration::minutes(1),
+            attempt_date: None,
+        };
         let effects = update(
             &mut model,
-            Msg::GeoUpdated(GeoResult::Error("net fail".into())),
+            Msg::GeoUpdated(GeoResult::Error {
+                message: "net fail".into(),
+                retry_state: Some(retry_state),
+                service_retry_states: Default::default(),
+                service_checked_at: Default::default(),
+                next_update: None,
+                service_next_updates: Default::default(),
+                updated_parts: Vec::new(),
+            }),
         );
         assert!(!model.geo_updating);
+        assert_eq!(model.geo_retry_state, Some(retry_state));
         assert_eq!(
             effects,
             vec![app_log_error("net fail"), Effect::BroadcastState]
@@ -2002,7 +2252,7 @@ mod tests {
     fn geo_auto_update_due_without_previous_check() {
         let mut model = model_with_profiles(vec![]);
         model.config.settings.geo_routing.set_region(GeoRegion::Ru);
-        model.config.settings.geo_routing.auto_update = GeoAutoUpdate::Every12h;
+        model.config.settings.geo_routing.auto_update = GeoAutoUpdate::Every1d;
 
         let effects = handle_tick(&mut model);
 
@@ -2030,6 +2280,99 @@ mod tests {
     }
 
     #[test]
+    fn geo_auto_update_honors_retry_deadline_before_normal_interval() {
+        let mut model = model_with_profiles(vec![]);
+        model.config.settings.geo_routing.set_region(GeoRegion::Ru);
+        model.config.settings.geo_routing.auto_update = GeoAutoUpdate::Every1d;
+        let now = Local::now();
+        model.geo_last_checked_at = Some(now - chrono::Duration::days(2));
+        model.geo_retry_state = Some(crate::geo::GeoRetryState {
+            consecutive_failures: 2,
+            retry_at: now + chrono::Duration::minutes(5),
+            attempt_date: None,
+        });
+
+        assert!(!geo_update_due(&model, now));
+        assert!(!geo_update_due(&model, now + chrono::Duration::minutes(4)));
+        assert!(geo_update_due(&model, now + chrono::Duration::minutes(5)));
+    }
+
+    #[test]
+    fn service_retry_is_independent_from_region_schedule() {
+        let mut model = model_with_profiles(vec![]);
+        model.connection = ConnectionState::Connected;
+        model.config.settings.geo_routing.set_region(GeoRegion::Ru);
+        model.config.settings.geo_routing.auto_update = GeoAutoUpdate::Off;
+        model.config.settings.geo_routing.service_routes.insert(
+            crate::config::profile::RoutedService::Telegram,
+            crate::config::profile::ServiceRoute::Proxy,
+        );
+        model.service_retry_states.insert(
+            crate::config::profile::RoutedService::Telegram,
+            crate::geo::GeoRetryState {
+                consecutive_failures: 2,
+                retry_at: Local::now() - chrono::Duration::seconds(1),
+                attempt_date: None,
+            },
+        );
+
+        let effects = handle_tick(&mut model);
+
+        assert!(effects.contains(&Effect::RetryServiceRuleSets {
+            services: vec![crate::config::profile::RoutedService::Telegram],
+        }));
+        assert!(!effects.contains(&Effect::DownloadGeo));
+    }
+
+    #[test]
+    fn global_auto_update_checks_enabled_services_only() {
+        let mut model = model_with_profiles(vec![]);
+        model.connection = ConnectionState::Connected;
+        model
+            .config
+            .settings
+            .geo_routing
+            .set_region(GeoRegion::Global);
+        model.config.settings.geo_routing.auto_update = GeoAutoUpdate::Every1d;
+        model.config.settings.geo_routing.service_routes.insert(
+            RoutedService::Telegram,
+            crate::config::profile::ServiceRoute::Proxy,
+        );
+
+        let effects = handle_tick(&mut model);
+        assert!(!effects.contains(&Effect::DownloadGeo));
+        assert!(effects.contains(&Effect::RetryServiceRuleSets {
+            services: vec![RoutedService::Telegram],
+        }));
+    }
+
+    #[test]
+    fn global_auto_update_skips_fresh_service_check() {
+        let mut model = model_with_profiles(vec![]);
+        model.connection = ConnectionState::Connected;
+        model
+            .config
+            .settings
+            .geo_routing
+            .set_region(GeoRegion::Global);
+        model.config.settings.geo_routing.auto_update = GeoAutoUpdate::Every1d;
+        model.config.settings.geo_routing.service_routes.insert(
+            RoutedService::Telegram,
+            crate::config::profile::ServiceRoute::Proxy,
+        );
+        model
+            .service_checked_at
+            .insert(RoutedService::Telegram, Local::now());
+
+        let effects = handle_tick(&mut model);
+        assert!(
+            !effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::RetryServiceRuleSets { .. }))
+        );
+    }
+
+    #[test]
     fn geo_auto_update_waits_for_vpn_when_kill_switch_is_enabled() {
         let mut model = model_with_profiles(vec![]);
         model.config.settings.geo_routing.set_region(GeoRegion::Ru);
@@ -2054,7 +2397,7 @@ mod tests {
         model.config.settings.geo_routing.set_region(GeoRegion::Ru);
         assert!(!geo_update_due(&model, now));
 
-        model.config.settings.geo_routing.auto_update = GeoAutoUpdate::Every12h;
+        model.config.settings.geo_routing.auto_update = GeoAutoUpdate::Every1d;
         model
             .config
             .settings
@@ -2071,7 +2414,6 @@ mod tests {
     fn shift_i_cycles_geo_auto_update_and_saves() {
         let mut model = model_with_profiles(vec![]);
         for expected in [
-            GeoAutoUpdate::Every12h,
             GeoAutoUpdate::Every1d,
             GeoAutoUpdate::Every3d,
             GeoAutoUpdate::Every7d,
@@ -2572,7 +2914,14 @@ mod tests {
         model.pending_service_reconnect = true;
         // Cursor rests on profile B — the reconnect must still target A.
         model.select_next();
-        update(&mut model, Msg::ServiceRuleSetsReady);
+        update(
+            &mut model,
+            Msg::ServiceRuleSetsReady {
+                retry_states: Default::default(),
+                checked_at: Default::default(),
+                next_updates: Default::default(),
+            },
+        );
         assert!(!model.pending_service_reconnect, "flag is consumed");
         assert_eq!(model.connection, ConnectionState::Connecting);
         assert_eq!(model.connecting_profile_id, Some(active_id));
@@ -2596,7 +2945,14 @@ mod tests {
         let mut model = model_with_profiles(vec![profile.clone()]);
         model.connection = ConnectionState::Connected;
         model.active_profile_id = Some(profile.id);
-        let effects = update(&mut model, Msg::ServiceRuleSetsReady);
+        let effects = update(
+            &mut model,
+            Msg::ServiceRuleSetsReady {
+                retry_states: Default::default(),
+                checked_at: Default::default(),
+                next_updates: Default::default(),
+            },
+        );
         assert!(effects.is_empty());
         assert_eq!(model.connection, ConnectionState::Connected);
     }
@@ -2608,7 +2964,14 @@ mod tests {
         model.connection = ConnectionState::Idle;
         model.active_profile_id = Some(profile.id);
         model.pending_service_reconnect = true;
-        let effects = update(&mut model, Msg::ServiceRuleSetsReady);
+        let effects = update(
+            &mut model,
+            Msg::ServiceRuleSetsReady {
+                retry_states: Default::default(),
+                checked_at: Default::default(),
+                next_updates: Default::default(),
+            },
+        );
         assert!(!model.pending_service_reconnect);
         assert!(!effects.iter().any(|e| matches!(e, Effect::Connect { .. })));
         assert_eq!(model.connection, ConnectionState::Idle);
@@ -2622,7 +2985,14 @@ mod tests {
         // Active profile id points at a profile that no longer exists.
         model.active_profile_id = Some(uuid::Uuid::new_v4());
         model.pending_service_reconnect = true;
-        let effects = update(&mut model, Msg::ServiceRuleSetsReady);
+        let effects = update(
+            &mut model,
+            Msg::ServiceRuleSetsReady {
+                retry_states: Default::default(),
+                checked_at: Default::default(),
+                next_updates: Default::default(),
+            },
+        );
         assert!(!model.pending_service_reconnect);
         assert!(!effects.iter().any(|e| matches!(e, Effect::Connect { .. })));
         // Never drop to Connecting without a resolvable target — that path
@@ -2941,8 +3311,10 @@ mod tests {
             id: other_sub_id,
             name: "Other".to_string(),
             url: "http://example.com/other".to_string(),
-            auto_update: SubscriptionAutoUpdate::Every1h,
+            auto_update: SubscriptionAutoUpdate::Every1d,
             last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
         });
 
         let new_sub_id = Uuid::new_v4();
@@ -2950,8 +3322,10 @@ mod tests {
             id: new_sub_id,
             name: "New".to_string(),
             url: "http://example.com/new".to_string(),
-            auto_update: SubscriptionAutoUpdate::Every1h,
+            auto_update: SubscriptionAutoUpdate::Every1d,
             last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
         });
 
         let fetched = Profile::new_vless(
@@ -2989,8 +3363,10 @@ mod tests {
             id: sub_id,
             name: "Sub".to_string(),
             url: "http://example.com/sub".to_string(),
-            auto_update: SubscriptionAutoUpdate::Every1h,
+            auto_update: SubscriptionAutoUpdate::Every1d,
             last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
         });
 
         let mut fetched = Profile::new_vless(
@@ -3048,14 +3424,19 @@ mod tests {
             id: sub_id,
             name: "Sub".to_string(),
             url: "http://example.com/sub".to_string(),
-            auto_update: SubscriptionAutoUpdate::Every1h,
+            auto_update: SubscriptionAutoUpdate::Every1d,
             last_updated: Some(last_updated),
+            next_auto_update: None,
+            retry_state: None,
         });
+        model.automatic_subscription_updates.insert(sub_id);
 
-        let effects = handle_subscription_result(
+        let failed_at = Local::now();
+        let effects = handle_subscription_result_at(
             &mut model,
             sub_id,
             Err(crate::app::msg::IpcError::new("network down")),
+            failed_at,
         );
 
         assert!(!model.subscription_fetching);
@@ -3066,8 +3447,19 @@ mod tests {
             Some(last_updated)
         );
         assert_eq!(
+            model.config.subscriptions[0].retry_state,
+            Some(crate::config::profile::SubscriptionRetryState {
+                consecutive_failures: 1,
+                retry_at: failed_at + chrono::Duration::minutes(1),
+                attempt_date: Some(failed_at.date_naive()),
+            })
+        );
+        assert_eq!(
             effects,
-            vec![app_log_error("Subscription failed: network down")]
+            vec![
+                Effect::SaveConfig,
+                app_log_error("Subscription failed: network down")
+            ]
         );
     }
 
@@ -3086,9 +3478,13 @@ mod tests {
             id: sub_id,
             name: "Sub".to_string(),
             url: "http://example.com/sub".to_string(),
-            auto_update: SubscriptionAutoUpdate::Every1h,
+            auto_update: SubscriptionAutoUpdate::Every1d,
             last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
         });
+        model.config.subscriptions[0].record_fetch_failure(Local::now());
+        model.automatic_subscription_updates.insert(sub_id);
 
         let new_profiles = vec![Profile::new_vless(
             "New".to_string(),
@@ -3112,6 +3508,7 @@ mod tests {
                 .last_updated
                 .is_some()
         );
+        assert!(model.config.subscriptions[0].retry_state.is_none());
         assert_eq!(
             effects,
             vec![
@@ -3136,8 +3533,10 @@ mod tests {
             id: sub_id,
             name: "Sub".to_string(),
             url: "http://example.com/sub".to_string(),
-            auto_update: SubscriptionAutoUpdate::Every1h,
+            auto_update: SubscriptionAutoUpdate::Every1d,
             last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
         });
         // Start with cursor on the subscription header.
         model.selected = crate::app::model::row_for_subscription_header(&model.config, 0);
@@ -3211,6 +3610,8 @@ mod tests {
             url: "http://example.com/sub".into(),
             auto_update: SubscriptionAutoUpdate::Off,
             last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
         });
         model.connection = ConnectionState::Connected;
         model.active_profile_id = Some(old_profile_id);
@@ -3249,6 +3650,8 @@ mod tests {
             url: "http://example.com/sub".into(),
             auto_update: SubscriptionAutoUpdate::Off,
             last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
         });
         assert!(queue_connect(&mut model, profile_id));
         model.connection = ConnectionState::ConnectPending;
@@ -3294,8 +3697,10 @@ mod tests {
             id: sub_id,
             name: "Sub".to_string(),
             url: "http://example.com/sub".to_string(),
-            auto_update: SubscriptionAutoUpdate::Every1h,
+            auto_update: SubscriptionAutoUpdate::Every1d,
             last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
         });
         model.selected = 0;
 
@@ -3324,17 +3729,21 @@ mod tests {
             id: sub_id,
             name: "Sub".to_string(),
             url: "http://example.com".to_string(),
-            auto_update: SubscriptionAutoUpdate::Every1h,
+            auto_update: SubscriptionAutoUpdate::Every1d,
             last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
         });
         model.selected = 0;
+        model.config.subscriptions[0].record_fetch_failure(Local::now());
         let effects = handle_sources(&mut model, KeyEvent::from(KeyCode::Char('i')));
         assert_eq!(
             model.config.subscriptions[0].auto_update,
-            SubscriptionAutoUpdate::Every12h
+            SubscriptionAutoUpdate::Every3d
         );
         assert!(effects.contains(&Effect::SaveConfig));
-        assert!(effects.contains(&app_log_info("Subscription 'Sub' [🗘 12h]")));
+        assert!(effects.contains(&app_log_info("Subscription 'Sub' [🗘 3d]")));
+        assert!(model.config.subscriptions[0].retry_state.is_none());
     }
 
     #[test]
@@ -3346,23 +3755,20 @@ mod tests {
             url: "http://example.com/sub".to_string(),
             auto_update: SubscriptionAutoUpdate::Off,
             last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
         });
         model.selected = 0;
 
         let _ = handle_sources(&mut model, KeyEvent::from(KeyCode::Char('i')));
         assert_eq!(
             model.config.subscriptions[0].auto_update,
-            SubscriptionAutoUpdate::Every1h
-        );
-        let _ = handle_sources(&mut model, KeyEvent::from(KeyCode::Char('i')));
-        assert_eq!(
-            model.config.subscriptions[0].auto_update,
-            SubscriptionAutoUpdate::Every12h
-        );
-        let _ = handle_sources(&mut model, KeyEvent::from(KeyCode::Char('i')));
-        assert_eq!(
-            model.config.subscriptions[0].auto_update,
             SubscriptionAutoUpdate::Every1d
+        );
+        let _ = handle_sources(&mut model, KeyEvent::from(KeyCode::Char('i')));
+        assert_eq!(
+            model.config.subscriptions[0].auto_update,
+            SubscriptionAutoUpdate::Every3d
         );
         let _ = handle_sources(&mut model, KeyEvent::from(KeyCode::Char('i')));
         assert_eq!(
@@ -3391,8 +3797,10 @@ mod tests {
             id: sub_id,
             name: "Sub".to_string(),
             url: "http://example.com/sub".to_string(),
-            auto_update: SubscriptionAutoUpdate::Every1h,
+            auto_update: SubscriptionAutoUpdate::Every1d,
             last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
         });
         // source_rows: [SubscriptionHeader(0), SubscriptionProfile { sub_idx: 0, profile_idx: 0 }]
         model.selected = 0;
@@ -3420,13 +3828,125 @@ mod tests {
             id: sub_id,
             name: "Sub".to_string(),
             url: "http://example.com/sub".to_string(),
-            auto_update: SubscriptionAutoUpdate::Every1h,
-            last_updated: Some(chrono::Local::now() - chrono::Duration::try_hours(2).unwrap()),
+            auto_update: SubscriptionAutoUpdate::Every1d,
+            last_updated: Some(chrono::Local::now() - chrono::Duration::try_hours(25).unwrap()),
+            next_auto_update: None,
+            retry_state: None,
         });
 
         let effects = check_due_subscriptions(&mut model);
 
         assert_eq!(effects, vec![Effect::UpdateSubscription { id: sub_id }]);
+        assert!(model.subscription_updates.contains(&sub_id));
+    }
+
+    #[test]
+    fn failed_subscription_waits_until_retry_deadline() {
+        let sub_id = Uuid::new_v4();
+        let now = Local::now();
+        let mut model = model_with_profiles(vec![]);
+        let mut sub = Subscription {
+            id: sub_id,
+            name: "Sub".to_string(),
+            url: "http://example.com/sub".to_string(),
+            auto_update: SubscriptionAutoUpdate::Every1d,
+            last_updated: Some(now - chrono::Duration::hours(2)),
+            next_auto_update: None,
+            retry_state: None,
+        };
+        sub.record_fetch_failure(now);
+        model.config.subscriptions.push(sub);
+
+        assert!(check_due_subscriptions_at(&mut model, now).is_empty());
+        assert!(
+            check_due_subscriptions_at(&mut model, now + chrono::Duration::seconds(59)).is_empty()
+        );
+        assert_eq!(
+            check_due_subscriptions_at(&mut model, now + chrono::Duration::minutes(1)),
+            vec![Effect::UpdateSubscription { id: sub_id }]
+        );
+    }
+
+    #[test]
+    fn subscription_stops_after_five_failures_and_reopens_at_eight_next_day() {
+        use chrono::TimeZone;
+
+        let today = Local.with_ymd_and_hms(2026, 8, 22, 12, 0, 0).unwrap();
+        let mut model = model_with_profiles(vec![]);
+        let id = Uuid::new_v4();
+        model.config.subscriptions.push(Subscription {
+            id,
+            name: "Sub".into(),
+            url: "https://example.com/sub".into(),
+            auto_update: SubscriptionAutoUpdate::Every1d,
+            last_updated: None,
+            next_auto_update: Some(today.date_naive()),
+            retry_state: Some(crate::config::profile::SubscriptionRetryState {
+                consecutive_failures: 5,
+                retry_at: today,
+                attempt_date: Some(today.date_naive()),
+            }),
+        });
+
+        assert!(check_due_subscriptions_at(&mut model, today).is_empty());
+        let before_window = today + chrono::Duration::hours(19);
+        assert!(check_due_subscriptions_at(&mut model, before_window).is_empty());
+        let at_window = today + chrono::Duration::hours(20);
+        assert_eq!(
+            check_due_subscriptions_at(&mut model, at_window),
+            vec![Effect::UpdateSubscription { id }]
+        );
+    }
+
+    #[test]
+    fn manual_subscription_result_does_not_change_automatic_schedule() {
+        let now = Local::now();
+        let id = Uuid::new_v4();
+        let mut model = model_with_profiles(vec![]);
+        let retry = crate::config::profile::SubscriptionRetryState {
+            consecutive_failures: 2,
+            retry_at: now + chrono::Duration::minutes(5),
+            attempt_date: Some(now.date_naive()),
+        };
+        model.config.subscriptions.push(Subscription {
+            id,
+            name: "Sub".into(),
+            url: "https://example.com/sub".into(),
+            auto_update: SubscriptionAutoUpdate::Every3d,
+            last_updated: None,
+            next_auto_update: Some(now.date_naive()),
+            retry_state: Some(retry.clone()),
+        });
+
+        handle_subscription_result_at(&mut model, id, Ok(Vec::new()), now);
+
+        assert_eq!(model.config.subscriptions[0].retry_state, Some(retry));
+        assert_eq!(
+            model.config.subscriptions[0].next_auto_update,
+            Some(now.date_naive())
+        );
+    }
+
+    #[test]
+    fn manual_subscription_update_ignores_retry_deadline() {
+        let sub_id = Uuid::new_v4();
+        let mut model = model_with_profiles(vec![]);
+        let mut sub = Subscription {
+            id: sub_id,
+            name: "Sub".to_string(),
+            url: "http://example.com/sub".to_string(),
+            auto_update: SubscriptionAutoUpdate::Every1d,
+            last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
+        };
+        sub.record_fetch_failure(Local::now());
+        model.config.subscriptions.push(sub);
+        model.selected = 0;
+
+        let effects = handle_sources(&mut model, KeyEvent::from(KeyCode::Char('u')));
+
+        assert!(effects.contains(&Effect::UpdateSubscription { id: sub_id }));
         assert!(model.subscription_updates.contains(&sub_id));
     }
 
@@ -3438,8 +3958,10 @@ mod tests {
             id: sub_id,
             name: "Sub".to_string(),
             url: "http://example.com/sub".to_string(),
-            auto_update: SubscriptionAutoUpdate::Every1h,
+            auto_update: SubscriptionAutoUpdate::Every1d,
             last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
         });
         model.config.settings.kill_switch = true;
 
@@ -3467,13 +3989,36 @@ mod tests {
             id: sub_id,
             name: "Sub".to_string(),
             url: "http://example.com/sub".to_string(),
-            auto_update: SubscriptionAutoUpdate::Every1h,
+            auto_update: SubscriptionAutoUpdate::Every1d,
             last_updated: Some(chrono::Local::now()),
+            next_auto_update: None,
+            retry_state: None,
         });
 
         let effects = check_due_subscriptions(&mut model);
 
         assert!(effects.is_empty());
+        assert!(!model.subscription_updates.contains(&sub_id));
+    }
+
+    #[test]
+    fn disabled_subscription_does_not_retry_persisted_failure() {
+        let sub_id = Uuid::new_v4();
+        let now = Local::now();
+        let mut model = model_with_profiles(vec![]);
+        let mut sub = Subscription {
+            id: sub_id,
+            name: "Sub".to_string(),
+            url: "http://example.com/sub".to_string(),
+            auto_update: SubscriptionAutoUpdate::Off,
+            last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
+        };
+        sub.record_fetch_failure(now - chrono::Duration::hours(1));
+        model.config.subscriptions.push(sub);
+
+        assert!(check_due_subscriptions_at(&mut model, now).is_empty());
         assert!(!model.subscription_updates.contains(&sub_id));
     }
 

--- a/src/app/update/key.rs
+++ b/src/app/update/key.rs
@@ -105,7 +105,11 @@ pub(super) fn handle_sources(model: &mut Model, key: KeyEvent) -> Vec<Effect> {
         KeyCode::Char('I') => {
             let schedule = model.config.settings.geo_routing.auto_update.next();
             model.config.settings.geo_routing.auto_update = schedule;
-            let mut effects = vec![Effect::SaveConfig];
+            let mut effects = vec![Effect::SaveConfig, Effect::ResetGeoUpdateSchedules];
+            if let Some(region) = model.config.settings.geo_routing.current_region {
+                model.geo_retry_state = None;
+                effects.push(Effect::ClearGeoRetryState { region });
+            }
             push_status(
                 &mut effects,
                 model,
@@ -117,6 +121,11 @@ pub(super) fn handle_sources(model: &mut Model, key: KeyEvent) -> Vec<Effect> {
             if let Some(idx) = model.selected_subscription_index() {
                 let (name, label) = if let Some(sub) = model.config.subscriptions.get_mut(idx) {
                     sub.auto_update = sub.auto_update.next();
+                    sub.clear_retry_state();
+                    sub.next_auto_update =
+                        (sub.auto_update != SubscriptionAutoUpdate::Off).then(|| {
+                            crate::config::profile::next_update_window_date(chrono::Local::now())
+                        });
                     (sub.name.clone(), sub.auto_update.label())
                 } else {
                     return effects;
@@ -304,16 +313,39 @@ pub(super) fn handle_update_key(model: &mut Model) -> Vec<Effect> {
         }
     } else if !model.geo_updating {
         if model.config.settings.geo_routing.current_region == Some(GeoRegion::Global) {
+            let services = model.config.settings.geo_routing.enabled_services();
+            if services.is_empty() {
+                push_status(
+                    &mut effects,
+                    model,
+                    crate::app::model::AppStatus::Info(
+                        "No enabled service rule-sets to update".to_string(),
+                    ),
+                );
+                return effects;
+            }
+            if model.connection != crate::app::model::ConnectionState::Connected {
+                push_status(
+                    &mut effects,
+                    model,
+                    crate::app::model::AppStatus::Info(
+                        "Connect before updating service rule-sets".to_string(),
+                    ),
+                );
+                return effects;
+            }
+            model.geo_updating = true;
+            model.geo_automatic_update = false;
             push_status(
                 &mut effects,
                 model,
-                crate::app::model::AppStatus::Info(
-                    "Geo updates are not available in Global region".to_string(),
-                ),
+                crate::app::model::AppStatus::Info("Checking service rule-sets...".to_string()),
             );
+            effects.push(Effect::RetryServiceRuleSets { services });
             return effects;
         }
         model.geo_updating = true;
+        model.geo_automatic_update = false;
         model.geo_last_attempt_at = Some(chrono::Local::now());
         push_status(
             &mut effects,
@@ -1408,6 +1440,8 @@ mod tests {
             url: "http://s".into(),
             auto_update: SubscriptionAutoUpdate::Off,
             last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
         });
         model.connection = ConnectionState::Connected;
         model.active_profile_id = Some(model.config.profiles[0].id);
@@ -1584,6 +1618,8 @@ mod tests {
             url: "http://e".into(),
             auto_update: SubscriptionAutoUpdate::Off,
             last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
         });
         model.overlay = Overlay::ConfirmDelete;
         model.selected = crate::app::model::row_for_subscription_header(&model.config, 0);

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,9 +19,14 @@ pub fn load_config_at(path: &Path) -> Result<Config> {
 
     let mut config: Config =
         serde_json::from_str(&contents).with_context(|| format!("Failed to parse {:?}", path))?;
+    let loaded_schema_version = config.schema_version;
     config
         .migrate()
         .with_context(|| format!("Failed to migrate {:?}", path))?;
+    if config.schema_version != loaded_schema_version && config.validate().is_ok() {
+        save_config_at(path, &config)
+            .with_context(|| format!("Failed to persist migration for {:?}", path))?;
+    }
 
     Ok(config)
 }
@@ -121,6 +126,43 @@ mod tests {
         save_config_at(&path, &config).unwrap();
         let loaded = load_config_at(&path).unwrap();
         assert_eq!(loaded, config);
+    }
+
+    #[test]
+    fn load_persists_v3_update_interval_migration() {
+        let file = NamedTempFile::new().unwrap();
+        let mut config = Config {
+            schema_version: 2,
+            ..Config::default()
+        };
+        config.subscriptions.push(profile::Subscription {
+            id: uuid::Uuid::new_v4(),
+            name: "legacy".into(),
+            url: "https://example.com/sub".into(),
+            auto_update: profile::SubscriptionAutoUpdate::Every1h,
+            last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
+        });
+        config.settings.geo_routing.auto_update = profile::GeoAutoUpdate::Every12h;
+        save_config_at(file.path(), &config).unwrap();
+
+        let loaded = load_config_at(file.path()).unwrap();
+        let persisted = fs::read_to_string(file.path()).unwrap();
+
+        assert_eq!(loaded.schema_version, profile::CURRENT_SCHEMA_VERSION);
+        assert_eq!(
+            loaded.subscriptions[0].auto_update,
+            profile::SubscriptionAutoUpdate::Every1d
+        );
+        assert_eq!(
+            loaded.settings.geo_routing.auto_update,
+            profile::GeoAutoUpdate::Every1d
+        );
+        assert!(persisted.contains("\"schema_version\": 3"));
+        assert!(persisted.contains("\"auto_update\": \"every1d\""));
+        assert!(!persisted.contains("every1h"));
+        assert!(!persisted.contains("every_12h"));
     }
 
     #[test]

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use anyhow::Result;
-use chrono::{DateTime, Local};
+use chrono::{DateTime, Datelike, Local, NaiveDate, Timelike};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -870,9 +870,12 @@ impl Profile {
 pub enum SubscriptionAutoUpdate {
     #[default]
     Off,
+    #[doc(hidden)]
     Every1h,
+    #[doc(hidden)]
     Every12h,
     Every1d,
+    Every3d,
     Every7d,
 }
 
@@ -881,9 +884,9 @@ impl SubscriptionAutoUpdate {
     pub fn interval_minutes(self) -> u64 {
         match self {
             Self::Off => 0,
-            Self::Every1h => 60,
-            Self::Every12h => 720,
+            Self::Every1h | Self::Every12h => 1_440,
             Self::Every1d => 1440,
+            Self::Every3d => 4320,
             Self::Every7d => 10080,
         }
     }
@@ -891,10 +894,10 @@ impl SubscriptionAutoUpdate {
     /// Cycle to the next schedule.
     pub fn next(self) -> Self {
         match self {
-            Self::Off => Self::Every1h,
-            Self::Every1h => Self::Every12h,
-            Self::Every12h => Self::Every1d,
-            Self::Every1d => Self::Every7d,
+            Self::Off => Self::Every1d,
+            Self::Every1h | Self::Every12h => Self::Every1d,
+            Self::Every1d => Self::Every3d,
+            Self::Every3d => Self::Every7d,
             Self::Every7d => Self::Off,
         }
     }
@@ -911,9 +914,9 @@ impl SubscriptionAutoUpdate {
     pub fn interval_label(self) -> String {
         match self {
             Self::Off => "off".to_string(),
-            Self::Every1h => "1h".to_string(),
-            Self::Every12h => "12h".to_string(),
+            Self::Every1h | Self::Every12h => "1d".to_string(),
             Self::Every1d => "1d".to_string(),
+            Self::Every3d => "3d".to_string(),
             Self::Every7d => "7d".to_string(),
         }
     }
@@ -931,19 +934,96 @@ pub struct Subscription {
     pub auto_update: SubscriptionAutoUpdate,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_updated: Option<DateTime<Local>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_auto_update: Option<NaiveDate>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_state: Option<SubscriptionRetryState>,
+}
+
+/// Persisted retry metadata for an auto-updating subscription.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct SubscriptionRetryState {
+    pub consecutive_failures: u32,
+    pub retry_at: DateTime<Local>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attempt_date: Option<NaiveDate>,
+}
+
+impl Subscription {
+    /// Record a failed fetch and schedule the next retry using the bounded
+    /// 1/5/15/60-minute backoff sequence.
+    pub fn record_fetch_failure(&mut self, now: DateTime<Local>) {
+        let today = now.date_naive();
+        let consecutive_failures = self
+            .retry_state
+            .as_ref()
+            .filter(|state| state.attempt_date == Some(today))
+            .map_or(1, |state| state.consecutive_failures.saturating_add(1));
+        let delay_minutes = match consecutive_failures {
+            1 => 1,
+            2 => 5,
+            3 => 15,
+            4 => 60,
+            _ => minutes_until_next_update_window(now),
+        };
+        self.retry_state = Some(SubscriptionRetryState {
+            consecutive_failures,
+            retry_at: now + chrono::Duration::minutes(delay_minutes),
+            attempt_date: Some(today),
+        });
+    }
+
+    pub fn clear_retry_state(&mut self) {
+        self.retry_state = None;
+    }
+
+    pub fn schedule_next_after_success(&mut self, now: DateTime<Local>) {
+        self.clear_retry_state();
+        let days = self.auto_update.interval_minutes() / 1_440;
+        self.next_auto_update =
+            (days != 0).then(|| now.date_naive() + chrono::Duration::days(days as i64));
+    }
+}
+
+pub fn next_update_window_date(now: DateTime<Local>) -> NaiveDate {
+    if now.hour() < 8 {
+        now.date_naive()
+    } else {
+        now.date_naive()
+            .succ_opt()
+            .expect("local date must advance")
+    }
+}
+
+pub fn retry_delay_minutes(failure: u32, now: DateTime<Local>) -> i64 {
+    match failure {
+        1 => 1,
+        2 => 5,
+        3 => 15,
+        4 => 60,
+        _ => minutes_until_next_update_window(now),
+    }
+}
+
+fn minutes_until_next_update_window(now: DateTime<Local>) -> i64 {
+    let next = next_update_window_date(now);
+    let days = next.num_days_from_ce() - now.date_naive().num_days_from_ce();
+    i64::from(days) * 1_440 - i64::from(now.hour()) * 60 - i64::from(now.minute()) + 8 * 60
 }
 
 #[test]
 fn subscription_auto_update_cycles_and_labels() {
     assert_eq!(SubscriptionAutoUpdate::Off.interval_minutes(), 0);
-    assert_eq!(SubscriptionAutoUpdate::Every1h.interval_minutes(), 60);
-    assert_eq!(SubscriptionAutoUpdate::Every12h.interval_minutes(), 720);
+    assert_eq!(SubscriptionAutoUpdate::Every1h.interval_minutes(), 1440);
+    assert_eq!(SubscriptionAutoUpdate::Every12h.interval_minutes(), 1440);
     assert_eq!(SubscriptionAutoUpdate::Every1d.interval_minutes(), 1440);
+    assert_eq!(SubscriptionAutoUpdate::Every3d.interval_minutes(), 4320);
     assert_eq!(SubscriptionAutoUpdate::Every7d.interval_minutes(), 10080);
 
     assert_eq!(
         SubscriptionAutoUpdate::Off.next(),
-        SubscriptionAutoUpdate::Every1h
+        SubscriptionAutoUpdate::Every1d
     );
     assert_eq!(
         SubscriptionAutoUpdate::Every7d.next(),
@@ -951,14 +1031,72 @@ fn subscription_auto_update_cycles_and_labels() {
     );
 
     assert_eq!(SubscriptionAutoUpdate::Off.label(), "✕");
-    assert_eq!(SubscriptionAutoUpdate::Every1h.label(), "🗘 1h");
+    assert_eq!(SubscriptionAutoUpdate::Every1d.label(), "🗘 1d");
+}
+
+#[test]
+fn subscription_retry_backoff_is_bounded_and_serializable() {
+    use chrono::TimeZone;
+
+    let now = Local.with_ymd_and_hms(2026, 8, 22, 12, 0, 0).unwrap();
+    let mut sub = Subscription {
+        id: Uuid::nil(),
+        name: "Sub".into(),
+        url: "https://example.com/sub".into(),
+        auto_update: SubscriptionAutoUpdate::Every1h,
+        last_updated: None,
+        next_auto_update: None,
+        retry_state: None,
+    };
+
+    for (failures, delay) in [(1, 1), (2, 5), (3, 15), (4, 60)] {
+        sub.record_fetch_failure(now);
+        let state = sub.retry_state.as_ref().unwrap();
+        assert_eq!(state.consecutive_failures, failures);
+        assert_eq!(state.retry_at, now + chrono::Duration::minutes(delay));
+    }
+    sub.record_fetch_failure(now);
+    assert_eq!(
+        sub.retry_state.as_ref().unwrap().retry_at,
+        Local.with_ymd_and_hms(2026, 8, 23, 8, 0, 0).unwrap()
+    );
+
+    let json = serde_json::to_string(&sub).unwrap();
+    let restored: Subscription = serde_json::from_str(&json).unwrap();
+    assert_eq!(restored, sub);
+}
+
+#[test]
+fn update_window_is_fixed_at_eight_local_time() {
+    use chrono::TimeZone;
+
+    let before = Local.with_ymd_and_hms(2026, 8, 22, 7, 59, 0).unwrap();
+    let after = Local.with_ymd_and_hms(2026, 8, 22, 11, 0, 0).unwrap();
+    assert_eq!(next_update_window_date(before), before.date_naive());
+    assert_eq!(
+        next_update_window_date(after),
+        after.date_naive().succ_opt().unwrap()
+    );
+}
+
+#[test]
+fn subscription_without_retry_state_remains_backward_compatible() {
+    let json = r#"{
+        "id":"00000000-0000-0000-0000-000000000000",
+        "name":"Sub",
+        "url":"https://example.com/sub",
+        "auto_update":"every1h"
+    }"#;
+
+    let sub: Subscription = serde_json::from_str(json).unwrap();
+    assert!(sub.retry_state.is_none());
+    assert!(!serde_json::to_string(&sub).unwrap().contains("retry_state"));
 }
 
 #[test]
 fn geo_auto_update_cycles_intervals_and_labels() {
     let schedules = [
         (GeoAutoUpdate::Off, 0, "off"),
-        (GeoAutoUpdate::Every12h, 720, "12h"),
         (GeoAutoUpdate::Every1d, 1_440, "1d"),
         (GeoAutoUpdate::Every3d, 4_320, "3d"),
         (GeoAutoUpdate::Every7d, 10_080, "7d"),
@@ -967,7 +1105,7 @@ fn geo_auto_update_cycles_intervals_and_labels() {
         assert_eq!(schedule.interval_minutes(), minutes);
         assert_eq!(schedule.label(), label);
     }
-    assert_eq!(GeoAutoUpdate::Off.next(), GeoAutoUpdate::Every12h);
+    assert_eq!(GeoAutoUpdate::Off.next(), GeoAutoUpdate::Every1d);
     assert_eq!(GeoAutoUpdate::Every12h.next(), GeoAutoUpdate::Every1d);
     assert_eq!(GeoAutoUpdate::Every1d.next(), GeoAutoUpdate::Every3d);
     assert_eq!(GeoAutoUpdate::Every3d.next(), GeoAutoUpdate::Every7d);
@@ -994,7 +1132,7 @@ impl GeoAutoUpdate {
     pub fn interval_minutes(self) -> u64 {
         match self {
             Self::Off => 0,
-            Self::Every12h => 720,
+            Self::Every12h => 1_440,
             Self::Every1d => 1_440,
             Self::Every3d => 4_320,
             Self::Every7d => 10_080,
@@ -1003,7 +1141,7 @@ impl GeoAutoUpdate {
 
     pub fn next(self) -> Self {
         match self {
-            Self::Off => Self::Every12h,
+            Self::Off => Self::Every1d,
             Self::Every12h => Self::Every1d,
             Self::Every1d => Self::Every3d,
             Self::Every3d => Self::Every7d,
@@ -1014,7 +1152,7 @@ impl GeoAutoUpdate {
     pub fn label(self) -> &'static str {
         match self {
             Self::Off => "off",
-            Self::Every12h => "12h",
+            Self::Every12h => "1d",
             Self::Every1d => "1d",
             Self::Every3d => "3d",
             Self::Every7d => "7d",
@@ -1322,7 +1460,7 @@ impl Default for Settings {
 
 /// Current schema version for `profiles.json`. Bumped on every breaking
 /// change to the persisted shape; new migrations go in `Config::migrate`.
-pub const CURRENT_SCHEMA_VERSION: u32 = 2;
+pub const CURRENT_SCHEMA_VERSION: u32 = 3;
 
 fn default_schema_version() -> u32 {
     // Files written before the version was introduced are treated as v0
@@ -1419,6 +1557,10 @@ impl Config {
             self.migrate_v1_to_v2();
             self.schema_version = 2;
         }
+        if self.schema_version == 2 {
+            self.migrate_v2_to_v3();
+            self.schema_version = 3;
+        }
         debug_assert_eq!(self.schema_version, CURRENT_SCHEMA_VERSION);
         Ok(())
     }
@@ -1448,6 +1590,27 @@ impl Config {
             {
                 cfg.tls.utls_fingerprint = Some(fp);
             }
+        }
+    }
+
+    fn migrate_v2_to_v3(&mut self) {
+        let next = next_update_window_date(Local::now());
+        for subscription in &mut self.subscriptions {
+            if matches!(
+                subscription.auto_update,
+                SubscriptionAutoUpdate::Every1h | SubscriptionAutoUpdate::Every12h
+            ) {
+                subscription.auto_update = SubscriptionAutoUpdate::Every1d;
+            }
+            if subscription.auto_update != SubscriptionAutoUpdate::Off
+                && subscription.next_auto_update.is_none()
+            {
+                subscription.next_auto_update = Some(next);
+            }
+            subscription.retry_state = None;
+        }
+        if self.settings.geo_routing.auto_update == GeoAutoUpdate::Every12h {
+            self.settings.geo_routing.auto_update = GeoAutoUpdate::Every1d;
         }
     }
 }
@@ -3227,6 +3390,34 @@ mod tests {
         cfg.migrate().unwrap();
         assert_eq!(cfg.schema_version, CURRENT_SCHEMA_VERSION);
         // No panic, no mutation.
+    }
+
+    #[test]
+    fn migrate_v2_to_v3_promotes_short_update_intervals() {
+        let mut cfg = Config {
+            schema_version: 2,
+            ..Config::default()
+        };
+        cfg.subscriptions.push(Subscription {
+            id: Uuid::new_v4(),
+            name: "short".into(),
+            url: "https://example.com/sub".into(),
+            auto_update: SubscriptionAutoUpdate::Every1h,
+            last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
+        });
+        cfg.settings.geo_routing.auto_update = GeoAutoUpdate::Every12h;
+
+        cfg.migrate().unwrap();
+
+        assert_eq!(cfg.schema_version, CURRENT_SCHEMA_VERSION);
+        assert_eq!(
+            cfg.subscriptions[0].auto_update,
+            SubscriptionAutoUpdate::Every1d
+        );
+        assert!(cfg.subscriptions[0].next_auto_update.is_some());
+        assert_eq!(cfg.settings.geo_routing.auto_update, GeoAutoUpdate::Every1d);
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -89,6 +89,8 @@ fn run_loop(
                 Effect::Connect { .. }
                     | Effect::Disconnect
                     | Effect::DownloadGeo
+                    | Effect::RetryServiceRuleSets { .. }
+                    | Effect::ResetGeoUpdateSchedules
                     | Effect::WriteState
                     | Effect::SaveConfig
                     | Effect::UpdateSubscription { .. }
@@ -279,25 +281,45 @@ fn execute_daemon_effect(
                 .current_region
                 .unwrap_or(crate::config::profile::GeoRegion::Global);
             let services = model.config.settings.geo_routing.enabled_services();
+            let automatic = model.geo_automatic_update;
+            let interval_days = (model
+                .config
+                .settings
+                .geo_routing
+                .auto_update
+                .interval_minutes()
+                / 1_440) as i64;
+            let existing_service_retries = model.service_retry_states.clone();
+            let existing_service_checked_at = model.service_checked_at.clone();
             thread::spawn(move || {
                 let gm = match crate::geo::GeoManager::new() {
                     Ok(gm) => gm,
                     Err(e) => {
-                        let _ = tx.send(Msg::GeoUpdated(GeoResult::Error(e.to_string())));
+                        let _ = tx.send(Msg::GeoUpdated(GeoResult::Error {
+                            message: e.to_string(),
+                            retry_state: None,
+                            service_retry_states: existing_service_retries,
+                            service_checked_at: existing_service_checked_at,
+                            next_update: None,
+                            service_next_updates: Default::default(),
+                            updated_parts: Vec::new(),
+                        }));
                         return;
                     }
                 };
-                let result = match gm.update_if_needed(region) {
-                    Ok(geo_result) => geo_result,
-                    Err(e) => GeoResult::Error(e.to_string()),
-                };
+                let regional = gm.update_if_needed(region);
+                let services =
+                    refresh_service_rule_sets(&gm, &services, automatic.then_some(interval_days));
+                let result = finalize_geo_result(
+                    &gm,
+                    region,
+                    regional,
+                    services,
+                    automatic,
+                    true,
+                    interval_days,
+                );
                 let _ = tx.send(Msg::GeoUpdated(result));
-                // Service rule-sets refresh only after the regional result is
-                // reported: they can take minutes on a slow link and must not
-                // pin the geo_updating spinner or delay further updates.
-                // Their failures are non-fatal — the route builder simply
-                // omits a service's rules until its files appear.
-                refresh_service_rule_sets(&gm, &services);
             });
         }
         Effect::DownloadServiceRuleSetsIfMissing => {
@@ -310,21 +332,97 @@ fn execute_daemon_effect(
             // it to run a pending reconnect, and the route builder tolerates
             // files that never arrived.
             let services = model.config.settings.geo_routing.enabled_services();
+            let schedule_enabled = model.config.settings.geo_routing.auto_update
+                != crate::config::profile::GeoAutoUpdate::Off;
             let tx = tx.clone();
             thread::spawn(move || {
-                match crate::geo::GeoManager::new() {
+                let (retry_states, checked_at, next_updates) = match crate::geo::GeoManager::new() {
                     Ok(gm) => {
+                        let _ = gm.ensure_update_schedules(
+                            crate::config::profile::GeoRegion::Global,
+                            &services,
+                            schedule_enabled,
+                        );
                         let missing: Vec<_> = services
                             .into_iter()
                             .filter(|s| !gm.has_service_databases(*s))
                             .collect();
-                        refresh_service_rule_sets(&gm, &missing);
+                        refresh_service_rule_sets(&gm, &missing, None);
+                        (
+                            gm.service_retry_states(),
+                            gm.service_checked_at(),
+                            gm.service_next_updates(),
+                        )
                     }
                     Err(e) => {
                         tracing::warn!("Failed to init geo manager for service rule-sets: {e:#}");
+                        (Default::default(), Default::default(), Default::default())
                     }
-                }
-                let _ = tx.send(Msg::ServiceRuleSetsReady);
+                };
+                let _ = tx.send(Msg::ServiceRuleSetsReady {
+                    retry_states,
+                    checked_at,
+                    next_updates,
+                });
+            });
+        }
+        Effect::RetryServiceRuleSets { services } => {
+            model.geo_updating = true;
+            let tx = tx.clone();
+            let region = model
+                .config
+                .settings
+                .geo_routing
+                .current_region
+                .unwrap_or(crate::config::profile::GeoRegion::Global);
+            let existing_service_retries = model.service_retry_states.clone();
+            let existing_service_checked_at = model.service_checked_at.clone();
+            let automatic = model.geo_automatic_update;
+            let interval_days = (model
+                .config
+                .settings
+                .geo_routing
+                .auto_update
+                .interval_minutes()
+                / 1_440) as i64;
+            thread::spawn(move || {
+                let result = match crate::geo::GeoManager::new() {
+                    Ok(gm) => {
+                        let checked_at = gm.last_checked_at(region);
+                        let services = refresh_service_rule_sets(
+                            &gm,
+                            &services,
+                            automatic.then_some(interval_days),
+                        );
+                        finalize_geo_result(
+                            &gm,
+                            region,
+                            Ok(GeoResult::UpToDate {
+                                checked_at,
+                                retry_state: gm.retry_state(region),
+                                service_retry_states: gm.service_retry_states(),
+                                service_checked_at: gm.service_checked_at(),
+                                next_update: gm.region_next_update(region),
+                                service_next_updates: gm.service_next_updates(),
+                                warnings: Vec::new(),
+                            }),
+                            services,
+                            false,
+                            false,
+                            interval_days,
+                        )
+                    }
+                    Err(e) => GeoResult::Error {
+                        message: e.to_string(),
+                        retry_state: None,
+                        service_retry_states: existing_service_retries,
+                        service_checked_at: existing_service_checked_at,
+                        next_update: None,
+                        service_next_updates: Default::default(),
+                        updated_parts: Vec::new(),
+                    },
+                };
+                let _ = tx.send(Msg::GeoUpdated(result));
             });
         }
         Effect::RefreshGeoLastUpdated => {
@@ -338,12 +436,52 @@ fn execute_daemon_effect(
             thread::spawn(move || {
                 let manager = crate::geo::GeoManager::new().ok();
                 let last_updated = manager.as_ref().and_then(|g| g.last_updated(region));
-                let last_checked_at = manager.and_then(|g| g.last_checked_at(region));
+                let last_checked_at = manager.as_ref().and_then(|g| g.last_checked_at(region));
+                let retry_state = manager.as_ref().and_then(|g| g.retry_state(region));
+                let service_retry_states = manager
+                    .as_ref()
+                    .map(|g| g.service_retry_states())
+                    .unwrap_or_default();
+                let service_checked_at = manager
+                    .as_ref()
+                    .map(|g| g.service_checked_at())
+                    .unwrap_or_default();
                 let _ = tx.send(Msg::GeoMetadataRefreshed {
                     last_updated,
                     last_checked_at,
+                    retry_state,
+                    service_retry_states,
+                    service_checked_at,
+                    next_update: manager.as_ref().and_then(|g| g.region_next_update(region)),
+                    service_next_updates: manager
+                        .as_ref()
+                        .map(|g| g.service_next_updates())
+                        .unwrap_or_default(),
                 });
             });
+        }
+        Effect::ClearGeoRetryState { region } => {
+            if let Ok(manager) = crate::geo::GeoManager::new()
+                && let Err(e) = manager.clear_retry_state(region)
+            {
+                tracing::warn!("Failed to clear geo retry state: {e}");
+            }
+        }
+        Effect::ResetGeoUpdateSchedules => {
+            if let Ok(manager) = crate::geo::GeoManager::new() {
+                let region = model
+                    .config
+                    .settings
+                    .geo_routing
+                    .current_region
+                    .unwrap_or(crate::config::profile::GeoRegion::Global);
+                let services = model.config.settings.geo_routing.enabled_services();
+                let enabled = model.config.settings.geo_routing.auto_update
+                    != crate::config::profile::GeoAutoUpdate::Off;
+                manager.reset_update_schedules(region, &services, enabled)?;
+                model.geo_next_update = manager.region_next_update(region);
+                model.service_next_updates = manager.service_next_updates();
+            }
         }
         Effect::DownloadGeoIfMissing => {
             model.geo_updating = true;
@@ -354,21 +492,50 @@ fn execute_daemon_effect(
                 .geo_routing
                 .current_region
                 .unwrap_or(crate::config::profile::GeoRegion::Global);
+            let retry_enabled = model.config.settings.geo_routing.auto_update
+                != crate::config::profile::GeoAutoUpdate::Off;
+            let interval_days = (model
+                .config
+                .settings
+                .geo_routing
+                .auto_update
+                .interval_minutes()
+                / 1_440) as i64;
             thread::spawn(move || {
                 let result = match crate::geo::GeoManager::new() {
                     Ok(gm) => {
                         if gm.has_databases(region) {
+                            let _ = gm.clear_retry_state(region);
                             GeoResult::UpToDate {
                                 checked_at: gm.last_checked_at(region),
+                                retry_state: None,
+                                service_retry_states: gm.service_retry_states(),
+                                service_checked_at: gm.service_checked_at(),
+                                next_update: gm.region_next_update(region),
+                                service_next_updates: gm.service_next_updates(),
+                                warnings: Vec::new(),
                             }
                         } else {
-                            match gm.update_if_needed(region) {
-                                Ok(geo_result) => geo_result,
-                                Err(e) => GeoResult::Error(e.to_string()),
-                            }
+                            finalize_geo_result(
+                                &gm,
+                                region,
+                                gm.update_if_needed(region),
+                                ServiceRefreshResult::default(),
+                                retry_enabled,
+                                true,
+                                interval_days,
+                            )
                         }
                     }
-                    Err(e) => GeoResult::Error(e.to_string()),
+                    Err(e) => GeoResult::Error {
+                        message: e.to_string(),
+                        retry_state: None,
+                        service_retry_states: Default::default(),
+                        service_checked_at: Default::default(),
+                        next_update: None,
+                        service_next_updates: Default::default(),
+                        updated_parts: Vec::new(),
+                    },
                 };
                 let _ = tx.send(Msg::GeoUpdated(result));
             });
@@ -593,10 +760,127 @@ fn socks5_connect_latency(addr: &str) -> anyhow::Result<u64> {
 fn refresh_service_rule_sets(
     gm: &crate::geo::GeoManager,
     services: &[crate::config::profile::RoutedService],
-) {
+    automatic_interval_days: Option<i64>,
+) -> ServiceRefreshResult {
+    let mut result = ServiceRefreshResult::default();
     for service in services {
-        if let Err(e) = gm.update_service_if_needed(*service) {
-            tracing::warn!("Failed to update {} rule-sets: {e:#}", service.label());
+        match gm.update_service_if_needed(*service) {
+            Ok(updated) => {
+                if let Some(days) = automatic_interval_days
+                    && let Err(e) = gm.record_service_schedule_success(*service, days)
+                {
+                    tracing::warn!("Failed to schedule {} update: {e}", service.label());
+                }
+                if updated {
+                    result
+                        .updated_parts
+                        .push(format!("service-{}", service.label().to_lowercase()));
+                }
+            }
+            Err(e) => {
+                let message = format!("{} rule-sets: {e:#}", service.label());
+                tracing::warn!("Failed to update {message}");
+                if automatic_interval_days.is_some() {
+                    let _ = gm.record_service_failure(*service);
+                }
+                result.errors.push(message);
+            }
+        }
+    }
+    result
+}
+
+#[derive(Default)]
+struct ServiceRefreshResult {
+    updated_parts: Vec<String>,
+    errors: Vec<String>,
+}
+
+fn finalize_geo_result(
+    manager: &crate::geo::GeoManager,
+    region: crate::config::profile::GeoRegion,
+    regional: anyhow::Result<GeoResult>,
+    services: ServiceRefreshResult,
+    retry_enabled: bool,
+    update_region: bool,
+    interval_days: i64,
+) -> GeoResult {
+    let regional_failed = regional.is_err();
+    let retry_state = if !update_region || !retry_enabled {
+        manager.retry_state(region)
+    } else if regional_failed && retry_enabled {
+        manager.record_update_failure(region).ok()
+    } else {
+        if !regional_failed
+            && let Err(e) = manager.record_region_schedule_success(region, interval_days)
+        {
+            tracing::warn!("Failed to schedule geo update: {e}");
+        }
+        None
+    };
+    let service_retry_states = manager.service_retry_states();
+    let service_checked_at = manager.service_checked_at();
+    let next_update = manager.region_next_update(region);
+    let service_next_updates = manager.service_next_updates();
+
+    match regional {
+        Ok(GeoResult::Updated {
+            mut parts,
+            last_updated,
+            checked_at,
+            ..
+        }) => {
+            parts.extend(services.updated_parts);
+            GeoResult::Updated {
+                parts,
+                last_updated,
+                checked_at,
+                retry_state,
+                service_retry_states,
+                service_checked_at,
+                next_update,
+                service_next_updates,
+                warnings: services.errors,
+            }
+        }
+        Ok(GeoResult::UpToDate { checked_at, .. }) if !services.updated_parts.is_empty() => {
+            GeoResult::Updated {
+                parts: services.updated_parts,
+                last_updated: manager.last_updated(region),
+                checked_at: checked_at.unwrap_or_else(chrono::Local::now),
+                retry_state,
+                service_retry_states,
+                service_checked_at,
+                next_update,
+                service_next_updates,
+                warnings: services.errors,
+            }
+        }
+        Ok(GeoResult::UpToDate { checked_at, .. }) => GeoResult::UpToDate {
+            checked_at,
+            retry_state,
+            service_retry_states,
+            service_checked_at,
+            next_update,
+            service_next_updates,
+            warnings: services.errors,
+        },
+        Ok(GeoResult::Error { .. }) => unreachable!("GeoManager never returns GeoResult::Error"),
+        Err(e) => {
+            let mut message = e.to_string();
+            if !services.errors.is_empty() {
+                message.push_str("; ");
+                message.push_str(&services.errors.join("; "));
+            }
+            GeoResult::Error {
+                message,
+                retry_state,
+                service_retry_states,
+                service_checked_at,
+                next_update,
+                service_next_updates,
+                updated_parts: services.updated_parts,
+            }
         }
     }
 }
@@ -844,8 +1128,11 @@ fn spawn_signal_handler(tx: Sender<Msg>) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ProcessSlot, handshake_protocols, lock_process_slot, poll_process_exit};
-    use crate::app::msg::Msg;
+    use super::{
+        ProcessSlot, ServiceRefreshResult, finalize_geo_result, handshake_protocols,
+        lock_process_slot, poll_process_exit,
+    };
+    use crate::app::msg::{GeoResult, Msg};
     use crate::config::profile::Protocol;
     use crate::singbox::process_handle::ProcessHandle;
     use std::sync::{Arc, Mutex};
@@ -912,5 +1199,94 @@ mod tests {
             handle: None,
         }));
         assert!(poll_process_exit(&slot).is_none());
+    }
+
+    #[test]
+    fn geo_batch_keeps_updates_and_schedules_retry_after_service_failure() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", dir.path()) };
+        let manager = crate::geo::GeoManager::new().unwrap();
+        let checked_at = chrono::Local::now();
+        let regional = Ok(GeoResult::Updated {
+            parts: vec!["geoip-ru".into()],
+            last_updated: None,
+            checked_at,
+            retry_state: None,
+            service_retry_states: Default::default(),
+            service_checked_at: Default::default(),
+            next_update: None,
+            service_next_updates: Default::default(),
+            warnings: Vec::new(),
+        });
+        let services = ServiceRefreshResult {
+            updated_parts: vec!["service-steam".into()],
+            errors: vec!["Telegram rule-sets: unavailable".into()],
+        };
+        manager
+            .record_service_failure(crate::config::profile::RoutedService::Telegram)
+            .unwrap();
+
+        let result = finalize_geo_result(
+            &manager,
+            crate::config::profile::GeoRegion::Ru,
+            regional,
+            services,
+            true,
+            true,
+            1,
+        );
+
+        let GeoResult::Updated {
+            parts,
+            retry_state,
+            service_retry_states,
+            warnings,
+            ..
+        } = result
+        else {
+            panic!("expected a partial updated result");
+        };
+        assert_eq!(parts, vec!["geoip-ru", "service-steam"]);
+        assert_eq!(warnings, vec!["Telegram rule-sets: unavailable"]);
+        assert!(retry_state.is_none());
+        assert_eq!(
+            service_retry_states[&crate::config::profile::RoutedService::Telegram]
+                .consecutive_failures,
+            1
+        );
+    }
+
+    #[test]
+    fn geo_batch_reports_service_update_when_region_failed() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", dir.path()) };
+        let manager = crate::geo::GeoManager::new().unwrap();
+        let services = ServiceRefreshResult {
+            updated_parts: vec!["service-steam".into()],
+            errors: Vec::new(),
+        };
+
+        let result = finalize_geo_result(
+            &manager,
+            crate::config::profile::GeoRegion::Ru,
+            Err(anyhow::anyhow!("regional unavailable")),
+            services,
+            true,
+            true,
+            1,
+        );
+
+        let GeoResult::Error {
+            updated_parts,
+            retry_state,
+            ..
+        } = result
+        else {
+            panic!("expected a partial error result");
+        };
+        assert_eq!(updated_parts, vec!["service-steam"]);
+        assert_eq!(retry_state.unwrap().consecutive_failures, 1);
     }
 }

--- a/src/geo.rs
+++ b/src/geo.rs
@@ -1,13 +1,17 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
-use chrono::{DateTime, Local};
+use chrono::{DateTime, Local, NaiveDate};
 use serde::{Deserialize, Serialize};
 
 use crate::app::msg::GeoResult;
 use crate::config::profile::{GeoRegion, RoutedService};
+
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+const GEO_BATCH_TIMEOUT: Duration = Duration::from_secs(180);
 
 /// One downloadable rule-set file (geoip *or* geosite) for a region.
 pub(crate) struct GeoAsset {
@@ -139,6 +143,24 @@ struct GeoMetadata {
     /// Last successful HTTP check, including checks that found no changes.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     checked_at: HashMap<GeoRegion, DateTime<Local>>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    region_retry_states: HashMap<GeoRegion, GeoRetryState>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    service_retry_states: HashMap<RoutedService, GeoRetryState>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    service_checked_at: HashMap<RoutedService, DateTime<Local>>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    region_next_update: HashMap<GeoRegion, NaiveDate>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    service_next_update: HashMap<RoutedService, NaiveDate>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GeoRetryState {
+    pub consecutive_failures: u32,
+    pub retry_at: DateTime<Local>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attempt_date: Option<NaiveDate>,
 }
 
 /// Deserialization shape that also accepts the legacy per-country etag fields
@@ -151,6 +173,16 @@ struct GeoMetadataRaw {
     updated_at: HashMap<GeoRegion, DateTime<Local>>,
     #[serde(default)]
     checked_at: HashMap<GeoRegion, DateTime<Local>>,
+    #[serde(default, alias = "retry_states")]
+    region_retry_states: HashMap<GeoRegion, GeoRetryState>,
+    #[serde(default)]
+    service_retry_states: HashMap<RoutedService, GeoRetryState>,
+    #[serde(default)]
+    service_checked_at: HashMap<RoutedService, DateTime<Local>>,
+    #[serde(default)]
+    region_next_update: HashMap<GeoRegion, NaiveDate>,
+    #[serde(default)]
+    service_next_update: HashMap<RoutedService, NaiveDate>,
     #[serde(default)]
     geoip_ru_etag: Option<String>,
     #[serde(default)]
@@ -183,6 +215,11 @@ impl From<GeoMetadataRaw> for GeoMetadata {
             etags,
             updated_at: raw.updated_at,
             checked_at: raw.checked_at,
+            region_retry_states: raw.region_retry_states,
+            service_retry_states: raw.service_retry_states,
+            service_checked_at: raw.service_checked_at,
+            region_next_update: raw.region_next_update,
+            service_next_update: raw.service_next_update,
         }
     }
 }
@@ -199,6 +236,7 @@ pub struct GeoManager {
     geo_dir: PathBuf,
     metadata_path: PathBuf,
     agent: ureq::Agent,
+    deadline: Instant,
 }
 
 impl GeoManager {
@@ -210,11 +248,9 @@ impl GeoManager {
             .with_context(|| format!("Failed to create geo dir {:?}", geo_dir))?;
 
         let metadata_path = geo_dir.join("metadata.json");
-        // Bounded setup-phase timeouts so a stalled GitHub connection can't
-        // wedge the geo update threads forever. Deliberately no body timeout
-        // (`timeout_recv_body` is cumulative, not idle): a multi-hundred-KB
-        // `.srs` on a slow pre-VPN link can legitimately take many minutes,
-        // and a transfer that is still making progress must not be aborted.
+        // Setup phases retain their tighter limits. `check_single` and
+        // `download_file` additionally cap each complete request (including
+        // its body) at 60 seconds and share a three-minute batch deadline.
         let agent: ureq::Agent = ureq::Agent::config_builder()
             .timeout_resolve(Some(std::time::Duration::from_secs(15)))
             .timeout_connect(Some(std::time::Duration::from_secs(15)))
@@ -226,6 +262,7 @@ impl GeoManager {
             geo_dir,
             metadata_path,
             agent,
+            deadline: Instant::now() + GEO_BATCH_TIMEOUT,
         })
     }
 
@@ -278,7 +315,11 @@ impl GeoManager {
     /// Returns `true` when at least one file was (re)downloaded.
     pub fn update_service_if_needed(&self, service: RoutedService) -> Result<bool> {
         let _guard = METADATA_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-        self.update_assets_if_needed(&service_assets(service).present())
+        let updated = self.update_assets_if_needed(&service_assets(service).present())?;
+        let mut meta = self.load_metadata().unwrap_or_default();
+        meta.service_checked_at.insert(service, Local::now());
+        self.save_metadata(&meta)?;
+        Ok(updated)
     }
 
     /// ETag-checked download of a set of assets. Every asset is attempted
@@ -355,6 +396,194 @@ impl GeoManager {
         self.load_metadata().ok()?.checked_at.get(&region).copied()
     }
 
+    pub fn retry_state(&self, region: GeoRegion) -> Option<GeoRetryState> {
+        self.load_metadata()
+            .ok()?
+            .region_retry_states
+            .get(&region)
+            .copied()
+    }
+
+    pub fn record_update_failure(&self, region: GeoRegion) -> Result<GeoRetryState> {
+        self.record_update_failure_at(region, Local::now())
+    }
+
+    fn record_update_failure_at(
+        &self,
+        region: GeoRegion,
+        now: DateTime<Local>,
+    ) -> Result<GeoRetryState> {
+        let _guard = METADATA_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let mut meta = self.load_metadata().unwrap_or_default();
+        let failures = meta
+            .region_retry_states
+            .get(&region)
+            .filter(|state| state.attempt_date == Some(now.date_naive()))
+            .map_or(1, |state| state.consecutive_failures.saturating_add(1));
+        let delay = crate::config::profile::retry_delay_minutes(failures, now);
+        let state = GeoRetryState {
+            consecutive_failures: failures,
+            retry_at: now + chrono::Duration::minutes(delay),
+            attempt_date: Some(now.date_naive()),
+        };
+        meta.region_retry_states.insert(region, state);
+        self.save_metadata(&meta)?;
+        Ok(state)
+    }
+
+    pub fn clear_retry_state(&self, region: GeoRegion) -> Result<()> {
+        let _guard = METADATA_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let mut meta = self.load_metadata().unwrap_or_default();
+        if meta.region_retry_states.remove(&region).is_some() {
+            self.save_metadata(&meta)?;
+        }
+        Ok(())
+    }
+
+    pub fn service_retry_states(&self) -> HashMap<RoutedService, GeoRetryState> {
+        self.load_metadata()
+            .map(|meta| meta.service_retry_states)
+            .unwrap_or_default()
+    }
+
+    pub fn service_checked_at(&self) -> HashMap<RoutedService, DateTime<Local>> {
+        self.load_metadata()
+            .map(|meta| meta.service_checked_at)
+            .unwrap_or_default()
+    }
+
+    pub fn region_next_update(&self, region: GeoRegion) -> Option<NaiveDate> {
+        self.load_metadata()
+            .ok()?
+            .region_next_update
+            .get(&region)
+            .copied()
+    }
+
+    pub fn service_next_updates(&self) -> HashMap<RoutedService, NaiveDate> {
+        self.load_metadata()
+            .map(|meta| meta.service_next_update)
+            .unwrap_or_default()
+    }
+
+    pub fn record_service_failure(&self, service: RoutedService) -> Result<GeoRetryState> {
+        let _guard = METADATA_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let mut meta = self.load_metadata().unwrap_or_default();
+        let now = Local::now();
+        let failures = meta
+            .service_retry_states
+            .get(&service)
+            .filter(|state| state.attempt_date == Some(now.date_naive()))
+            .map_or(1, |state| state.consecutive_failures.saturating_add(1));
+        let delay = crate::config::profile::retry_delay_minutes(failures, now);
+        let state = GeoRetryState {
+            consecutive_failures: failures,
+            retry_at: now + chrono::Duration::minutes(delay),
+            attempt_date: Some(now.date_naive()),
+        };
+        meta.service_retry_states.insert(service, state);
+        self.save_metadata(&meta)?;
+        Ok(state)
+    }
+
+    #[cfg(test)]
+    pub fn clear_service_retry_state(&self, service: RoutedService) -> Result<()> {
+        let _guard = METADATA_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let mut meta = self.load_metadata().unwrap_or_default();
+        if meta.service_retry_states.remove(&service).is_some() {
+            self.save_metadata(&meta)?;
+        }
+        Ok(())
+    }
+
+    pub fn reset_update_schedules(
+        &self,
+        region: GeoRegion,
+        services: &[RoutedService],
+        enabled: bool,
+    ) -> Result<()> {
+        let _guard = METADATA_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let mut meta = self.load_metadata().unwrap_or_default();
+        meta.region_retry_states.remove(&region);
+        for service in services {
+            meta.service_retry_states.remove(service);
+        }
+        if enabled {
+            let next = crate::config::profile::next_update_window_date(Local::now());
+            if region != GeoRegion::Global {
+                meta.region_next_update.insert(region, next);
+            }
+            for service in services {
+                meta.service_next_update.insert(*service, next);
+            }
+        } else {
+            meta.region_next_update.remove(&region);
+            for service in services {
+                meta.service_next_update.remove(service);
+            }
+        }
+        self.save_metadata(&meta)
+    }
+
+    pub fn ensure_update_schedules(
+        &self,
+        region: GeoRegion,
+        services: &[RoutedService],
+        enabled: bool,
+    ) -> Result<()> {
+        if !enabled {
+            return Ok(());
+        }
+        let _guard = METADATA_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let mut meta = self.load_metadata().unwrap_or_default();
+        let next = crate::config::profile::next_update_window_date(Local::now());
+        let mut changed = false;
+        if region != GeoRegion::Global && !meta.region_next_update.contains_key(&region) {
+            meta.region_next_update.insert(region, next);
+            changed = true;
+        }
+        for service in services {
+            if !meta.service_next_update.contains_key(service) {
+                meta.service_next_update.insert(*service, next);
+                changed = true;
+            }
+        }
+        if changed {
+            self.save_metadata(&meta)?;
+        }
+        Ok(())
+    }
+
+    pub fn record_region_schedule_success(
+        &self,
+        region: GeoRegion,
+        interval_days: i64,
+    ) -> Result<()> {
+        let _guard = METADATA_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let mut meta = self.load_metadata().unwrap_or_default();
+        meta.region_retry_states.remove(&region);
+        meta.region_next_update.insert(
+            region,
+            Local::now().date_naive() + chrono::Duration::days(interval_days),
+        );
+        self.save_metadata(&meta)
+    }
+
+    pub fn record_service_schedule_success(
+        &self,
+        service: RoutedService,
+        interval_days: i64,
+    ) -> Result<()> {
+        let _guard = METADATA_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let mut meta = self.load_metadata().unwrap_or_default();
+        meta.service_retry_states.remove(&service);
+        meta.service_next_update.insert(
+            service,
+            Local::now().date_naive() + chrono::Duration::days(interval_days),
+        );
+        self.save_metadata(&meta)
+    }
+
     /// Check whether rule-sets have updates available for the given region.
     /// Returns `(geoip_has_update, geosite_has_update)`. For `Global`, both
     /// are `false`.
@@ -409,7 +638,15 @@ impl GeoManager {
     /// Returns typed result describing what happened.
     pub fn update_if_needed(&self, region: GeoRegion) -> Result<GeoResult> {
         if matches!(region, GeoRegion::Global) {
-            return Ok(GeoResult::UpToDate { checked_at: None });
+            return Ok(GeoResult::UpToDate {
+                checked_at: None,
+                retry_state: None,
+                service_retry_states: Default::default(),
+                service_checked_at: Default::default(),
+                next_update: None,
+                service_next_updates: Default::default(),
+                warnings: Vec::new(),
+            });
         }
         let _guard = METADATA_LOCK.lock().unwrap_or_else(|p| p.into_inner());
 
@@ -422,6 +659,12 @@ impl GeoManager {
             self.save_metadata(&meta)?;
             return Ok(GeoResult::UpToDate {
                 checked_at: Some(checked_at),
+                retry_state: None,
+                service_retry_states: Default::default(),
+                service_checked_at: Default::default(),
+                next_update: None,
+                service_next_updates: Default::default(),
+                warnings: Vec::new(),
             });
         }
 
@@ -439,10 +682,22 @@ impl GeoManager {
                 parts,
                 last_updated,
                 checked_at: self.last_checked_at(region).unwrap_or_else(Local::now),
+                retry_state: None,
+                service_retry_states: Default::default(),
+                service_checked_at: Default::default(),
+                next_update: None,
+                service_next_updates: Default::default(),
+                warnings: Vec::new(),
             })
         } else {
             Ok(GeoResult::UpToDate {
                 checked_at: Some(Local::now()),
+                retry_state: None,
+                service_retry_states: Default::default(),
+                service_checked_at: Default::default(),
+                next_update: None,
+                service_next_updates: Default::default(),
+                warnings: Vec::new(),
             })
         }
     }
@@ -469,9 +724,13 @@ impl GeoManager {
     }
 
     fn check_single(&self, url: &str, saved_etag: Option<&str>) -> Result<bool> {
+        let timeout = self.request_timeout()?;
         let resp = self
             .agent
             .head(url)
+            .config()
+            .timeout_global(Some(timeout))
+            .build()
             .call()
             .with_context(|| format!("HEAD request failed for {}", url))?;
 
@@ -490,9 +749,13 @@ impl GeoManager {
 
     /// Download a file and return its ETag on success.
     fn download_file(&self, url: &str, dest: &Path) -> Result<Option<String>> {
+        let timeout = self.request_timeout()?;
         let resp = self
             .agent
             .get(url)
+            .config()
+            .timeout_global(Some(timeout))
+            .build()
             .call()
             .with_context(|| format!("GET {}", url))?;
 
@@ -512,6 +775,14 @@ impl GeoManager {
             .context("Failed to read response body")?;
         self.write_atomic(dest, &bytes)?;
         Ok(etag)
+    }
+
+    fn request_timeout(&self) -> Result<Duration> {
+        let remaining = self.deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            anyhow::bail!("Geo update batch timed out after 180 seconds");
+        }
+        Ok(remaining.min(HTTP_REQUEST_TIMEOUT))
     }
 
     fn write_atomic(&self, dest: &Path, data: &[u8]) -> Result<()> {
@@ -537,6 +808,27 @@ mod tests {
             assert!(a.geoip.url.contains(a.geoip.filename));
             assert!(a.geosite.url.contains(a.geosite.filename));
         }
+    }
+
+    #[test]
+    fn request_timeout_is_capped_by_request_and_batch_deadlines() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", dir.path()) };
+        let mut gm = GeoManager::new().unwrap();
+
+        assert!(gm.request_timeout().unwrap() <= HTTP_REQUEST_TIMEOUT);
+
+        gm.deadline = Instant::now() + Duration::from_millis(50);
+        assert!(gm.request_timeout().unwrap() <= Duration::from_millis(50));
+
+        gm.deadline = Instant::now() - Duration::from_millis(1);
+        assert!(
+            gm.request_timeout()
+                .unwrap_err()
+                .to_string()
+                .contains("batch timed out")
+        );
     }
 
     #[test]
@@ -743,26 +1035,6 @@ mod tests {
         );
     }
 
-    /// Integration test that hits the real network. Run with `cargo test -- --ignored`.
-    #[test]
-    #[ignore]
-    fn test_download_service_srs_files() {
-        let gm = GeoManager::new().unwrap();
-        for service in RoutedService::ALL {
-            for (_, path) in gm.service_local_paths(service) {
-                let _ = fs::remove_file(path);
-            }
-
-            assert!(
-                gm.update_service_if_needed(service).unwrap(),
-                "expected download for {service:?}"
-            );
-            assert!(gm.has_service_databases(service));
-            // Second run must be an ETag-checked no-op.
-            assert!(!gm.update_service_if_needed(service).unwrap());
-        }
-    }
-
     #[test]
     fn local_paths_match_region_assets() {
         let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
@@ -805,6 +1077,11 @@ mod tests {
             etags,
             updated_at,
             checked_at: HashMap::new(),
+            region_retry_states: HashMap::new(),
+            service_retry_states: HashMap::new(),
+            service_checked_at: HashMap::new(),
+            region_next_update: HashMap::new(),
+            service_next_update: HashMap::new(),
         };
         gm.save_metadata(&meta).unwrap();
         let loaded = gm.load_metadata().unwrap();
@@ -840,6 +1117,84 @@ mod tests {
         assert_eq!(gm.last_checked_at(GeoRegion::Cn), Some(cn_checked));
         assert_eq!(gm.last_checked_at(GeoRegion::Ir), None);
         assert_eq!(gm.last_checked_at(GeoRegion::Global), None);
+    }
+
+    #[test]
+    fn service_checked_at_roundtrips_independently() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", dir.path()) };
+        let gm = GeoManager::new().unwrap();
+        let checked = Local::now();
+        let mut meta = GeoMetadata::default();
+        meta.service_checked_at
+            .insert(RoutedService::Telegram, checked);
+        meta.checked_at
+            .insert(GeoRegion::Ru, checked - chrono::Duration::hours(1));
+
+        gm.save_metadata(&meta).unwrap();
+
+        assert_eq!(
+            gm.service_checked_at().get(&RoutedService::Telegram),
+            Some(&checked)
+        );
+        assert_eq!(
+            gm.last_checked_at(GeoRegion::Ru),
+            meta.checked_at.get(&GeoRegion::Ru).copied()
+        );
+    }
+
+    #[test]
+    fn retry_backoff_persists_per_region_and_clears_independently() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", dir.path()) };
+        let gm = GeoManager::new().unwrap();
+        let now = Local::now();
+
+        for (failures, delay) in [(1, 1), (2, 5), (3, 15), (4, 60)] {
+            let state = gm.record_update_failure_at(GeoRegion::Ru, now).unwrap();
+            assert_eq!(state.consecutive_failures, failures);
+            assert_eq!(state.retry_at, now + chrono::Duration::minutes(delay));
+        }
+        let fifth = gm.record_update_failure_at(GeoRegion::Ru, now).unwrap();
+        assert_eq!(fifth.consecutive_failures, 5);
+        assert!(fifth.retry_at.date_naive() > now.date_naive());
+        let cn = gm.record_update_failure_at(GeoRegion::Cn, now).unwrap();
+        assert_eq!(cn.consecutive_failures, 1);
+        assert_eq!(
+            gm.retry_state(GeoRegion::Ru).unwrap().consecutive_failures,
+            5
+        );
+
+        gm.clear_retry_state(GeoRegion::Ru).unwrap();
+        assert!(gm.retry_state(GeoRegion::Ru).is_none());
+        assert_eq!(gm.retry_state(GeoRegion::Cn), Some(cn));
+    }
+
+    #[test]
+    fn service_retry_backoff_is_independent_from_regions_and_other_services() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", dir.path()) };
+        let gm = GeoManager::new().unwrap();
+
+        gm.record_update_failure(GeoRegion::Ru).unwrap();
+        gm.record_service_failure(RoutedService::Steam).unwrap();
+        let steam = gm.record_service_failure(RoutedService::Steam).unwrap();
+        let telegram = gm.record_service_failure(RoutedService::Telegram).unwrap();
+
+        assert_eq!(steam.consecutive_failures, 2);
+        assert_eq!(telegram.consecutive_failures, 1);
+        assert_eq!(
+            gm.retry_state(GeoRegion::Ru).unwrap().consecutive_failures,
+            1
+        );
+        gm.clear_service_retry_state(RoutedService::Steam).unwrap();
+        let states = gm.service_retry_states();
+        assert!(!states.contains_key(&RoutedService::Steam));
+        assert_eq!(states[&RoutedService::Telegram], telegram);
+        assert!(gm.retry_state(GeoRegion::Ru).is_some());
     }
 
     #[test]
@@ -1050,32 +1405,5 @@ mod tests {
         fs::write(&gm.metadata_path, b"not valid json {{").unwrap();
         let err = gm.load_metadata().unwrap_err().to_string();
         assert!(err.contains("Failed to parse"));
-    }
-
-    /// Integration test that hits the real network. Run with `cargo test -- --ignored`.
-    #[test]
-    #[ignore]
-    fn test_download_srs_files() {
-        let gm = GeoManager::new().unwrap();
-        let (geoip_ru, geosite_ru) = gm.local_paths(GeoRegion::Ru).unwrap();
-        let _ = fs::remove_file(&geoip_ru);
-        let _ = fs::remove_file(&geosite_ru);
-
-        let result = gm.download_databases(GeoRegion::Ru);
-        assert!(result.is_ok(), "download failed: {:?}", result);
-        assert!(result.unwrap(), "expected updated=true");
-
-        assert!(geoip_ru.exists(), "geoip-ru.srs should exist");
-        assert!(geosite_ru.exists(), "geosite-category-ru.srs should exist");
-
-        let updated = gm.last_updated(GeoRegion::Ru);
-        assert!(updated.is_some(), "last_updated should be set");
-
-        let result = gm.update_if_needed(GeoRegion::Ru).unwrap();
-        assert!(
-            matches!(result, GeoResult::UpToDate { .. }),
-            "unexpected result: {:?}",
-            result
-        );
     }
 }

--- a/src/geo.rs
+++ b/src/geo.rs
@@ -793,6 +793,17 @@ impl GeoManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Timelike;
+
+    fn after_update_window() -> DateTime<Local> {
+        Local::now()
+            .with_hour(9)
+            .unwrap()
+            .with_minute(0)
+            .unwrap()
+            .with_second(0)
+            .unwrap()
+    }
 
     /// Regions that actually have rule-sets (all of `GeoRegion::ALL` except
     /// `Global`). Used to parametrize per-country tests.
@@ -1150,7 +1161,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         unsafe { std::env::set_var("XDG_CONFIG_HOME", dir.path()) };
         let gm = GeoManager::new().unwrap();
-        let now = Local::now();
+        let now = after_update_window();
 
         for (failures, delay) in [(1, 1), (2, 5), (3, 15), (4, 60)] {
             let state = gm.record_update_failure_at(GeoRegion::Ru, now).unwrap();

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1248,8 +1248,10 @@ mod tests {
             id: sub_id,
             name: "Example".to_string(),
             url: "http://example.com/sub".to_string(),
-            auto_update: SubscriptionAutoUpdate::Every1h,
+            auto_update: SubscriptionAutoUpdate::Every1d,
             last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
         });
         model.selected = 0;
         insta::assert_snapshot!(snapshot_terminal(&model, 80, 20));
@@ -1521,6 +1523,8 @@ mod tests {
             url: "http://example.com/sub".to_string(),
             auto_update: SubscriptionAutoUpdate::Every1d,
             last_updated: Some(last_updated),
+            next_auto_update: None,
+            retry_state: None,
         });
         model.selected = 0;
         insta::assert_snapshot!(snapshot_terminal(&model, 80, 20));

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_sources_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_sources_snapshot.snap
@@ -10,7 +10,7 @@ expression: "snapshot_terminal(&model, 80, 20)"
 │├ Alpha             vless  1.1.1.1:443││                                      │
 │└ Beta              vless  2.2.2.2:443││                                      │
 │                                      ││                                      │
-│Subscription: Example (2) [🗘 1h]      ││                                      │
+│Subscription: Example (2) [🗘 1d]      ││                                      │
 │├ Gamma             vless  3.3.3.3:443││                                      │
 │└ Delta             vless  4.4.4.4:443││                                      │
 │                                      ││                                      │


### PR DESCRIPTION
## Summary

This PR unifies automatic update scheduling for subscriptions, regional Geo rule-sets, and service rule-sets.

## Changes

- Unified the available automatic update intervals:
  - 1 day
  - 3 days
  - 7 days
  - Off
- Scheduled automatic updates for the 08:00 local-time window.
- Added persistent next-update dates so schedules survive daemon restarts.
- Added bounded retries with 1, 5, 15, and 60-minute delays.
- Limited automatic updates to five attempts per component per day.
- Added independent retry and scheduling state for:
  - Each subscription
  - Each Geo region
  - Each routed service
- Kept manual updates independent from automatic schedules and retry state.
- Combined regional and enabled service rule-set updates into one batch.
- Delayed reconnects until the complete rule-set batch finishes.
- Preserved successful downloads when another component in the batch fails.
- Continued processing remaining components after partial failures.
- Added service-only updates for enabled services in the Global region.
- Added HTTP safety limits for Geo downloads:
  - 60 seconds per complete HTTP request
  - 180 seconds for the complete Geo batch
- Reset update schedules and retry state when the selected interval changes.
- Added configuration schema version 3.
- Migrated legacy 1-hour and 12-hour intervals to 1 day.
- Persisted successful configuration migrations immediately.
- Removed ignored tests that depended on the external network.

## Failure handling

A failed automatic update no longer retries continuously:

1. The first retry is scheduled after 1 minute.
2. Further failures use 5, 15, and 60-minute delays.
3. After five failed attempts, retries stop for the current day.
4. The component becomes eligible again during the next daily update window.

Regional Geo data and every routed service maintain separate retry state. A failure updating one component does not prevent successful components from being saved or independently scheduled.

HTTP requests now include response-body time in their timeout. A stalled server therefore cannot leave the Geo update worker and `[Geo: updating...]` status active indefinitely.

## Reconnect behavior

When rule-set files change, the active connection is restarted only after all requested regional and service files have been processed.

If a batch partially succeeds:

- Successfully downloaded files are retained.
- Updated files are applied with a reconnect.
- Failed components receive their own retry schedule.
- The failure is reported without discarding successful updates.

## Migration

Configuration schema version 3 migrates existing settings as follows:

- Subscription intervals of 1 hour or 12 hours become 1 day.
- The legacy Geo interval of 12 hours becomes 1 day.
- Missing next-update dates are initialized.
- Obsolete retry state is cleared.
- The migrated configuration is written back to `profiles.json`.
