### PR TITLE
feat(tui): add mouse controls and log selection

### DIFF
--- a/src/app/msg.rs
+++ b/src/app/msg.rs
@@ -1,7 +1,7 @@
 use crate::app::model::{ConnectionState, Overlay, TrafficStats};
 use crate::config::profile::{DnsStrategy, Profile, Settings, Subscription};
 use crate::ui::styles::Theme;
-use crossterm::event::KeyEvent;
+use crossterm::event::{KeyEvent, MouseEvent};
 use uuid::Uuid;
 
 /// Structured error carried inside `Msg` variants.
@@ -45,6 +45,7 @@ impl From<anyhow::Error> for IpcError {
 
 pub enum Msg {
     Key(KeyEvent),
+    Mouse(MouseEvent),
     Tick,
     Resize,
     GeoUpdated(GeoResult),
@@ -204,6 +205,12 @@ pub enum IpcCommand {
         char: Option<char>,
         ctrl: bool,
     },
+    SelectSource {
+        index: usize,
+    },
+    ConnectProfile {
+        profile_id: Uuid,
+    },
     Paste {
         text: String,
     },
@@ -263,6 +270,10 @@ mod tests {
                 code: "Char".into(),
                 char: Some('a'),
                 ctrl: false,
+            },
+            IpcCommand::SelectSource { index: 1 },
+            IpcCommand::ConnectProfile {
+                profile_id: Uuid::nil(),
             },
             IpcCommand::Paste {
                 text: "hello".into(),

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -298,6 +298,7 @@ pub fn update(model: &mut Model, msg: Msg) -> Vec<Effect> {
             model.profile_latencies.insert(id, latency_ms);
             vec![Effect::BroadcastState]
         }
+        Msg::Mouse(_) => vec![],
     }
 }
 

--- a/src/app/update/key.rs
+++ b/src/app/update/key.rs
@@ -448,6 +448,16 @@ pub(super) fn handle_ipc_command(
                 vec![]
             }
         }
+        IpcCommand::SelectSource { index } => {
+            if index < model.source_rows().len() {
+                model.selected = index;
+            }
+            vec![]
+        }
+        IpcCommand::ConnectProfile { profile_id } => {
+            queue_connect(model, profile_id);
+            vec![]
+        }
         IpcCommand::Paste { text } => handle_clipboard_text(model, &text),
         IpcCommand::Copied { name, count } => handle_copied_status(model, name, count),
         IpcCommand::ReloadConfig => {
@@ -1794,6 +1804,19 @@ mod tests {
     }
 
     #[test]
+    fn ipc_log_copy_sets_clear_status() {
+        let mut model = model_with_profiles(vec![]);
+        handle_ipc_command(
+            &mut model,
+            crate::app::msg::IpcCommand::Copied {
+                name: "log".into(),
+                count: 1,
+            },
+        );
+        assert_eq!(model.status.text(), "Copied: log");
+    }
+
+    #[test]
     fn ipc_command_key_with_unknown_code_only_broadcasts() {
         let mut model = model_with_profiles(vec![]);
         let effects = handle_ipc_command(
@@ -1988,5 +2011,64 @@ mod tests {
             model.status.text(),
             "Service routing saved — takes effect on next reconnect"
         );
+    }
+
+    #[test]
+    fn ipc_mouse_selection_validates_the_source_index() {
+        let profile = Profile::new_vless("A".into(), "e".into(), 1, "u".into());
+        let mut model = model_with_profiles(vec![profile]);
+        model.selected = 0;
+        handle_ipc_command(
+            &mut model,
+            crate::app::msg::IpcCommand::SelectSource { index: 99 },
+        );
+        assert_eq!(model.selected, 0);
+    }
+
+    #[test]
+    fn ipc_connect_profile_switches_or_reconnects_without_disconnecting() {
+        let first = Profile::new_vless("A".into(), "a".into(), 1, "u".into());
+        let second = Profile::new_vless("B".into(), "b".into(), 2, "v".into());
+        let mut model = model_with_profiles(vec![first.clone(), second.clone()]);
+        model.connection = ConnectionState::Connected;
+        model.active_profile_id = Some(first.id);
+
+        let effects = handle_ipc_command(
+            &mut model,
+            crate::app::msg::IpcCommand::ConnectProfile {
+                profile_id: second.id,
+            },
+        );
+        assert_eq!(model.connection, ConnectionState::Connecting);
+        assert_eq!(model.connecting_profile_id, Some(second.id));
+        assert!(!effects.contains(&Effect::Disconnect));
+
+        model.connection = ConnectionState::Connected;
+        model.active_profile_id = Some(first.id);
+        let effects = handle_ipc_command(
+            &mut model,
+            crate::app::msg::IpcCommand::ConnectProfile {
+                profile_id: first.id,
+            },
+        );
+        assert_eq!(model.connection, ConnectionState::Connecting);
+        assert_eq!(model.connecting_profile_id, Some(first.id));
+        assert!(!effects.contains(&Effect::Disconnect));
+    }
+
+    #[test]
+    fn ipc_connect_profile_rejects_unknown_uuid() {
+        let profile = Profile::new_vless("A".into(), "a".into(), 1, "u".into());
+        let mut model = model_with_profiles(vec![profile.clone()]);
+        model.connection = ConnectionState::Connected;
+        model.active_profile_id = Some(profile.id);
+        handle_ipc_command(
+            &mut model,
+            crate::app::msg::IpcCommand::ConnectProfile {
+                profile_id: uuid::Uuid::new_v4(),
+            },
+        );
+        assert_eq!(model.connection, ConnectionState::Connected);
+        assert_eq!(model.connecting_profile_id, None);
     }
 }

--- a/src/tui_client.rs
+++ b/src/tui_client.rs
@@ -7,7 +7,7 @@ use std::io::{self, IsTerminal, Write};
 use std::sync::Arc;
 use std::sync::mpsc::{Sender, channel};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use crossterm::ExecutableCommand;
@@ -37,6 +37,37 @@ pub(crate) fn osc11(color: Color) -> String {
 /// OSC 111: reset terminal background to its default. Emitted on exit so
 /// we don't leave the user's terminal stuck on our palette color.
 pub(crate) const OSC_RESET_BG: &str = "\x1b]111\x1b\\";
+/// Show a pointing hand over clickable rows; an empty shape list restores the
+/// terminal's contextual default (usually an I-beam over terminal text).
+pub(crate) const OSC_POINTER_INTERACTIVE: &str = "\x1b]22;pointer\x1b\\";
+pub(crate) const OSC_POINTER_TEXT: &str = "\x1b]22;text\x1b\\";
+pub(crate) const OSC_POINTER_DEFAULT: &str = "\x1b]22;\x1b\\";
+const DOUBLE_CLICK_INTERVAL: Duration = Duration::from_millis(300);
+
+#[derive(Default)]
+struct ClickTracker(Option<(uuid::Uuid, Instant)>);
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum PointerShape {
+    #[default]
+    Default,
+    Source,
+    Logs,
+}
+
+impl ClickTracker {
+    fn profile_pressed(&mut self, profile_id: uuid::Uuid, now: Instant) -> bool {
+        let double = self.0.is_some_and(|(previous, at)| {
+            previous == profile_id && now.saturating_duration_since(at) <= DOUBLE_CLICK_INTERVAL
+        });
+        self.0 = (!double).then_some((profile_id, now));
+        double
+    }
+
+    fn reset(&mut self) {
+        self.0 = None;
+    }
+}
 
 /// Owns the terminal modes enabled by the TUI and restores them on every
 /// return path (including an error from the render loop).
@@ -55,6 +86,13 @@ impl TerminalSession {
             let _ = disable_raw_mode();
             return Err(error.into());
         }
+        if let Err(error) = input::enable_mouse_capture(&mut stdout) {
+            let _ = input::disable_mouse_capture(&mut stdout);
+            let _ = input::disable_keyboard_protocol(&mut stdout);
+            let _ = stdout.execute(LeaveAlternateScreen);
+            let _ = disable_raw_mode();
+            return Err(error.into());
+        }
         Ok(Self)
     }
 }
@@ -62,6 +100,8 @@ impl TerminalSession {
 impl Drop for TerminalSession {
     fn drop(&mut self) {
         let mut stdout = io::stdout();
+        let _ = stdout.write_all(OSC_POINTER_DEFAULT.as_bytes());
+        let _ = input::disable_mouse_capture(&mut stdout);
         let _ = input::disable_keyboard_protocol(&mut stdout);
         let _ = disable_raw_mode();
         let _ = stdout.execute(LeaveAlternateScreen);
@@ -138,12 +178,92 @@ fn run_loop(
 ) -> Result<()> {
     // Initial draw
     terminal.draw(|f| crate::ui::draw(f, model))?;
+    let mut pointer_shape = PointerShape::Default;
+    let mut mouse_position: Option<(u16, u16)> = None;
+    let mut click_tracker = ClickTracker::default();
+    let mut log_selection: Option<crate::ui::layout::LogSelection> = None;
+    let mut log_dragging = false;
 
     loop {
         let msg = rx.recv()?;
         let mut needs_redraw = false;
 
         match msg {
+            Msg::Mouse(mouse) => {
+                use crossterm::event::{MouseButton, MouseEventKind};
+                mouse_position = Some((mouse.column, mouse.row));
+                let hit =
+                    update_pointer_shape(terminal, model, mouse_position, &mut pointer_shape)?;
+                match mouse.kind {
+                    MouseEventKind::Down(MouseButton::Left) => {
+                        log_selection = None;
+                        log_dragging = false;
+                        let area: ratatui::layout::Rect = terminal.size()?.into();
+                        if let Some(selection) = crate::ui::layout::log_viewport(model, area)
+                            .and_then(|viewport| {
+                                crate::ui::layout::LogSelection::start(
+                                    viewport,
+                                    mouse.column,
+                                    mouse.row,
+                                )
+                            })
+                        {
+                            click_tracker.reset();
+                            log_selection = Some(selection);
+                            log_dragging = true;
+                        } else if let Some(index) = hit {
+                            client.send(&IpcCommand::SelectSource { index })?;
+                            model.selected = index;
+                            let profile_id = match model.source_rows()[index] {
+                                crate::app::model::SourceRow::StandaloneProfile(profile_idx)
+                                | crate::app::model::SourceRow::SubscriptionProfile {
+                                    profile_idx,
+                                    ..
+                                } => Some(model.config.profiles[profile_idx].id),
+                                crate::app::model::SourceRow::SubscriptionHeader(_) => None,
+                            };
+                            if let Some(profile_id) = profile_id
+                                && click_tracker.profile_pressed(profile_id, Instant::now())
+                            {
+                                client.send(&IpcCommand::ConnectProfile { profile_id })?;
+                            } else if profile_id.is_none() {
+                                click_tracker.reset();
+                            }
+                        } else {
+                            click_tracker.reset();
+                        }
+                        needs_redraw = true;
+                    }
+                    MouseEventKind::Moved => {
+                        if log_dragging && let Some(selection) = &mut log_selection {
+                            selection.update(mouse.column, mouse.row);
+                            needs_redraw = true;
+                        }
+                    }
+                    MouseEventKind::Up(MouseButton::Left) => {
+                        if log_dragging && let Some(selection) = &mut log_selection {
+                            log_dragging = false;
+                            selection.update(mouse.column, mouse.row);
+                            let copy_result = (!selection.is_empty())
+                                .then(|| self::clipboard::write_clipboard_text(&selection.text()));
+                            log_selection = None;
+                            if let Some(result) = copy_result {
+                                match result {
+                                    Ok(()) => client.send(&IpcCommand::Copied {
+                                        name: "log".into(),
+                                        count: 1,
+                                    })?,
+                                    Err(error) => client.send(&IpcCommand::ClientError {
+                                        message: format!("Failed to copy log text: {error:#}"),
+                                    })?,
+                                }
+                            }
+                            needs_redraw = true;
+                        }
+                    }
+                    _ => {}
+                }
+            }
             Msg::Key(key) => {
                 use crossterm::event::{KeyCode, KeyModifiers};
                 let mut forward_key = || {
@@ -196,10 +316,16 @@ fn run_loop(
                         }
                     }
                     KeyCode::Char('e') => {
+                        log_selection = None;
+                        log_dragging = false;
                         anyhow::ensure!(
                             event_reader_control.pause(),
                             "Timed out while pausing terminal input for external editor"
                         );
+                        terminal
+                            .backend_mut()
+                            .write_all(OSC_POINTER_DEFAULT.as_bytes())?;
+                        input::disable_mouse_capture(terminal.backend_mut())?;
                         input::disable_keyboard_protocol(terminal.backend_mut())?;
                         disable_raw_mode()?;
                         terminal.backend_mut().execute(LeaveAlternateScreen)?;
@@ -208,9 +334,12 @@ fn run_loop(
                         enable_raw_mode()?;
                         terminal.backend_mut().execute(EnterAlternateScreen)?;
                         input::enable_keyboard_protocol(terminal.backend_mut())?;
+                        input::enable_mouse_capture(terminal.backend_mut())?;
+                        pointer_shape = PointerShape::Default;
                         terminal.clear()?;
                         input::discard_pending_input();
                         event_reader_control.resume();
+                        update_pointer_shape(terminal, model, mouse_position, &mut pointer_shape)?;
                         match result {
                             Ok(_) => {
                                 if let Ok(config) = crate::config::load_config() {
@@ -240,15 +369,27 @@ fn run_loop(
             }
             Msg::StateUpdate(snapshot) => {
                 apply_snapshot(model, *snapshot);
+                if model.overlay != crate::app::model::Overlay::None {
+                    log_selection = None;
+                    log_dragging = false;
+                }
+                update_pointer_shape(terminal, model, mouse_position, &mut pointer_shape)?;
                 needs_redraw = true;
             }
             Msg::Tick => {
-                for line in log_tailer.tail() {
+                let new_lines = log_tailer.tail();
+                if !new_lines.is_empty() && !log_dragging {
+                    log_selection = None;
+                }
+                for line in new_lines {
                     model.push_log(line);
                 }
                 needs_redraw = true;
             }
             Msg::Resize => {
+                log_selection = None;
+                log_dragging = false;
+                update_pointer_shape(terminal, model, mouse_position, &mut pointer_shape)?;
                 needs_redraw = true;
             }
             Msg::ThemeChanged(theme)
@@ -265,10 +406,47 @@ fn run_loop(
         }
 
         if needs_redraw {
-            terminal.draw(|f| crate::ui::draw(f, model))?;
+            terminal.draw(|f| {
+                crate::ui::layout::draw_with_log_selection(f, model, log_selection.as_ref())
+            })?;
         }
     }
     Ok(())
+}
+
+fn update_pointer_shape(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    model: &Model,
+    position: Option<(u16, u16)>,
+    pointer_shape: &mut PointerShape,
+) -> Result<Option<usize>> {
+    let area: ratatui::layout::Rect = terminal.size()?.into();
+    let hit = if let Some((column, row)) = position {
+        crate::ui::layout::source_hit_test(model, area, column, row)
+    } else {
+        None
+    };
+    let next_shape = if hit.is_some() {
+        PointerShape::Source
+    } else if position.is_some_and(|(column, row)| {
+        crate::ui::layout::log_viewport(model, area)
+            .is_some_and(|viewport| viewport.contains(column, row))
+    }) {
+        PointerShape::Logs
+    } else {
+        PointerShape::Default
+    };
+    if next_shape != *pointer_shape {
+        let sequence = match next_shape {
+            PointerShape::Default => OSC_POINTER_DEFAULT,
+            PointerShape::Source => OSC_POINTER_INTERACTIVE,
+            PointerShape::Logs => OSC_POINTER_TEXT,
+        };
+        terminal.backend_mut().write_all(sequence.as_bytes())?;
+        terminal.backend_mut().flush()?;
+        *pointer_shape = next_shape;
+    }
+    Ok(hit)
 }
 
 fn apply_snapshot(model: &mut Model, snapshot: crate::app::msg::StateSnapshot) {
@@ -353,5 +531,27 @@ mod tests {
     #[test]
     fn osc_reset_bg_is_osc_111() {
         assert_eq!(OSC_RESET_BG, "\x1b]111\x1b\\");
+    }
+
+    #[test]
+    fn click_tracker_requires_same_profile_within_300ms() {
+        let first = uuid::Uuid::new_v4();
+        let other = uuid::Uuid::new_v4();
+        let start = Instant::now();
+
+        let mut tracker = ClickTracker::default();
+        assert!(!tracker.profile_pressed(first, start));
+        assert!(tracker.profile_pressed(first, start + Duration::from_millis(300)));
+
+        assert!(!tracker.profile_pressed(first, start));
+        assert!(!tracker.profile_pressed(other, start + Duration::from_millis(100)));
+        assert!(!tracker.profile_pressed(other, start + Duration::from_millis(401)));
+    }
+
+    #[test]
+    fn pointer_shape_sequences_use_osc_22() {
+        assert_eq!(OSC_POINTER_INTERACTIVE, "\x1b]22;pointer\x1b\\");
+        assert_eq!(OSC_POINTER_TEXT, "\x1b]22;text\x1b\\");
+        assert_eq!(OSC_POINTER_DEFAULT, "\x1b]22;\x1b\\");
     }
 }

--- a/src/tui_client/input.rs
+++ b/src/tui_client/input.rs
@@ -14,7 +14,9 @@ use std::sync::mpsc::Sender;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crossterm::event::{KeyCode, KeyEvent, KeyEventState, KeyModifiers};
+use crossterm::event::{
+    KeyCode, KeyEvent, KeyEventState, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+};
 use signal_hook::consts::signal::SIGWINCH;
 use signal_hook::iterator::Signals;
 
@@ -25,6 +27,8 @@ use crate::app::msg::Msg;
 pub(super) const PUSH_KEYBOARD_PROTOCOL: &str = "\x1b[>13u";
 /// Restore the keyboard flags that were active before kvn-tui started.
 pub(super) const POP_KEYBOARD_PROTOCOL: &str = "\x1b[<1u";
+pub(super) const ENABLE_MOUSE_CAPTURE: &str = "\x1b[?1003h\x1b[?1006h";
+pub(super) const DISABLE_MOUSE_CAPTURE: &str = "\x1b[?1006l\x1b[?1003l";
 
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 const ESCAPE_TIMEOUT: Duration = Duration::from_millis(30);
@@ -70,6 +74,16 @@ pub(super) fn disable_keyboard_protocol(out: &mut impl Write) -> io::Result<()> 
     out.flush()
 }
 
+pub(super) fn enable_mouse_capture(out: &mut impl Write) -> io::Result<()> {
+    out.write_all(ENABLE_MOUSE_CAPTURE.as_bytes())?;
+    out.flush()
+}
+
+pub(super) fn disable_mouse_capture(out: &mut impl Write) -> io::Result<()> {
+    out.write_all(DISABLE_MOUSE_CAPTURE.as_bytes())?;
+    out.flush()
+}
+
 pub(super) fn spawn_event_reader(tx: Sender<Msg>, control: Arc<EventReaderControl>) {
     spawn_resize_reader(tx.clone());
     thread::spawn(move || {
@@ -97,8 +111,12 @@ pub(super) fn spawn_event_reader(tx: Sender<Msg>, control: Arc<EventReaderContro
                 Err(_) => break,
             }
 
-            for key in decoder.drain(Instant::now()) {
-                if tx.send(Msg::Key(key)).is_err() {
+            for event in decoder.drain(Instant::now()) {
+                let msg = match event {
+                    InputEvent::Key(key) => Msg::Key(key),
+                    InputEvent::Mouse(mouse) => Msg::Mouse(mouse),
+                };
+                if tx.send(msg).is_err() {
                     return;
                 }
             }
@@ -166,7 +184,7 @@ impl Decoder {
         self.pending.extend_from_slice(bytes);
     }
 
-    fn drain(&mut self, now: Instant) -> Vec<KeyEvent> {
+    fn drain(&mut self, now: Instant) -> Vec<InputEvent> {
         let mut events = Vec::new();
         loop {
             match parse_one(&self.pending, self.escape_expired(now)) {
@@ -196,9 +214,15 @@ impl Decoder {
 }
 
 enum ParseResult {
-    Event(KeyEvent, usize),
+    Event(InputEvent, usize),
     Discard(usize),
     Incomplete,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InputEvent {
+    Key(KeyEvent),
+    Mouse(MouseEvent),
 }
 
 fn parse_one(bytes: &[u8], escape_expired: bool) -> ParseResult {
@@ -263,6 +287,7 @@ fn parse_csi(bytes: &[u8]) -> ParseResult {
         return ParseResult::Discard(used);
     };
     match bytes[end] {
+        b'M' | b'm' if parameters.starts_with('<') => parse_sgr_mouse(parameters, bytes[end], used),
         b'u' => parse_csi_u(parameters, used),
         b'A' => modified_key(KeyCode::Up, parameters, used),
         b'B' => modified_key(KeyCode::Down, parameters, used),
@@ -280,6 +305,61 @@ fn parse_csi(bytes: &[u8]) -> ParseResult {
         },
         _ => ParseResult::Discard(used),
     }
+}
+
+fn parse_sgr_mouse(parameters: &str, terminator: u8, used: usize) -> ParseResult {
+    let mut fields = parameters.strip_prefix('<').unwrap_or_default().split(';');
+    let Some(button) = fields.next().and_then(|value| value.parse::<u16>().ok()) else {
+        return ParseResult::Discard(used);
+    };
+    let Some(column) = fields
+        .next()
+        .and_then(|value| value.parse::<u16>().ok())
+        .and_then(|value| value.checked_sub(1))
+    else {
+        return ParseResult::Discard(used);
+    };
+    let Some(row) = fields
+        .next()
+        .and_then(|value| value.parse::<u16>().ok())
+        .and_then(|value| value.checked_sub(1))
+    else {
+        return ParseResult::Discard(used);
+    };
+    if fields.next().is_some() {
+        return ParseResult::Discard(used);
+    }
+
+    let mut modifiers = KeyModifiers::NONE;
+    modifiers.set(KeyModifiers::SHIFT, button & 4 != 0);
+    modifiers.set(KeyModifiers::ALT, button & 8 != 0);
+    modifiers.set(KeyModifiers::CONTROL, button & 16 != 0);
+    let kind = if button & 32 != 0 {
+        MouseEventKind::Moved
+    } else if button & 64 != 0 {
+        return ParseResult::Discard(used);
+    } else {
+        let mouse_button = match button & 3 {
+            0 => MouseButton::Left,
+            1 => MouseButton::Middle,
+            2 => MouseButton::Right,
+            _ => return ParseResult::Discard(used),
+        };
+        if terminator == b'm' {
+            MouseEventKind::Up(mouse_button)
+        } else {
+            MouseEventKind::Down(mouse_button)
+        }
+    };
+    ParseResult::Event(
+        InputEvent::Mouse(MouseEvent {
+            kind,
+            column,
+            row,
+            modifiers,
+        }),
+        used,
+    )
 }
 
 fn modified_key(code: KeyCode, parameters: &str, used: usize) -> ParseResult {
@@ -316,12 +396,12 @@ fn parse_csi_u(parameters: &str, used: usize) -> ParseResult {
         }
     };
     ParseResult::Event(
-        KeyEvent::new_with_kind_and_state(
+        InputEvent::Key(KeyEvent::new_with_kind_and_state(
             code,
             modifiers,
             crossterm::event::KeyEventKind::Press,
             state,
-        ),
+        )),
         used,
     )
 }
@@ -426,7 +506,7 @@ fn parse_utf8(bytes: &[u8], modifiers: KeyModifiers, prefix: usize) -> ParseResu
 }
 
 fn event(code: KeyCode, modifiers: KeyModifiers, used: usize) -> ParseResult {
-    ParseResult::Event(KeyEvent::new(code, modifiers), used)
+    ParseResult::Event(InputEvent::Key(KeyEvent::new(code, modifiers)), used)
 }
 
 #[cfg(test)]
@@ -454,7 +534,7 @@ mod tests {
 
     fn decode(input: &[u8]) -> KeyEvent {
         match parse_one(input, true) {
-            ParseResult::Event(event, used) => {
+            ParseResult::Event(InputEvent::Key(event), used) => {
                 assert_eq!(used, input.len());
                 event
             }
@@ -517,14 +597,74 @@ mod tests {
         decoder.push(b"\x1b[1086::106;1ujk");
         let events = decoder.drain(Instant::now());
         assert_eq!(events.len(), 3);
-        assert_eq!(events[0].code, KeyCode::Char('j'));
-        assert_eq!(events[1].code, KeyCode::Char('j'));
-        assert_eq!(events[2].code, KeyCode::Char('k'));
+        let codes: Vec<_> = events
+            .into_iter()
+            .map(|event| match event {
+                InputEvent::Key(key) => key.code,
+                InputEvent::Mouse(_) => panic!("expected key"),
+            })
+            .collect();
+        assert_eq!(
+            codes,
+            [KeyCode::Char('j'), KeyCode::Char('j'), KeyCode::Char('k')]
+        );
+    }
+
+    fn mouse(input: &[u8]) -> MouseEvent {
+        match parse_one(input, false) {
+            ParseResult::Event(InputEvent::Mouse(event), used) => {
+                assert_eq!(used, input.len());
+                event
+            }
+            _ => panic!("input did not decode to a mouse event"),
+        }
+    }
+
+    #[test]
+    fn decodes_sgr_mouse_move_press_and_release() {
+        let moved = mouse(b"\x1b[<35;12;8M");
+        assert_eq!(moved.kind, MouseEventKind::Moved);
+        assert_eq!((moved.column, moved.row), (11, 7));
+
+        let down = mouse(b"\x1b[<0;2;3M");
+        assert_eq!(down.kind, MouseEventKind::Down(MouseButton::Left));
+        assert_eq!((down.column, down.row), (1, 2));
+
+        let up = mouse(b"\x1b[<0;2;3m");
+        assert_eq!(up.kind, MouseEventKind::Up(MouseButton::Left));
+    }
+
+    #[test]
+    fn decoder_handles_fragmented_and_combined_mouse_sequences() {
+        let mut decoder = Decoder::default();
+        decoder.push(b"\x1b[<0;4");
+        assert!(decoder.drain(Instant::now()).is_empty());
+        decoder.push(b";5M\x1b[<0;4;5m");
+        let events = decoder.drain(Instant::now());
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[0],
+            InputEvent::Mouse(MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 3,
+                row: 4,
+                ..
+            })
+        ));
+        assert!(matches!(
+            events[1],
+            InputEvent::Mouse(MouseEvent {
+                kind: MouseEventKind::Up(MouseButton::Left),
+                ..
+            })
+        ));
     }
 
     #[test]
     fn protocol_sequences_are_balanced() {
         assert_eq!(PUSH_KEYBOARD_PROTOCOL, "\x1b[>13u");
         assert_eq!(POP_KEYBOARD_PROTOCOL, "\x1b[<1u");
+        assert_eq!(ENABLE_MOUSE_CAPTURE, "\x1b[?1003h\x1b[?1006h");
+        assert_eq!(DISABLE_MOUSE_CAPTURE, "\x1b[?1006l\x1b[?1003l");
     }
 }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -17,8 +17,313 @@ use crate::ui::widgets::{
 /// top/bottom borders = 3 lines.
 const TRAFFIC_PANEL_HEIGHT: u16 = 3;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct LogPoint {
+    row: usize,
+    column: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LogDisplayRow {
+    text: String,
+    hard_break_after: bool,
+    error: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LogViewport {
+    area: Rect,
+    rows: Vec<LogDisplayRow>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LogSelection {
+    viewport: LogViewport,
+    anchor: LogPoint,
+    focus: LogPoint,
+}
+
+impl LogSelection {
+    pub(crate) fn start(viewport: LogViewport, column: u16, row: u16) -> Option<Self> {
+        let point = viewport.point_at(column, row)?;
+        Some(Self {
+            viewport,
+            anchor: point,
+            focus: point,
+        })
+    }
+
+    pub(crate) fn update(&mut self, column: u16, row: u16) {
+        self.focus = self.viewport.clamped_point(column, row);
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.anchor == self.focus
+    }
+
+    pub(crate) fn text(&self) -> String {
+        if self.is_empty() {
+            return String::new();
+        }
+        let (start, end) = self.bounds();
+        let mut output = String::new();
+        for row_index in start.row..=end.row {
+            let row = &self.viewport.rows[row_index];
+            let from = if row_index == start.row {
+                start.column
+            } else {
+                0
+            };
+            let to = if row_index == end.row {
+                end.column
+            } else {
+                u16::MAX
+            };
+            output.push_str(&text_between_columns(&row.text, from, to));
+            if row_index < end.row && row.hard_break_after {
+                output.push('\n');
+            }
+        }
+        output
+    }
+
+    fn bounds(&self) -> (LogPoint, LogPoint) {
+        if self.anchor <= self.focus {
+            (self.anchor, self.focus)
+        } else {
+            (self.focus, self.anchor)
+        }
+    }
+
+    fn contains(&self, row: usize, column: u16, width: u16) -> bool {
+        if self.is_empty() {
+            return false;
+        }
+        let (start, end) = self.bounds();
+        let point_end = column.saturating_add(width.saturating_sub(1));
+        (row > start.row || (row == start.row && point_end >= start.column))
+            && (row < end.row || (row == end.row && column <= end.column))
+    }
+}
+
+impl LogViewport {
+    pub(crate) fn contains(&self, column: u16, row: u16) -> bool {
+        column >= self.area.x
+            && column < self.area.x.saturating_add(self.area.width)
+            && row >= self.area.y
+            && row < self.area.y.saturating_add(self.area.height)
+    }
+
+    fn point_at(&self, column: u16, row: u16) -> Option<LogPoint> {
+        if self.rows.is_empty()
+            || !self.contains(column, row)
+            || row.saturating_sub(self.area.y) as usize >= self.rows.len()
+        {
+            return None;
+        }
+        Some(self.clamped_point(column, row))
+    }
+
+    fn clamped_point(&self, column: u16, row: u16) -> LogPoint {
+        let max_row = self.rows.len().saturating_sub(1);
+        let local_row = row.saturating_sub(self.area.y) as usize;
+        let row = local_row.min(max_row);
+        let max_column = visual_width(&self.rows[row].text).saturating_sub(1) as u16;
+        LogPoint {
+            row,
+            column: column.saturating_sub(self.area.x).min(max_column),
+        }
+    }
+}
+
+fn build_log_viewport(model: &Model, area: Rect) -> LogViewport {
+    let mut rows = Vec::new();
+    if area.width > 0 {
+        for line in &model.logs {
+            let error = line.starts_with("[error]");
+            let wrapped = wrap_log_line(line, area.width as usize);
+            let last = wrapped.len().saturating_sub(1);
+            rows.extend(
+                wrapped
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, text)| LogDisplayRow {
+                        text,
+                        hard_break_after: index == last,
+                        error,
+                    }),
+            );
+        }
+    }
+    let keep = area.height as usize;
+    if rows.len() > keep {
+        rows.drain(..rows.len() - keep);
+    }
+    LogViewport { area, rows }
+}
+
+fn wrap_log_line(line: &str, width: usize) -> Vec<String> {
+    if line.is_empty() || width == 0 {
+        return vec![String::new()];
+    }
+    let mut rows = vec![String::new()];
+    let mut used = 0;
+    for character in line.chars() {
+        let char_width = UnicodeWidthChar::width(character).unwrap_or(0);
+        if used > 0 && used + char_width > width {
+            rows.push(String::new());
+            used = 0;
+        }
+        rows.last_mut().expect("one row exists").push(character);
+        used += char_width;
+    }
+    rows
+}
+
+fn text_between_columns(text: &str, from: u16, to: u16) -> String {
+    let mut result = String::new();
+    let mut column = 0_u16;
+    for character in text.chars() {
+        let width = UnicodeWidthChar::width(character).unwrap_or(0) as u16;
+        let end = column.saturating_add(width.saturating_sub(1));
+        if end >= from && column <= to {
+            result.push(character);
+        }
+        column = column.saturating_add(width);
+    }
+    result
+}
+
+fn log_display_line(
+    model: &Model,
+    row: &LogDisplayRow,
+    row_index: usize,
+    selection: Option<&LogSelection>,
+) -> Line<'static> {
+    let base = if row.error {
+        model.theme.error()
+    } else {
+        model.theme.normal()
+    };
+    let mut column = 0_u16;
+    let spans = row
+        .text
+        .chars()
+        .map(|character| {
+            let width = UnicodeWidthChar::width(character).unwrap_or(0) as u16;
+            let selected =
+                selection.is_some_and(|selection| selection.contains(row_index, column, width));
+            column = column.saturating_add(width);
+            Span::styled(
+                character.to_string(),
+                if selected {
+                    model.theme.selected()
+                } else {
+                    base
+                },
+            )
+        })
+        .collect::<Vec<_>>();
+    Line::from(spans)
+}
+
+fn main_panes(terminal_area: Rect) -> (Rect, Rect) {
+    let main_area = if terminal_area.height > TRAFFIC_PANEL_HEIGHT + 5 {
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(TRAFFIC_PANEL_HEIGHT),
+                Constraint::Min(0),
+                Constraint::Length(1),
+            ])
+            .split(terminal_area)[1]
+    } else {
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(0), Constraint::Length(1)])
+            .split(terminal_area)[0]
+    };
+    let panes = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(main_area);
+    (panes[0], panes[1])
+}
+
+pub(crate) fn log_viewport(model: &Model, terminal_area: Rect) -> Option<LogViewport> {
+    if model.overlay != Overlay::None {
+        return None;
+    }
+    let (_, logs) = main_panes(terminal_area);
+    let area = Rect::new(
+        logs.x.saturating_add(1),
+        logs.y.saturating_add(1),
+        logs.width.saturating_sub(2),
+        logs.height.saturating_sub(2),
+    );
+    if area.width == 0 || area.height == 0 {
+        return None;
+    }
+    Some(build_log_viewport(model, area))
+}
+
+/// Return the selectable Sources row under a terminal cell. Borders, group
+/// labels, separators, Logs, clipped rows, and every overlay are inert.
+pub(crate) fn source_hit_test(
+    model: &Model,
+    terminal_area: Rect,
+    column: u16,
+    row: u16,
+) -> Option<usize> {
+    if model.overlay != Overlay::None {
+        return None;
+    }
+    let (sources, _) = main_panes(terminal_area);
+    let inside = column > sources.x
+        && column < sources.x.saturating_add(sources.width).saturating_sub(1)
+        && row > sources.y
+        && row < sources.y.saturating_add(sources.height).saturating_sub(1);
+    if !inside {
+        return None;
+    }
+
+    let rows = model.source_rows();
+    let mut visual_rows = Vec::new();
+    let standalone: Vec<_> = rows
+        .iter()
+        .enumerate()
+        .filter(|(_, source)| matches!(source, SourceRow::StandaloneProfile(_)))
+        .map(|(index, _)| index)
+        .collect();
+    if !standalone.is_empty() {
+        visual_rows.push(None); // "Standalone profiles" is only a label.
+        visual_rows.extend(standalone.into_iter().map(Some));
+        visual_rows.push(None);
+    }
+    for sub_idx in 0..model.config.subscriptions.len() {
+        visual_rows.push(rows.iter().position(
+            |source| matches!(source, SourceRow::SubscriptionHeader(index) if *index == sub_idx),
+        ));
+        visual_rows.extend(rows.iter().enumerate().filter_map(|(index, source)| {
+            matches!(source, SourceRow::SubscriptionProfile { sub_idx: index_sub, .. } if *index_sub == sub_idx)
+                .then_some(Some(index))
+        }));
+        visual_rows.push(None);
+    }
+    let line = row.saturating_sub(sources.y + 1) as usize;
+    visual_rows.get(line).copied().flatten()
+}
+
 /// Render the full application UI into the terminal frame.
 pub fn draw(frame: &mut Frame, model: &Model) {
+    draw_with_log_selection(frame, model, None);
+}
+
+pub(crate) fn draw_with_log_selection(
+    frame: &mut Frame,
+    model: &Model,
+    log_selection: Option<&LogSelection>,
+) {
     let area = frame.area();
 
     // Paint the palette's background across the whole frame first so that
@@ -52,7 +357,7 @@ pub fn draw(frame: &mut Frame, model: &Model) {
     if let Some(area) = traffic_area {
         draw_traffic_panel(frame, model, area);
     }
-    draw_main(frame, model, main_area);
+    draw_main(frame, model, main_area, log_selection);
     draw_status_bar(frame, model, status_area);
 
     let theme = &model.theme;
@@ -69,7 +374,7 @@ pub fn draw(frame: &mut Frame, model: &Model) {
 }
 
 /// Draw the main content area with the Sources list and logs.
-fn draw_main(frame: &mut Frame, model: &Model, area: Rect) {
+fn draw_main(frame: &mut Frame, model: &Model, area: Rect, log_selection: Option<&LogSelection>) {
     let theme = &model.theme;
     let content_chunks = Layout::default()
         .direction(Direction::Horizontal)
@@ -83,26 +388,25 @@ fn draw_main(frame: &mut Frame, model: &Model, area: Rect) {
         .borders(Borders::ALL)
         .border_style(theme.border());
 
-    // Show the most recent log lines that fit in the available area.
-    let available_height = content_chunks[1].height.saturating_sub(2) as usize;
-    let start = model.logs.len().saturating_sub(available_height);
-    let log_text: Vec<Line> = model
-        .logs
+    let inner = Rect::new(
+        content_chunks[1].x.saturating_add(1),
+        content_chunks[1].y.saturating_add(1),
+        content_chunks[1].width.saturating_sub(2),
+        content_chunks[1].height.saturating_sub(2),
+    );
+    let viewport = log_selection
+        .map(|selection| &selection.viewport)
+        .filter(|viewport| viewport.area == inner)
+        .cloned()
+        .unwrap_or_else(|| build_log_viewport(model, inner));
+    let log_text: Vec<Line> = viewport
+        .rows
         .iter()
-        .skip(start)
-        .map(|l| {
-            let style = if l.starts_with("[error]") {
-                theme.error()
-            } else {
-                theme.normal()
-            };
-            Line::from(Span::styled(l.as_str(), style))
-        })
+        .enumerate()
+        .map(|(row_index, row)| log_display_line(model, row, row_index, log_selection))
         .collect();
 
-    let logs = Paragraph::new(log_text)
-        .block(log_block)
-        .wrap(Wrap { trim: true });
+    let logs = Paragraph::new(log_text).block(log_block);
     frame.render_widget(logs, content_chunks[1]);
 }
 
@@ -811,6 +1115,151 @@ mod tests {
     use crate::test_helpers::{buffer_to_string, model_with_profiles};
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
+
+    fn mouse_model() -> Model {
+        use crate::config::profile::{Subscription, SubscriptionAutoUpdate};
+        use uuid::Uuid;
+
+        let sub_id = Uuid::new_v4();
+        let standalone = Profile::new_vless("A".into(), "a".into(), 1, "u".into());
+        let mut nested = Profile::new_vless("B".into(), "b".into(), 2, "v".into());
+        nested.subscription_id = Some(sub_id);
+        let mut model = model_with_profiles(vec![standalone, nested]);
+        model.config.subscriptions.push(Subscription {
+            id: sub_id,
+            name: "Sub".into(),
+            url: "https://example.test".into(),
+            auto_update: SubscriptionAutoUpdate::Off,
+            last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
+        });
+        model
+    }
+
+    #[test]
+    fn source_hit_test_maps_rows_in_both_vertical_layouts() {
+        let model = mouse_model();
+        // Tall: traffic panel occupies rows 0..=2, Sources content starts at 4.
+        assert_eq!(
+            source_hit_test(&model, Rect::new(0, 0, 80, 20), 2, 5),
+            Some(0)
+        );
+        assert_eq!(
+            source_hit_test(&model, Rect::new(0, 0, 80, 20), 2, 7),
+            Some(1)
+        );
+        assert_eq!(
+            source_hit_test(&model, Rect::new(0, 0, 80, 20), 2, 8),
+            Some(2)
+        );
+        // Short: traffic is hidden and Sources content starts at row 1.
+        assert_eq!(
+            source_hit_test(&model, Rect::new(0, 0, 80, 8), 2, 2),
+            Some(0)
+        );
+        assert_eq!(
+            source_hit_test(&model, Rect::new(0, 0, 80, 8), 2, 4),
+            Some(1)
+        );
+        assert_eq!(
+            source_hit_test(&model, Rect::new(0, 0, 80, 8), 2, 5),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn source_hit_test_ignores_labels_borders_separators_logs_clipping_and_overlays() {
+        let mut model = mouse_model();
+        let area = Rect::new(0, 0, 80, 20);
+        assert_eq!(source_hit_test(&model, area, 2, 4), None); // standalone label
+        assert_eq!(source_hit_test(&model, area, 2, 6), None); // separator
+        assert_eq!(source_hit_test(&model, area, 0, 5), None); // border
+        assert_eq!(source_hit_test(&model, area, 50, 5), None); // Logs
+        assert_eq!(source_hit_test(&model, Rect::new(0, 0, 80, 5), 2, 4), None);
+        model.overlay = Overlay::Help;
+        assert_eq!(source_hit_test(&model, area, 2, 5), None);
+    }
+
+    #[test]
+    fn log_viewport_hit_test_excludes_border_and_overlay() {
+        let mut model = mouse_model();
+        model.push_log("hello".into());
+        let area = Rect::new(0, 0, 80, 20);
+        let viewport = log_viewport(&model, area).unwrap();
+        assert!(viewport.contains(41, 4));
+        assert!(!viewport.contains(40, 4));
+        assert!(!viewport.contains(41, 3));
+        model.overlay = Overlay::Help;
+        assert!(log_viewport(&model, area).is_none());
+    }
+
+    #[test]
+    fn log_selection_joins_soft_wraps_and_preserves_real_line_breaks() {
+        let mut model = mouse_model();
+        model.push_log("abcdef".into());
+        model.push_log("ghi".into());
+        let viewport = build_log_viewport(&model, Rect::new(10, 5, 3, 3));
+        assert_eq!(viewport.rows.len(), 3);
+        let mut selection = LogSelection::start(viewport, 10, 5).unwrap();
+        selection.update(12, 7);
+        assert_eq!(selection.text(), "abcdef\nghi");
+    }
+
+    #[test]
+    fn log_selection_works_backwards_and_clamps_to_log_bounds() {
+        let mut model = mouse_model();
+        model.push_log("abc".into());
+        model.push_log("def".into());
+        let viewport = build_log_viewport(&model, Rect::new(10, 5, 3, 2));
+        let mut selection = LogSelection::start(viewport, 12, 6).unwrap();
+        selection.update(0, 0);
+        assert_eq!(selection.text(), "abc\ndef");
+    }
+
+    #[test]
+    fn log_selection_does_not_split_wide_unicode_characters() {
+        let mut model = mouse_model();
+        model.push_log("a界b".into());
+        let viewport = build_log_viewport(&model, Rect::new(0, 0, 4, 1));
+        let mut selection = LogSelection::start(viewport, 1, 0).unwrap();
+        selection.update(2, 0);
+        assert_eq!(selection.text(), "界");
+    }
+
+    #[test]
+    fn log_selection_single_click_is_empty() {
+        let mut model = mouse_model();
+        model.push_log("abc".into());
+        let viewport = build_log_viewport(&model, Rect::new(0, 0, 3, 1));
+        let selection = LogSelection::start(viewport, 1, 0).unwrap();
+        assert!(selection.is_empty());
+        assert!(selection.text().is_empty());
+    }
+
+    #[test]
+    fn active_log_selection_freezes_viewport_until_it_is_cleared() {
+        let mut model = mouse_model();
+        model.push_log("visible before drag".into());
+        let area = Rect::new(0, 0, 80, 20);
+        let viewport = log_viewport(&model, area).unwrap();
+        let mut selection = LogSelection::start(viewport, 41, 4).unwrap();
+        selection.update(42, 4);
+
+        model.push_log("arrived during drag".into());
+        let backend = TestBackend::new(80, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| draw_with_log_selection(frame, &model, Some(&selection)))
+            .unwrap();
+        let frozen = buffer_to_string(terminal.backend().buffer());
+        assert!(frozen.contains("visible before drag"));
+        assert!(!frozen.contains("arrived during drag"));
+
+        terminal.draw(|frame| draw(frame, &model)).unwrap();
+        let current = buffer_to_string(terminal.backend().buffer());
+        assert!(current.contains("arrived during drag"));
+    }
 
     fn snapshot_terminal(model: &Model, width: u16, height: u16) -> String {
         let backend = TestBackend::new(width, height);


### PR DESCRIPTION
## Summary

  Adds mouse support for navigating Sources and copying text from the Logs panel.

  ## Changes

  - Added single-click selection for profiles and subscription headers.
  - Added profile connection by double-clicking within 300 ms.
  - Double-clicking another profile switches the active connection.
  - Double-clicking the active profile reconnects it.
  - Double-clicking a subscription header only selects it.
  - Added contextual pointer shapes:
    - pointer hand over interactive Sources rows;
    - text-selection cursor over Logs;
    - default cursor elsewhere.
  - Added mouse-based text selection within the Logs panel.
  - Selected log text is automatically copied to the system clipboard on release.
  - The Logs viewport remains stable while text is being selected.
  - New log entries are displayed after copying finishes.
  - Added `Copied: log` status feedback after a successful copy.
  - Added IPC commands for selecting source rows and connecting profiles by UUID.
  - Mouse capture and pointer state are restored correctly when opening the editor or exiting the TUI.