### PR TITLE
feat(downloads): allow updates without VPN

### DIFF
--- a/src/app/effect.rs
+++ b/src/app/effect.rs
@@ -16,9 +16,8 @@ pub enum Effect {
     RevokeKillSwitchExceptions,
     DownloadGeo,
     DownloadGeoIfMissing,
-    /// Fetch rule-sets for enabled service routes if absent. Emitted after a
-    /// successful connect so the download rides the freshly opened tunnel —
-    /// pre-tunnel the source may be unreachable (kill switch or ISP blocks).
+    /// Fetch rule-sets for enabled service routes if absent. This may run
+    /// directly when the kill switch is off, or through an active tunnel.
     DownloadServiceRuleSetsIfMissing,
     RetryServiceRuleSets {
         services: Vec<crate::config::profile::RoutedService>,

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -179,7 +179,7 @@ pub struct Model {
     /// configuration until the user confirms them.
     pub service_routing_draft: Option<HashMap<RoutedService, ServiceRoute>>,
     /// Set when a service-routing commit is waiting for its rule-sets to be
-    /// fetched through the still-active tunnel; `Msg::ServiceRuleSetsReady`
+    /// fetched using the currently available network; `Msg::ServiceRuleSetsReady`
     /// consumes it and triggers the reconnect. Downloading BEFORE the
     /// reconnect matters: reconnecting first would build the new sing-box
     /// config while the files are still missing, leaving the freshly enabled

--- a/src/app/msg.rs
+++ b/src/app/msg.rs
@@ -87,9 +87,8 @@ pub enum Msg {
     },
     /// A service rule-set download pass finished (files may still be missing
     /// if individual downloads failed — absence degrades to "no rule for
-    /// that service"). Consumed by the reducer to run the reconnect that a
-    /// service-routing commit deferred until the rule-sets were fetched
-    /// through the still-active tunnel (`Model::pending_service_reconnect`).
+    /// that service"). Consumed by the reducer to report the result and run
+    /// any reconnect deferred by a service-routing commit.
     ServiceRuleSetsReady {
         retry_states: std::collections::HashMap<
             crate::config::profile::RoutedService,
@@ -101,6 +100,8 @@ pub enum Msg {
         >,
         next_updates:
             std::collections::HashMap<crate::config::profile::RoutedService, chrono::NaiveDate>,
+        updated_parts: Vec<String>,
+        errors: Vec<String>,
     },
     SubscriptionFetched {
         id: Uuid,

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -126,7 +126,11 @@ pub fn update(model: &mut Model, msg: Msg) -> Vec<Effect> {
             }
             effects
         }
-        Msg::SubscriptionFetched { id, result } => handle_subscription_result(model, id, result),
+        Msg::SubscriptionFetched { id, result } => {
+            let mut effects = handle_subscription_result(model, id, result);
+            effects.push(Effect::BroadcastState);
+            effects
+        }
         Msg::ServiceRuleSetsReady {
             retry_states,
             checked_at,
@@ -3578,6 +3582,21 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn subscription_fetched_error_broadcasts_state_without_other_effects() {
+        let mut model = model_with_profiles(vec![]);
+        let effects = update(
+            &mut model,
+            Msg::SubscriptionFetched {
+                id: Uuid::nil(),
+                result: Err(crate::app::msg::IpcError::new("network down")),
+            },
+        );
+
+        assert!(effects.contains(&Effect::BroadcastState));
+        assert!(matches!(model.status, AppStatus::Error(_)));
     }
 
     #[test]

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -131,22 +131,45 @@ pub fn update(model: &mut Model, msg: Msg) -> Vec<Effect> {
             retry_states,
             checked_at,
             next_updates,
+            updated_parts,
+            errors,
         } => {
+            model.geo_updating = false;
             model.service_retry_states = retry_states;
             model.service_checked_at = checked_at;
             model.service_next_updates = next_updates;
-            // The post-connect backstop download also reports here; without
-            // a pending commit there is nothing to do.
+            let mut effects = Vec::new();
+            for part in updated_parts {
+                effects.push(Effect::AppendAppLog {
+                    level: "INFO".to_string(),
+                    message: format!("Updated: {part}"),
+                });
+            }
+            if !errors.is_empty() {
+                push_status(
+                    &mut effects,
+                    model,
+                    AppStatus::Error(format!(
+                        "Service rule-set update failed: {}",
+                        errors.join("; ")
+                    )),
+                );
+                append_download_hint(&mut effects, model, DownloadKind::Geo);
+            }
             if !model.pending_service_reconnect {
-                return vec![];
+                if !effects.is_empty() {
+                    effects.push(Effect::BroadcastState);
+                }
+                return effects;
             }
             model.pending_service_reconnect = false;
             if model.connection != ConnectionState::Connected {
                 // Disconnected while the download ran — the files are on
                 // disk and apply on whatever connect happens next.
-                return vec![];
+                effects.push(Effect::BroadcastState);
+                return effects;
             }
-            let mut effects = vec![Effect::BroadcastState];
+            effects.push(Effect::BroadcastState);
             // Reconnect the ACTIVE profile explicitly — never the cursor's
             // row, which may have moved since the routing change.
             let active = model
@@ -387,6 +410,56 @@ fn push_status(effects: &mut Vec<Effect>, model: &mut Model, status: AppStatus) 
     }
 }
 
+#[derive(Clone, Copy)]
+pub(super) enum DownloadKind {
+    Geo,
+    Subscription,
+}
+
+pub(super) fn download_allowed(model: &Model) -> bool {
+    !model.config.settings.kill_switch || model.connection == ConnectionState::Connected
+}
+
+pub(super) fn push_download_blocked(
+    effects: &mut Vec<Effect>,
+    model: &mut Model,
+    kind: DownloadKind,
+) {
+    let message = match kind {
+        DownloadKind::Geo => {
+            "Geo download is blocked by the kill switch. Connect to VPN and retry."
+        }
+        DownloadKind::Subscription => {
+            "Subscription update is blocked by the kill switch. Connect to VPN and retry."
+        }
+    };
+    push_status(effects, model, AppStatus::Error(message.into()));
+}
+
+fn append_download_hint(effects: &mut Vec<Effect>, model: &Model, kind: DownloadKind) {
+    if model.connection == ConnectionState::Connected {
+        return;
+    }
+    let message = match (model.config.settings.kill_switch, kind) {
+        (true, DownloadKind::Geo) => {
+            "Kill switch is enabled and VPN is disconnected. Reconnect VPN and retry the geo download."
+        }
+        (true, DownloadKind::Subscription) => {
+            "Kill switch is enabled and VPN is disconnected. Reconnect VPN and retry the subscription update."
+        }
+        (false, DownloadKind::Geo) => {
+            "VPN is disconnected. Try connecting to VPN and retrying the geo download."
+        }
+        (false, DownloadKind::Subscription) => {
+            "VPN is disconnected. Try connecting to VPN and retrying the subscription update."
+        }
+    };
+    effects.push(Effect::AppendAppLog {
+        level: "WARN".to_string(),
+        message: message.into(),
+    });
+}
+
 fn handle_config_reloaded(
     model: &mut Model,
     result: Result<crate::config::profile::Config, crate::app::msg::IpcError>,
@@ -534,7 +607,7 @@ fn handle_tick_at(model: &mut Model, now: chrono::DateTime<Local>) -> Vec<Effect
         model.geo_automatic_update = true;
         model.geo_last_attempt_at = Some(now);
         effects.push(Effect::DownloadGeo);
-    } else if !model.geo_updating && model.connection == ConnectionState::Connected {
+    } else if !model.geo_updating && download_allowed(model) {
         let due_services: Vec<_> = model
             .config
             .settings
@@ -816,10 +889,14 @@ fn add_and_fetch_subscription(model: &mut Model, url: &str) -> Vec<Effect> {
         &model.config,
         model.config.subscriptions.len().saturating_sub(1),
     );
+    let mut effects = vec![Effect::SaveConfig];
+    if !download_allowed(model) {
+        push_download_blocked(&mut effects, model, DownloadKind::Subscription);
+        return effects;
+    }
     model.subscription_fetching = true;
     model.subscription_updates.insert(id);
-
-    let mut effects = vec![Effect::SaveConfig, Effect::UpdateSubscription { id }];
+    effects.push(Effect::UpdateSubscription { id });
     push_status(
         &mut effects,
         model,
@@ -969,6 +1046,7 @@ fn handle_subscription_result_at(
                 model,
                 crate::app::model::AppStatus::Error(format!("Subscription failed: {}", err)),
             );
+            append_download_hint(&mut effects, model, DownloadKind::Subscription);
             effects
         }
     };
@@ -1069,6 +1147,9 @@ fn handle_geo_result(model: &mut Model, result: GeoResult) -> Vec<Effect> {
                     message: format!("Geo batch partial failure: {warning}"),
                 });
             }
+            if !warnings.is_empty() {
+                append_download_hint(&mut log_effects, model, DownloadKind::Geo);
+            }
             let status = if warnings.is_empty() {
                 AppStatus::Info("Geo databases updated".into())
             } else {
@@ -1110,6 +1191,9 @@ fn handle_geo_result(model: &mut Model, result: GeoResult) -> Vec<Effect> {
                 ))
             };
             push_status(&mut effects, model, status);
+            if !warnings.is_empty() {
+                append_download_hint(&mut effects, model, DownloadKind::Geo);
+            }
             effects
         }
         GeoResult::Error {
@@ -1133,6 +1217,7 @@ fn handle_geo_result(model: &mut Model, result: GeoResult) -> Vec<Effect> {
                 model,
                 crate::app::model::AppStatus::Error(message),
             );
+            append_download_hint(&mut effects, model, DownloadKind::Geo);
             for part in updated_parts {
                 effects.push(Effect::AppendAppLog {
                     level: "INFO".to_string(),
@@ -2254,7 +2339,16 @@ mod tests {
         assert_eq!(model.geo_retry_state, Some(retry_state));
         assert_eq!(
             effects,
-            vec![app_log_error("net fail"), Effect::BroadcastState]
+            vec![
+                app_log_error("net fail"),
+                Effect::AppendAppLog {
+                    level: "WARN".into(),
+                    message:
+                        "VPN is disconnected. Try connecting to VPN and retrying the geo download."
+                            .into(),
+                },
+                Effect::BroadcastState,
+            ]
         );
     }
 
@@ -2930,6 +3024,8 @@ mod tests {
                 retry_states: Default::default(),
                 checked_at: Default::default(),
                 next_updates: Default::default(),
+                updated_parts: Vec::new(),
+                errors: Vec::new(),
             },
         );
         assert!(!model.pending_service_reconnect, "flag is consumed");
@@ -2961,6 +3057,8 @@ mod tests {
                 retry_states: Default::default(),
                 checked_at: Default::default(),
                 next_updates: Default::default(),
+                updated_parts: Vec::new(),
+                errors: Vec::new(),
             },
         );
         assert!(effects.is_empty());
@@ -2980,6 +3078,8 @@ mod tests {
                 retry_states: Default::default(),
                 checked_at: Default::default(),
                 next_updates: Default::default(),
+                updated_parts: Vec::new(),
+                errors: Vec::new(),
             },
         );
         assert!(!model.pending_service_reconnect);
@@ -3001,6 +3101,8 @@ mod tests {
                 retry_states: Default::default(),
                 checked_at: Default::default(),
                 next_updates: Default::default(),
+                updated_parts: Vec::new(),
+                errors: Vec::new(),
             },
         );
         assert!(!model.pending_service_reconnect);
@@ -3468,7 +3570,12 @@ mod tests {
             effects,
             vec![
                 Effect::SaveConfig,
-                app_log_error("Subscription failed: network down")
+                app_log_error("Subscription failed: network down"),
+                Effect::AppendAppLog {
+                    level: "WARN".into(),
+                    message: "VPN is disconnected. Try connecting to VPN and retrying the subscription update."
+                        .into(),
+                },
             ]
         );
     }
@@ -4526,5 +4633,102 @@ mod tests {
             "failure stores None (shown as err in UI)"
         );
         assert!(effects.iter().any(|e| matches!(e, Effect::BroadcastState)));
+    }
+
+    #[test]
+    fn manual_geo_update_is_blocked_only_by_disconnected_kill_switch() {
+        let mut direct = model_with_profiles(vec![]);
+        direct.config.settings.geo_routing.set_region(GeoRegion::Ru);
+        let effects = update(&mut direct, Msg::Key(key('u')));
+        assert!(effects.contains(&Effect::DownloadGeo));
+
+        let mut blocked = model_with_profiles(vec![]);
+        blocked
+            .config
+            .settings
+            .geo_routing
+            .set_region(GeoRegion::Ru);
+        blocked.config.settings.kill_switch = true;
+        let effects = update(&mut blocked, Msg::Key(key('u')));
+        assert!(!effects.contains(&Effect::DownloadGeo));
+        assert!(!blocked.geo_updating);
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            Effect::AppendAppLog { message, .. }
+                if message.contains("blocked by the kill switch")
+        )));
+
+        blocked.connection = ConnectionState::Connected;
+        let effects = update(&mut blocked, Msg::Key(key('u')));
+        assert!(effects.contains(&Effect::DownloadGeo));
+    }
+
+    #[test]
+    fn pasted_subscription_is_saved_but_not_fetched_behind_kill_switch() {
+        let mut model = model_with_profiles(vec![]);
+        model.config.settings.kill_switch = true;
+        let effects = handle_clipboard_text(&mut model, "https://example.com/sub");
+
+        assert_eq!(model.config.subscriptions.len(), 1);
+        assert!(!model.subscription_fetching);
+        assert!(model.subscription_updates.is_empty());
+        assert!(effects.contains(&Effect::SaveConfig));
+        assert!(
+            !effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::UpdateSubscription { .. }))
+        );
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            Effect::AppendAppLog { message, .. }
+                if message.contains("Subscription update is blocked")
+        )));
+    }
+
+    #[test]
+    fn pasted_subscription_can_fetch_directly_or_through_vpn() {
+        let mut direct = model_with_profiles(vec![]);
+        let effects = handle_clipboard_text(&mut direct, "https://example.com/direct");
+        assert!(
+            effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::UpdateSubscription { .. }))
+        );
+
+        let mut tunneled = model_with_profiles(vec![]);
+        tunneled.config.settings.kill_switch = true;
+        tunneled.connection = ConnectionState::Connected;
+        let effects = handle_clipboard_text(&mut tunneled, "https://example.com/tunneled");
+        assert!(
+            effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::UpdateSubscription { .. }))
+        );
+    }
+
+    #[test]
+    fn automatic_service_update_can_run_directly_without_kill_switch() {
+        let mut model = model_with_profiles(vec![]);
+        model
+            .config
+            .settings
+            .geo_routing
+            .set_region(GeoRegion::Global);
+        model.config.settings.geo_routing.auto_update = GeoAutoUpdate::Every1d;
+        model.config.settings.geo_routing.service_routes.insert(
+            RoutedService::Steam,
+            crate::config::profile::ServiceRoute::Direct,
+        );
+        let now = after_update_window();
+        model
+            .service_next_updates
+            .insert(RoutedService::Steam, now.date_naive());
+
+        let effects = handle_tick_at(&mut model, now);
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            Effect::RetryServiceRuleSets { services }
+                if services == &vec![RoutedService::Steam]
+        )));
     }
 }

--- a/src/app/update/key.rs
+++ b/src/app/update/key.rs
@@ -275,6 +275,11 @@ pub(super) fn handle_enter_on_sources(model: &mut Model) -> Vec<Effect> {
             .iter()
             .any(|p| p.subscription_id == Some(id))
         {
+            if !download_allowed(model) {
+                let mut result = vec![Effect::SaveConfig];
+                push_download_blocked(&mut result, model, DownloadKind::Subscription);
+                return result;
+            }
             model.subscription_fetching = true;
             model.subscription_updates.insert(id);
             let mut result = vec![Effect::SaveConfig, Effect::UpdateSubscription { id }];
@@ -301,6 +306,10 @@ pub(super) fn handle_update_key(model: &mut Model) -> Vec<Effect> {
         if let Some(sub) = model.config.subscriptions.get(idx) {
             let id = sub.id;
             let name = sub.name.clone();
+            if !download_allowed(model) {
+                push_download_blocked(&mut effects, model, DownloadKind::Subscription);
+                return effects;
+            }
             model.subscription_fetching = true;
             model.subscription_updates.insert(id);
             let mut result = vec![Effect::SaveConfig, Effect::UpdateSubscription { id }];
@@ -324,14 +333,8 @@ pub(super) fn handle_update_key(model: &mut Model) -> Vec<Effect> {
                 );
                 return effects;
             }
-            if model.connection != crate::app::model::ConnectionState::Connected {
-                push_status(
-                    &mut effects,
-                    model,
-                    crate::app::model::AppStatus::Info(
-                        "Connect before updating service rule-sets".to_string(),
-                    ),
-                );
+            if !download_allowed(model) {
+                push_download_blocked(&mut effects, model, DownloadKind::Geo);
                 return effects;
             }
             model.geo_updating = true;
@@ -342,6 +345,10 @@ pub(super) fn handle_update_key(model: &mut Model) -> Vec<Effect> {
                 crate::app::model::AppStatus::Info("Checking service rule-sets...".to_string()),
             );
             effects.push(Effect::RetryServiceRuleSets { services });
+            return effects;
+        }
+        if !download_allowed(model) {
+            push_download_blocked(&mut effects, model, DownloadKind::Geo);
             return effects;
         }
         model.geo_updating = true;
@@ -621,14 +628,20 @@ pub(super) fn handle_geo_region(model: &mut Model, key: KeyEvent) -> Vec<Effect>
                 // If the region changed and is not Global, check whether geo databases
                 // are present and download them automatically if they are missing.
                 if changed && region != GeoRegion::Global {
-                    model.geo_updating = true;
-                    model.geo_last_attempt_at = Some(chrono::Local::now());
-                    push_status(
-                        &mut effects,
-                        model,
-                        crate::app::model::AppStatus::Info("Checking geo databases...".to_string()),
-                    );
-                    effects.push(Effect::DownloadGeoIfMissing);
+                    if download_allowed(model) {
+                        model.geo_updating = true;
+                        model.geo_last_attempt_at = Some(chrono::Local::now());
+                        push_status(
+                            &mut effects,
+                            model,
+                            crate::app::model::AppStatus::Info(
+                                "Checking geo databases...".to_string(),
+                            ),
+                        );
+                        effects.push(Effect::DownloadGeoIfMissing);
+                    } else {
+                        push_download_blocked(&mut effects, model, DownloadKind::Geo);
+                    }
                 }
 
                 // Persist the previously active routing mode under the old region
@@ -1045,11 +1058,30 @@ pub(super) fn handle_service_routing(model: &mut Model, key: KeyEvent) -> Vec<Ef
                     );
                 }
                 _ => {
-                    push_status(
-                        &mut effects,
-                        model,
-                        crate::app::model::AppStatus::Info("Service routing updated".into()),
-                    );
+                    if model
+                        .config
+                        .settings
+                        .geo_routing
+                        .enabled_services()
+                        .is_empty()
+                    {
+                        push_status(
+                            &mut effects,
+                            model,
+                            crate::app::model::AppStatus::Info("Service routing updated".into()),
+                        );
+                    } else if download_allowed(model) {
+                        push_status(
+                            &mut effects,
+                            model,
+                            crate::app::model::AppStatus::Info(
+                                "Service routing changed — updating rule-sets".into(),
+                            ),
+                        );
+                        effects.push(Effect::DownloadServiceRuleSetsIfMissing);
+                    } else {
+                        push_download_blocked(&mut effects, model, DownloadKind::Geo);
+                    }
                 }
             }
             return effects;
@@ -1865,6 +1897,7 @@ mod tests {
             ServiceRoute::Proxy
         );
         assert!(effects.contains(&Effect::SaveConfig));
+        assert!(effects.contains(&Effect::DownloadServiceRuleSetsIfMissing));
         // Not connected — no reconnect.
         assert_eq!(model.connection, ConnectionState::Idle);
     }
@@ -1893,7 +1926,7 @@ mod tests {
         // First-enable ordering: the commit must NOT reconnect immediately —
         // a first-enabled service's rule-sets may not be on disk yet, and
         // the new sing-box would come up without its rules. Instead it
-        // downloads through the still-active tunnel and defers the reconnect
+        // downloads using the still-active tunnel and defers the reconnect
         // to Msg::ServiceRuleSetsReady (covered in update.rs tests).
         let a = Profile::new_vless("A".into(), "e".into(), 1, "u".into());
         let active_id = a.id;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -323,46 +323,55 @@ fn execute_daemon_effect(
             });
         }
         Effect::DownloadServiceRuleSetsIfMissing => {
-            // Fired while a tunnel is up (after `Msg::Connected`, or on a
-            // service-routing commit before its deferred reconnect), so the
-            // fetch goes through the VPN — pre-tunnel, GitHub may be
-            // unreachable (kill switch allowlists only the VPN endpoint, and
-            // the ISP may block it). `Msg::ServiceRuleSetsReady` is sent in
-            // every exit path, download failures included: the reducer uses
-            // it to run a pending reconnect, and the route builder tolerates
-            // files that never arrived.
+            // May run directly when the kill switch is off, or through a
+            // tunnel after connect. Always report partial failures so the
+            // reducer can log them and run any pending reconnect.
+            model.geo_updating = true;
             let services = model.config.settings.geo_routing.enabled_services();
             let schedule_enabled = model.config.settings.geo_routing.auto_update
                 != crate::config::profile::GeoAutoUpdate::Off;
             let tx = tx.clone();
             thread::spawn(move || {
-                let (retry_states, checked_at, next_updates) = match crate::geo::GeoManager::new() {
-                    Ok(gm) => {
-                        let _ = gm.ensure_update_schedules(
-                            crate::config::profile::GeoRegion::Global,
-                            &services,
-                            schedule_enabled,
-                        );
-                        let missing: Vec<_> = services
-                            .into_iter()
-                            .filter(|s| !gm.has_service_databases(*s))
-                            .collect();
-                        refresh_service_rule_sets(&gm, &missing, None);
-                        (
-                            gm.service_retry_states(),
-                            gm.service_checked_at(),
-                            gm.service_next_updates(),
-                        )
-                    }
-                    Err(e) => {
-                        tracing::warn!("Failed to init geo manager for service rule-sets: {e:#}");
-                        (Default::default(), Default::default(), Default::default())
-                    }
-                };
+                let (retry_states, checked_at, next_updates, updated_parts, errors) =
+                    match crate::geo::GeoManager::new() {
+                        Ok(gm) => {
+                            let _ = gm.ensure_update_schedules(
+                                crate::config::profile::GeoRegion::Global,
+                                &services,
+                                schedule_enabled,
+                            );
+                            let missing: Vec<_> = services
+                                .into_iter()
+                                .filter(|s| !gm.has_service_databases(*s))
+                                .collect();
+                            let refreshed = refresh_service_rule_sets(&gm, &missing, None);
+                            (
+                                gm.service_retry_states(),
+                                gm.service_checked_at(),
+                                gm.service_next_updates(),
+                                refreshed.updated_parts,
+                                refreshed.errors,
+                            )
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "Failed to init geo manager for service rule-sets: {e:#}"
+                            );
+                            (
+                                Default::default(),
+                                Default::default(),
+                                Default::default(),
+                                Vec::new(),
+                                vec![e.to_string()],
+                            )
+                        }
+                    };
                 let _ = tx.send(Msg::ServiceRuleSetsReady {
                     retry_states,
                     checked_at,
                     next_updates,
+                    updated_parts,
+                    errors,
                 });
             });
         }


### PR DESCRIPTION
## Summary

Allow geo rule-sets and subscriptions to download without an active VPN when the kill switch is disabled.

When the kill switch is enabled, downloads require an active VPN connection.

## Changes

- Apply the same network policy to:
  - Regional geo databases
  - Steam and Telegram rule-sets
  - Subscription updates
- Allow direct downloads when the kill switch is disabled.
- Block manual downloads when the kill switch is enabled and VPN is disconnected.
- Keep automatic updates pending until the VPN connects.
- Download missing service rule-sets immediately when enabling service routing.
- Preserve newly added subscriptions when their initial fetch is blocked.
- Log a separate VPN retry hint after failed downloads without a VPN.
- Report service rule-set updates and partial failures instead of silently discarding them.

## Behavior

| Kill switch | VPN | Result |
|---|---|---|
| Disabled | Disconnected | Download directly |
| Disabled | Connected | Download through the active connection |
| Enabled | Disconnected | Block manual downloads; automatic updates wait |
| Enabled | Connected | Download through VPN |

Manual operations blocked by the kill switch must be retried after connecting. Due automatic updates start on the next daemon tick after the VPN becomes connected.
