### PR TITLE
feat(tui): add session-aware log navigation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 ## Features
 
-- **Vim-style navigation** — `j`/`k` to move, `g`/`G` to jump, `?` for help
+- **Vim-style navigation** — `j`/`k` to move, `gg`/`G` to jump, `?` for help
 - **Profiles & subscriptions** — import, export, edit, and automatically update VPN profiles
 - **Geo & service routing** — choose country-based routing modes and ready-made overrides for selected services
 - **DNS controls** — built-in DoH, DoT, system resolver, strategy, and fake-IP settings
@@ -207,10 +207,26 @@ unusable.
 
 | Key | Action |
 |-----|--------|
-| `j` / `↓` | Move down |
-| `k` / `↑` | Move up |
-| `g` | Go to first profile |
-| `G` | Go to last profile |
+| `h` / `l` | Focus the Sources / Logs panel |
+| `j` / `↓` | Move down one source or complete log record |
+| `k` / `↑` | Move up one source or complete log record |
+| `gg` | Go to the first item or the top of the complete log buffer |
+| `G` | Go to the last item or the bottom of the complete log buffer |
+
+The focused panel is preserved while the daemon remains active. Selectable
+overlays use the same `j` / `k` / `gg` / `G` navigation. In Logs, the first
+`j` selects the top visible record and the first `k` selects the bottom visible
+record; the record focus clears after 15 seconds of inactivity.
+
+**Logs**
+
+| Key | Action |
+|-----|--------|
+| `y` | Copy the focused log record, or every record in the visual selection |
+| `Shift+V` | Start a record-wise visual selection |
+| `j` / `k` | Extend the visual selection by one complete log record |
+| `gg` / `G` | Extend the visual selection to the start / end of the complete log buffer |
+| `Esc` | Cancel the visual selection |
 
 **Profiles & subscriptions**
 
@@ -218,7 +234,7 @@ unusable.
 |-----|--------|
 | `Enter` | Connect to selected profile |
 | `p` | Paste share link or subscription URL from clipboard |
-| `y` | Yank selected profile as a share link (or subscription source URL) to clipboard |
+| `y` | Yank the selected profile as a share link (or subscription source URL) to the clipboard |
 | `d` | Delete selected source |
 | `u` | Update selected subscription or geoip/geosite databases |
 | `i` | Cycle subscription auto-update interval |
@@ -245,7 +261,7 @@ unusable.
 
 | Key | Action |
 |-----|--------|
-| `q` / `Esc` | Close the active overlay; otherwise exit only the TUI — the daemon and VPN keep running |
+| `q` / `Esc` | Close the active overlay; otherwise exit only the TUI — the daemon and VPN keep running (`Esc` cancels an active log selection first) |
 | `Ctrl+C` | Stop the daemon, disconnect the VPN, and exit completely |
 | `?` | Show help |
 

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -24,6 +24,15 @@ pub enum Overlay {
     ServiceRouting,
 }
 
+/// Main panel focused by the active daemon session. It is deliberately not
+/// persisted to config: a fresh daemon always starts on Sources.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum MainPaneFocus {
+    #[default]
+    Sources,
+    Logs,
+}
+
 /// A single selectable row in the unified Sources list.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SourceRow {
@@ -144,6 +153,7 @@ pub(crate) fn row_for_subscription_header(config: &Config, sub_idx: usize) -> us
 /// Application data model — no side effects.
 pub struct Model {
     pub overlay: Overlay,
+    pub main_pane_focus: MainPaneFocus,
     pub connection: ConnectionState,
     pub config: Config,
     pub selected: usize,
@@ -361,6 +371,7 @@ impl Model {
 
         let mut model = Self {
             overlay: Overlay::None,
+            main_pane_focus: MainPaneFocus::Sources,
             connection,
             config,
             selected,
@@ -464,6 +475,7 @@ impl Model {
 
         let mut model = Self {
             overlay: Overlay::None,
+            main_pane_focus: MainPaneFocus::Sources,
             connection: ConnectionState::Idle,
             config,
             selected,
@@ -692,6 +704,7 @@ impl Model {
         let selected = 0;
         Self {
             overlay: Overlay::None,
+            main_pane_focus: MainPaneFocus::Sources,
             connection: ConnectionState::Idle,
             config,
             selected,

--- a/src/app/msg.rs
+++ b/src/app/msg.rs
@@ -1,4 +1,4 @@
-use crate::app::model::{ConnectionState, Overlay, TrafficStats};
+use crate::app::model::{ConnectionState, MainPaneFocus, Overlay, TrafficStats};
 use crate::config::profile::{DnsStrategy, Profile, Settings, Subscription};
 use crate::ui::styles::Theme;
 use crossterm::event::{KeyEvent, MouseEvent};
@@ -208,6 +208,12 @@ pub enum IpcCommand {
     SelectSource {
         index: usize,
     },
+    SetMainPaneFocus {
+        focus: MainPaneFocus,
+    },
+    /// Semantic result of a client-local `gg` sequence. The daemon applies
+    /// it to whichever selectable main view or overlay is currently active.
+    GoFirst,
     ConnectProfile {
         profile_id: Uuid,
     },
@@ -272,6 +278,10 @@ mod tests {
                 ctrl: false,
             },
             IpcCommand::SelectSource { index: 1 },
+            IpcCommand::SetMainPaneFocus {
+                focus: MainPaneFocus::Logs,
+            },
+            IpcCommand::GoFirst,
             IpcCommand::ConnectProfile {
                 profile_id: Uuid::nil(),
             },
@@ -336,11 +346,17 @@ pub struct StateSnapshot {
     pub geo_updating: bool,
     pub geo_last_updated: Option<String>,
     pub overlay: Overlay,
+    #[serde(default)]
+    pub main_pane_focus: MainPaneFocus,
     pub profiles: Vec<Profile>,
     pub subscriptions: Vec<Subscription>,
     pub settings: Settings,
     #[serde(default)]
     pub traffic: TrafficStats,
+    /// Byte offsets of the log files at daemon startup. A TUI client uses
+    /// them to restore only the current daemon session when it attaches.
+    #[serde(default)]
+    pub log_session_offsets: Option<LogSessionOffsets>,
     /// Latency results keyed by profile UUID string. `null` = error, number =
     /// ms. Absent key = not yet tested. Transient — not persisted to disk.
     #[serde(default)]
@@ -348,4 +364,10 @@ pub struct StateSnapshot {
     /// Profile UUIDs whose test is currently in-flight (spinner indicator).
     #[serde(default)]
     pub testing_profiles: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
+pub struct LogSessionOffsets {
+    pub app: u64,
+    pub singbox: u64,
 }

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -828,7 +828,9 @@ fn check_due_subscriptions_at(model: &mut Model, now: chrono::DateTime<Local>) -
 }
 
 fn handle_copied_status(model: &mut Model, name: String, count: usize) -> Vec<Effect> {
-    let msg = if count <= 1 {
+    let msg = if name == "log" && count > 1 {
+        format!("Copied {count} logs")
+    } else if count <= 1 {
         format!("Copied: {name}")
     } else {
         format!("Copied {count} links from {name}")
@@ -1306,6 +1308,8 @@ mod tests {
         let _ = handle_sources(&mut model, key('G'));
         assert_eq!(model.selected, 1);
         let _ = handle_sources(&mut model, key('g'));
+        assert_eq!(model.selected, 1); // a lone g is only a client-side prefix
+        let _ = handle_ipc_command(&mut model, crate::app::msg::IpcCommand::GoFirst);
         assert_eq!(model.selected, 0);
     }
 
@@ -1861,6 +1865,8 @@ mod tests {
         let _ = handle_routing_mode(&mut model, key('k'));
         assert_eq!(model.routing_selected, 1);
         let _ = handle_routing_mode(&mut model, key('g'));
+        assert_eq!(model.routing_selected, 1);
+        let _ = handle_ipc_command(&mut model, crate::app::msg::IpcCommand::GoFirst);
         assert_eq!(model.routing_selected, 0);
         let _ = handle_routing_mode(&mut model, key('G'));
         assert_eq!(model.routing_selected, 2);
@@ -1933,6 +1939,8 @@ mod tests {
         let _ = handle_geo_region(&mut model, key('k'));
         assert_eq!(model.geo_region_selected, 2);
         let _ = handle_geo_region(&mut model, key('g'));
+        assert_eq!(model.geo_region_selected, 2);
+        let _ = handle_ipc_command(&mut model, crate::app::msg::IpcCommand::GoFirst);
         assert_eq!(model.geo_region_selected, 0);
         let _ = handle_geo_region(&mut model, key('G'));
         assert_eq!(model.geo_region_selected, 3);
@@ -2579,6 +2587,8 @@ mod tests {
         let _ = handle_key(&mut model, key('G'));
         assert_eq!(model.selected, 1);
         let _ = handle_key(&mut model, key('g'));
+        assert_eq!(model.selected, 1);
+        let _ = handle_ipc_command(&mut model, crate::app::msg::IpcCommand::GoFirst);
         assert_eq!(model.selected, 0);
     }
 

--- a/src/app/update/key.rs
+++ b/src/app/update/key.rs
@@ -72,7 +72,6 @@ pub(super) fn handle_sources(model: &mut Model, key: KeyEvent) -> Vec<Effect> {
         // Navigation
         KeyCode::Char('j') | KeyCode::Down => model.select_next(),
         KeyCode::Char('k') | KeyCode::Up => model.select_prev(),
-        KeyCode::Char('g') => model.select_first(),
         KeyCode::Char('G') => model.select_last(),
 
         // Actions. Note: 'p' (paste) and 'e' (edit profiles) are handled in
@@ -454,6 +453,11 @@ pub(super) fn handle_ipc_command(
             }
             vec![]
         }
+        IpcCommand::SetMainPaneFocus { focus } => {
+            model.main_pane_focus = focus;
+            vec![]
+        }
+        IpcCommand::GoFirst => handle_go_first(model),
         IpcCommand::ConnectProfile { profile_id } => {
             queue_connect(model, profile_id);
             vec![]
@@ -472,6 +476,24 @@ pub(super) fn handle_ipc_command(
     };
     effects.push(Effect::BroadcastState);
     effects
+}
+
+fn handle_go_first(model: &mut Model) -> Vec<Effect> {
+    match model.overlay {
+        Overlay::None => model.select_first(),
+        Overlay::RoutingMode => crate::ui::nav::select_first(&mut model.routing_selected),
+        Overlay::GeoRegions => crate::ui::nav::select_first(&mut model.geo_region_selected),
+        Overlay::DnsSettings => crate::ui::nav::select_first(&mut model.dns_selected),
+        Overlay::ThemeSettings => {
+            crate::ui::nav::select_first(&mut model.theme_selected);
+            model.theme_draft = theme_picker_slugs().first().cloned();
+        }
+        Overlay::ServiceRouting => {
+            crate::ui::nav::select_first(&mut model.service_routing_selected);
+        }
+        Overlay::Help | Overlay::ConfirmDelete => {}
+    }
+    vec![]
 }
 
 pub(super) fn rebuild_key_event(
@@ -505,9 +527,6 @@ pub(super) fn handle_routing_mode(model: &mut Model, key: KeyEvent) -> Vec<Effec
         }
         KeyCode::Char('k') | KeyCode::Up => {
             crate::ui::nav::select_prev(&mut model.routing_selected);
-        }
-        KeyCode::Char('g') => {
-            crate::ui::nav::select_first(&mut model.routing_selected);
         }
         KeyCode::Char('G') => {
             crate::ui::nav::select_last(&mut model.routing_selected, available.len());
@@ -567,10 +586,6 @@ pub(super) fn handle_theme_picker(model: &mut Model, key: KeyEvent) -> Vec<Effec
             crate::ui::nav::select_prev(&mut model.theme_selected);
             model.theme_draft = slugs.get(model.theme_selected).cloned();
         }
-        KeyCode::Char('g') => {
-            crate::ui::nav::select_first(&mut model.theme_selected);
-            model.theme_draft = slugs.first().cloned();
-        }
         KeyCode::Char('G') => {
             crate::ui::nav::select_last(&mut model.theme_selected, slugs.len());
             model.theme_draft = slugs.get(model.theme_selected).cloned();
@@ -611,9 +626,6 @@ pub(super) fn handle_geo_region(model: &mut Model, key: KeyEvent) -> Vec<Effect>
         }
         KeyCode::Char('k') | KeyCode::Up => {
             crate::ui::nav::select_prev(&mut model.geo_region_selected);
-        }
-        KeyCode::Char('g') => {
-            crate::ui::nav::select_first(&mut model.geo_region_selected);
         }
         KeyCode::Char('G') => {
             crate::ui::nav::select_last(&mut model.geo_region_selected, regions.len());
@@ -762,7 +774,6 @@ pub(super) fn handle_dns_settings(model: &mut Model, key: KeyEvent) -> Vec<Effec
         KeyCode::Char('k') | KeyCode::Up => {
             crate::ui::nav::select_prev(&mut model.dns_selected);
         }
-        KeyCode::Char('g') => crate::ui::nav::select_first(&mut model.dns_selected),
         KeyCode::Char('G') => crate::ui::nav::select_last(&mut model.dns_selected, len),
         KeyCode::Char('l') | KeyCode::Right if on_strategy => {
             let base = model
@@ -993,7 +1004,6 @@ pub(super) fn handle_service_routing(model: &mut Model, key: KeyEvent) -> Vec<Ef
         KeyCode::Char('k') | KeyCode::Up => {
             crate::ui::nav::select_prev(&mut model.service_routing_selected);
         }
-        KeyCode::Char('g') => crate::ui::nav::select_first(&mut model.service_routing_selected),
         KeyCode::Char('G') => crate::ui::nav::select_last(&mut model.service_routing_selected, len),
         KeyCode::Char('l') | KeyCode::Right | KeyCode::Char('h') | KeyCode::Left => {
             let Some(service) = RoutedService::ALL
@@ -1190,6 +1200,8 @@ mod tests {
         handle_dns_settings(&mut model, key('G'));
         assert_eq!(model.dns_selected, DnsSettingsItem::ALL.len() - 1);
         handle_dns_settings(&mut model, key('g'));
+        assert_eq!(model.dns_selected, DnsSettingsItem::ALL.len() - 1);
+        handle_go_first(&mut model);
         assert_eq!(model.dns_selected, 0);
     }
 
@@ -1783,6 +1795,23 @@ mod tests {
     }
 
     #[test]
+    fn ipc_command_updates_session_pane_focus() {
+        use crate::app::model::MainPaneFocus;
+
+        let mut model = model_with_profiles(vec![]);
+        assert_eq!(model.main_pane_focus, MainPaneFocus::Sources);
+
+        let effects = handle_ipc_command(
+            &mut model,
+            crate::app::msg::IpcCommand::SetMainPaneFocus {
+                focus: MainPaneFocus::Logs,
+            },
+        );
+        assert_eq!(model.main_pane_focus, MainPaneFocus::Logs);
+        assert_eq!(effects, vec![Effect::BroadcastState]);
+    }
+
+    #[test]
     fn ipc_command_quit_emits_quit_then_broadcast() {
         let mut model = model_with_profiles(vec![]);
         let effects = handle_ipc_command(&mut model, crate::app::msg::IpcCommand::Quit);
@@ -1817,6 +1846,19 @@ mod tests {
     }
 
     #[test]
+    fn ipc_multi_log_copy_uses_log_count_in_status() {
+        let mut model = model_with_profiles(vec![]);
+        handle_ipc_command(
+            &mut model,
+            crate::app::msg::IpcCommand::Copied {
+                name: "log".into(),
+                count: 3,
+            },
+        );
+        assert_eq!(model.status.text(), "Copied 3 logs");
+    }
+
+    #[test]
     fn ipc_command_key_with_unknown_code_only_broadcasts() {
         let mut model = model_with_profiles(vec![]);
         let effects = handle_ipc_command(
@@ -1828,6 +1870,65 @@ mod tests {
             },
         );
         assert_eq!(effects, vec![Effect::BroadcastState]);
+    }
+
+    #[test]
+    fn ipc_go_first_dispatches_to_sources_and_selectable_overlays() {
+        let mut model = model_with_profiles(vec![
+            crate::config::profile::Profile::new_vless(
+                "A".into(),
+                "1.1.1.1".into(),
+                443,
+                "u1".into(),
+            ),
+            crate::config::profile::Profile::new_vless(
+                "B".into(),
+                "2.2.2.2".into(),
+                443,
+                "u2".into(),
+            ),
+        ]);
+        model.selected = 1;
+        handle_ipc_command(&mut model, crate::app::msg::IpcCommand::GoFirst);
+        assert_eq!(model.selected, 0);
+
+        model.overlay = Overlay::RoutingMode;
+        model.routing_selected = 2;
+        handle_ipc_command(&mut model, crate::app::msg::IpcCommand::GoFirst);
+        assert_eq!(model.routing_selected, 0);
+
+        model.overlay = Overlay::GeoRegions;
+        model.geo_region_selected = 3;
+        handle_ipc_command(&mut model, crate::app::msg::IpcCommand::GoFirst);
+        assert_eq!(model.geo_region_selected, 0);
+
+        model.overlay = Overlay::DnsSettings;
+        model.dns_selected = DnsSettingsItem::ALL.len() - 1;
+        handle_ipc_command(&mut model, crate::app::msg::IpcCommand::GoFirst);
+        assert_eq!(model.dns_selected, 0);
+
+        model.overlay = Overlay::ThemeSettings;
+        model.theme_selected = theme_picker_slugs().len().saturating_sub(1);
+        handle_ipc_command(&mut model, crate::app::msg::IpcCommand::GoFirst);
+        assert_eq!(model.theme_selected, 0);
+        assert_eq!(model.theme_draft, theme_picker_slugs().first().cloned());
+
+        model.overlay = Overlay::ServiceRouting;
+        model.service_routing_selected = 1;
+        handle_ipc_command(&mut model, crate::app::msg::IpcCommand::GoFirst);
+        assert_eq!(model.service_routing_selected, 0);
+    }
+
+    #[test]
+    fn ipc_go_first_is_noop_for_non_selectable_overlays() {
+        let mut model = model_with_profiles(vec![]);
+        model.routing_selected = 2;
+        for overlay in [Overlay::Help, Overlay::ConfirmDelete] {
+            model.overlay = overlay;
+            handle_ipc_command(&mut model, crate::app::msg::IpcCommand::GoFirst);
+            assert_eq!(model.overlay, overlay);
+            assert_eq!(model.routing_selected, 2);
+        }
     }
 
     // ---- handle_service_routing ----
@@ -1870,6 +1971,8 @@ mod tests {
         handle_service_routing(&mut model, key('G'));
         assert_eq!(model.service_routing_selected, RoutedService::ALL.len() - 1);
         handle_service_routing(&mut model, key('g'));
+        assert_eq!(model.service_routing_selected, RoutedService::ALL.len() - 1);
+        handle_go_first(&mut model);
         assert_eq!(model.service_routing_selected, 0);
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 
 use crate::app::effect::Effect;
 use crate::app::model::{AppStatus, ConnectionState, Model, Overlay, TrafficStats};
-use crate::app::msg::{GeoResult, IpcCommand, Msg, StateSnapshot};
+use crate::app::msg::{GeoResult, IpcCommand, LogSessionOffsets, Msg, StateSnapshot};
 use crate::app::update::update;
 use crate::ipc::{IpcServer, cleanup_socket};
 use crate::singbox::process_handle::ProcessHandle;
@@ -21,6 +21,10 @@ struct ProcessSlot {
 
 /// Run the daemon main loop.
 pub fn run(mut model: Model) -> Result<()> {
+    let log_session_offsets = LogSessionOffsets {
+        app: log_file_len(crate::paths::app_log_path()),
+        singbox: log_file_len(crate::paths::singbox_log_path()),
+    };
     let (tx, rx) = channel::<Msg>();
     let ipc_server = IpcServer::bind(tx.clone())?;
 
@@ -45,6 +49,7 @@ pub fn run(mut model: Model) -> Result<()> {
         process_slot.clone(),
         connect_coordinator.clone(),
         &ipc_server,
+        log_session_offsets,
     );
 
     // Cleanup
@@ -73,6 +78,7 @@ fn run_loop(
     process_slot: Arc<Mutex<ProcessSlot>>,
     connect_coordinator: Arc<Mutex<()>>,
     ipc_server: &IpcServer,
+    log_session_offsets: LogSessionOffsets,
 ) -> Result<()> {
     loop {
         let msg = rx.recv()?;
@@ -110,7 +116,7 @@ fn run_loop(
         }
 
         if should_broadcast {
-            ipc_server.broadcast(&build_snapshot(model));
+            ipc_server.broadcast(&build_snapshot(model, log_session_offsets));
         }
     }
     Ok(())
@@ -1019,7 +1025,7 @@ fn dns_bootstrap_endpoints(
         .collect()
 }
 
-fn build_snapshot(model: &Model) -> StateSnapshot {
+fn build_snapshot(model: &Model, log_session_offsets: LogSessionOffsets) -> StateSnapshot {
     StateSnapshot {
         connection: model.connection,
         status: model.status.text().to_string(),
@@ -1039,10 +1045,12 @@ fn build_snapshot(model: &Model) -> StateSnapshot {
         geo_updating: model.geo_updating,
         geo_last_updated: model.geo_last_updated.clone(),
         overlay: model.overlay,
+        main_pane_focus: model.main_pane_focus,
         profiles: model.config.profiles.clone(),
         subscriptions: model.config.subscriptions.clone(),
         settings: model.config.settings.clone(),
         traffic: model.traffic.clone(),
+        log_session_offsets: Some(log_session_offsets),
         profile_latencies: model
             .profile_latencies
             .iter()
@@ -1054,6 +1062,12 @@ fn build_snapshot(model: &Model) -> StateSnapshot {
             .map(|id| id.to_string())
             .collect(),
     }
+}
+
+fn log_file_len(path: std::path::PathBuf) -> u64 {
+    std::fs::metadata(path)
+        .map(|metadata| metadata.len())
+        .unwrap_or(0)
 }
 
 fn spawn_ticker(tx: Sender<Msg>, process_slot: Weak<Mutex<ProcessSlot>>) {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -242,10 +242,12 @@ mod tests {
             geo_updating: false,
             geo_last_updated: None,
             overlay: Overlay::None,
+            main_pane_focus: Default::default(),
             profiles: vec![],
             subscriptions: vec![],
             settings: Settings::default(),
             traffic: TrafficStats::default(),
+            log_session_offsets: None,
             profile_latencies: Default::default(),
             testing_profiles: Default::default(),
         }

--- a/src/services/log_tailer.rs
+++ b/src/services/log_tailer.rs
@@ -67,19 +67,7 @@ impl LogTailer {
                     if line.trim().is_empty() {
                         continue;
                     }
-                    let parsed = parse_timestamp(&line);
-                    let formatted = if let Some((dt, prefix_len)) = parsed {
-                        let remainder = line.get(prefix_len..).unwrap_or_default();
-                        format!("{} {}{}", tag, dt.format("%H:%M:%S"), remainder)
-                    } else {
-                        format!("{} {}", tag, line)
-                    };
-                    let sort_key = parsed.map(|(dt, _)| dt).unwrap_or_else(|| {
-                        FixedOffset::east_opt(0)
-                            .unwrap()
-                            .from_utc_datetime(&Local::now().naive_local())
-                    });
-                    entries.push((sort_key, formatted));
+                    entries.push(format_entry(&line, tag));
                 }
                 if let Ok(new_pos) = reader.stream_position() {
                     *pos = new_pos;
@@ -90,6 +78,92 @@ impl LogTailer {
         entries.sort_by_key(|a| a.0);
         entries.into_iter().map(|(_, line)| line).collect()
     }
+
+    /// Load at most `max_lines` entries written since the supplied byte
+    /// offsets, then continue tailing from the current ends of the files.
+    /// A truncated/rotated file starts at byte zero for the new session.
+    pub fn load_history(&mut self, start_positions: &[u64], max_lines: usize) -> Vec<String> {
+        if max_lines == 0 {
+            return Vec::new();
+        }
+
+        let mut entries = Vec::new();
+        for (index, (path, tag, pos)) in self.files.iter_mut().enumerate() {
+            let Ok(mut file) = File::open(path) else {
+                continue;
+            };
+            let Ok(metadata) = file.metadata() else {
+                continue;
+            };
+            let file_len = metadata.len();
+            let requested_start = start_positions.get(index).copied().unwrap_or(file_len);
+            let start = if requested_start <= file_len {
+                requested_start
+            } else {
+                0
+            };
+
+            for line in read_last_lines(&mut file, start, file_len, max_lines) {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                entries.push(format_entry(&line, tag));
+            }
+            *pos = file_len;
+        }
+
+        entries.sort_by_key(|entry| entry.0);
+        let keep_from = entries.len().saturating_sub(max_lines);
+        entries
+            .into_iter()
+            .skip(keep_from)
+            .map(|(_, line)| line)
+            .collect()
+    }
+}
+
+fn format_entry(line: &str, tag: &str) -> (DateTime<FixedOffset>, String) {
+    let parsed = parse_timestamp(line);
+    let formatted = if let Some((dt, prefix_len)) = parsed {
+        let remainder = line.get(prefix_len..).unwrap_or_default();
+        format!("{} {}{}", tag, dt.format("%H:%M:%S"), remainder)
+    } else {
+        format!("{} {}", tag, line)
+    };
+    let sort_key = parsed.map(|(dt, _)| dt).unwrap_or_else(|| {
+        FixedOffset::east_opt(0)
+            .unwrap()
+            .from_utc_datetime(&Local::now().naive_local())
+    });
+    (sort_key, formatted)
+}
+
+fn read_last_lines(file: &mut File, start: u64, end: u64, limit: usize) -> Vec<String> {
+    const CHUNK_SIZE: u64 = 8 * 1024;
+
+    let mut cursor = end;
+    let mut newline_count = 0;
+    let mut chunks = Vec::new();
+    while cursor > start && newline_count <= limit {
+        let chunk_start = cursor.saturating_sub(CHUNK_SIZE).max(start);
+        let mut chunk = vec![0; (cursor - chunk_start) as usize];
+        if file.seek(SeekFrom::Start(chunk_start)).is_err() || file.read_exact(&mut chunk).is_err()
+        {
+            return Vec::new();
+        }
+        newline_count += chunk.iter().filter(|byte| **byte == b'\n').count();
+        chunks.push(chunk);
+        cursor = chunk_start;
+    }
+
+    chunks.reverse();
+    let bytes = chunks.concat();
+    let text = String::from_utf8_lossy(&bytes);
+    let lines: Vec<_> = text.lines().collect();
+    lines[lines.len().saturating_sub(limit)..]
+        .iter()
+        .map(|line| line.trim_end_matches('\r').to_string())
+        .collect()
 }
 
 /// Parse a sing-box style timestamp from the start of a line.
@@ -190,6 +264,57 @@ mod tests {
         assert!(lines[1].starts_with("[app] 00:00:02"));
         assert!(lines[2].starts_with("[sb] 00:00:03"));
         assert!(lines[3].starts_with("[app] 00:00:04"));
+    }
+
+    #[test]
+    fn history_starts_at_daemon_offsets_and_keeps_global_tail() {
+        let mut app = tempfile::NamedTempFile::new().unwrap();
+        let mut singbox = tempfile::NamedTempFile::new().unwrap();
+        writeln!(app, "+0000 2024-01-01 00:00:00 INFO old app").unwrap();
+        writeln!(singbox, "+0000 2024-01-01 00:00:00 INFO old sing-box").unwrap();
+        app.flush().unwrap();
+        singbox.flush().unwrap();
+        let offsets = [
+            app.as_file().metadata().unwrap().len(),
+            singbox.as_file().metadata().unwrap().len(),
+        ];
+
+        writeln!(app, "+0000 2024-01-01 00:00:01 INFO app one").unwrap();
+        writeln!(singbox, "+0000 2024-01-01 00:00:02 INFO sb two").unwrap();
+        writeln!(app, "+0000 2024-01-01 00:00:03 INFO app three").unwrap();
+        writeln!(singbox, "+0000 2024-01-01 00:00:04 INFO sb four").unwrap();
+        app.flush().unwrap();
+        singbox.flush().unwrap();
+
+        let mut tailer = LogTailer::new(vec![
+            (app.path().to_path_buf(), "[app]"),
+            (singbox.path().to_path_buf(), "[sb]"),
+        ]);
+        assert_eq!(
+            tailer.load_history(&offsets, 3),
+            vec![
+                "[sb] 00:00:02 INFO sb two",
+                "[app] 00:00:03 INFO app three",
+                "[sb] 00:00:04 INFO sb four",
+            ]
+        );
+
+        writeln!(app, "+0000 2024-01-01 00:00:05 INFO appended").unwrap();
+        app.flush().unwrap();
+        assert_eq!(tailer.tail(), vec!["[app] 00:00:05 INFO appended"]);
+    }
+
+    #[test]
+    fn history_reads_rotated_file_from_its_new_start() {
+        let mut temp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(temp, "+0000 2024-01-01 00:00:01 INFO new session").unwrap();
+        temp.flush().unwrap();
+
+        let mut tailer = LogTailer::new(vec![(temp.path().to_path_buf(), "[app]")]);
+        assert_eq!(
+            tailer.load_history(&[u64::MAX], 1000),
+            vec!["[app] 00:00:01 INFO new session"]
+        );
     }
 
     #[test]

--- a/src/tui_client.rs
+++ b/src/tui_client.rs
@@ -5,7 +5,7 @@ pub(crate) mod theme_watch;
 
 use std::io::{self, IsTerminal, Write};
 use std::sync::Arc;
-use std::sync::mpsc::{Sender, channel};
+use std::sync::mpsc::{Receiver, Sender, channel};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -46,6 +46,29 @@ const DOUBLE_CLICK_INTERVAL: Duration = Duration::from_millis(300);
 
 #[derive(Default)]
 struct ClickTracker(Option<(uuid::Uuid, Instant)>);
+
+#[derive(Debug, Default)]
+struct GoFirstSequence {
+    pending: bool,
+}
+
+impl GoFirstSequence {
+    /// Consume one key and report whether it completes a consecutive `gg`.
+    /// Any non-g key cancels a pending prefix before continuing normally.
+    fn feed(&mut self, code: &crossterm::event::KeyCode) -> bool {
+        if *code != crossterm::event::KeyCode::Char('g') {
+            self.pending = false;
+            return false;
+        }
+        if self.pending {
+            self.pending = false;
+            true
+        } else {
+            self.pending = true;
+            false
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 enum PointerShape {
@@ -146,17 +169,18 @@ pub fn run() -> Result<()> {
     theme_watch::spawn_theme_watcher(tx.clone());
     client.spawn_reader(tx.clone())?;
 
+    let mut log_tailer = LogTailer::new(vec![
+        (crate::paths::app_log_path(), "[app]"),
+        (crate::paths::singbox_log_path(), "[sb]"),
+    ]);
+    receive_initial_state(&rx, &mut model, &mut log_tailer)?;
+
     let _terminal_session = TerminalSession::enter()?;
     apply_terminal_bg(model.theme.palette_background());
     let stdout = io::stdout();
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
     input::spawn_event_reader(tx, event_reader_control.clone());
-
-    let mut log_tailer = LogTailer::new(vec![
-        (crate::paths::app_log_path(), "[app]"),
-        (crate::paths::singbox_log_path(), "[sb]"),
-    ]);
 
     run_loop(
         &mut terminal,
@@ -168,6 +192,35 @@ pub fn run() -> Result<()> {
     )
 }
 
+fn receive_initial_state(
+    rx: &Receiver<Msg>,
+    model: &mut Model,
+    log_tailer: &mut LogTailer,
+) -> Result<()> {
+    loop {
+        match rx.recv()? {
+            Msg::StateUpdate(snapshot) => {
+                if let Some(offsets) = snapshot.log_session_offsets {
+                    for line in log_tailer.load_history(
+                        &[offsets.app, offsets.singbox],
+                        crate::app::model::MAX_LOG_LINES,
+                    ) {
+                        model.push_log(line);
+                    }
+                }
+                apply_snapshot(model, *snapshot);
+                return Ok(());
+            }
+            Msg::ThemeChanged(theme)
+                if model.config.settings.theme == theme_watch::OMARCHY_SENTINEL =>
+            {
+                model.theme = theme;
+            }
+            _ => {}
+        }
+    }
+}
+
 fn run_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     model: &mut Model,
@@ -176,6 +229,12 @@ fn run_loop(
     log_tailer: &mut LogTailer,
     event_reader_control: Arc<input::EventReaderControl>,
 ) -> Result<()> {
+    use crate::app::model::MainPaneFocus;
+    use crate::ui::layout::LogNavigation;
+
+    let mut pane_focus = model.main_pane_focus;
+    let mut log_navigation = LogNavigation::default();
+    let mut go_first_sequence = GoFirstSequence::default();
     // Initial draw
     terminal.draw(|f| crate::ui::draw(f, model))?;
     let mut pointer_shape = PointerShape::Default;
@@ -199,19 +258,31 @@ fn run_loop(
                         log_selection = None;
                         log_dragging = false;
                         let area: ratatui::layout::Rect = terminal.size()?.into();
-                        if let Some(selection) = crate::ui::layout::log_viewport(model, area)
-                            .and_then(|viewport| {
-                                crate::ui::layout::LogSelection::start(
-                                    viewport,
-                                    mouse.column,
-                                    mouse.row,
-                                )
-                            })
-                        {
+                        if let Some(selection) = crate::ui::layout::log_viewport_with_navigation(
+                            model,
+                            area,
+                            Some(&log_navigation),
+                        )
+                        .and_then(|viewport| {
+                            crate::ui::layout::LogSelection::start(
+                                viewport,
+                                mouse.column,
+                                mouse.row,
+                            )
+                        }) {
+                            pane_focus = MainPaneFocus::Logs;
+                            client.send(&IpcCommand::SetMainPaneFocus {
+                                focus: MainPaneFocus::Logs,
+                            })?;
+                            log_navigation.clear();
                             click_tracker.reset();
                             log_selection = Some(selection);
                             log_dragging = true;
                         } else if let Some(index) = hit {
+                            pane_focus = MainPaneFocus::Sources;
+                            client.send(&IpcCommand::SetMainPaneFocus {
+                                focus: MainPaneFocus::Sources,
+                            })?;
                             client.send(&IpcCommand::SelectSource { index })?;
                             model.selected = index;
                             let profile_id = match model.source_rows()[index] {
@@ -229,6 +300,12 @@ fn run_loop(
                             } else if profile_id.is_none() {
                                 click_tracker.reset();
                             }
+                        } else if pointer_shape == PointerShape::Logs {
+                            pane_focus = MainPaneFocus::Logs;
+                            client.send(&IpcCommand::SetMainPaneFocus {
+                                focus: MainPaneFocus::Logs,
+                            })?;
+                            click_tracker.reset();
                         } else {
                             click_tracker.reset();
                         }
@@ -266,6 +343,7 @@ fn run_loop(
             }
             Msg::Key(key) => {
                 use crossterm::event::{KeyCode, KeyModifiers};
+                let completes_gg = go_first_sequence.feed(&key.code);
                 let mut forward_key = || {
                     let (code, ch) = match key.code {
                         KeyCode::Char(c) => ("Char".to_string(), Some(c)),
@@ -279,24 +357,150 @@ fn run_loop(
                     })
                 };
                 match key.code {
+                    KeyCode::Char('g') => {
+                        if completes_gg {
+                            if model.overlay == crate::app::model::Overlay::None
+                                && pane_focus == MainPaneFocus::Logs
+                            {
+                                log_navigation.select_buffer_edge(
+                                    model.logs.len(),
+                                    true,
+                                    Instant::now(),
+                                );
+                            } else {
+                                client.send(&IpcCommand::GoFirst)?;
+                            }
+                        }
+                        needs_redraw = true;
+                    }
                     KeyCode::Char('q') | KeyCode::Esc => {
-                        if model.overlay == crate::app::model::Overlay::None {
+                        if key.code == KeyCode::Esc
+                            && model.overlay == crate::app::model::Overlay::None
+                            && pane_focus == MainPaneFocus::Logs
+                            && log_navigation.is_visual()
+                        {
+                            log_navigation.cancel_visual();
+                            needs_redraw = true;
+                        } else if model.overlay == crate::app::model::Overlay::None {
                             client.send(&IpcCommand::Detach)?;
                             break;
+                        } else {
+                            forward_key()?;
                         }
-                        forward_key()?;
                     }
                     KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                         let _ = client.send(&IpcCommand::Quit);
                         std::thread::sleep(Duration::from_millis(300));
                         break;
                     }
+                    KeyCode::Char('h') if model.overlay == crate::app::model::Overlay::None => {
+                        pane_focus = MainPaneFocus::Sources;
+                        client.send(&IpcCommand::SetMainPaneFocus {
+                            focus: MainPaneFocus::Sources,
+                        })?;
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char('l') if model.overlay == crate::app::model::Overlay::None => {
+                        pane_focus = MainPaneFocus::Logs;
+                        client.send(&IpcCommand::SetMainPaneFocus {
+                            focus: MainPaneFocus::Logs,
+                        })?;
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char('j') | KeyCode::Down
+                        if model.overlay == crate::app::model::Overlay::None
+                            && pane_focus == MainPaneFocus::Logs =>
+                    {
+                        let area: ratatui::layout::Rect = terminal.size()?.into();
+                        let now = Instant::now();
+                        if log_navigation.cursor().is_none() {
+                            if let Some(viewport) = crate::ui::layout::log_viewport_with_navigation(
+                                model,
+                                area,
+                                Some(&log_navigation),
+                            ) {
+                                log_navigation.select_edge(&viewport, true, now);
+                            }
+                        } else {
+                            crate::ui::layout::sync_log_scroll(model, area, &mut log_navigation);
+                            log_navigation.move_by(1, model.logs.len(), now);
+                        }
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char('k') | KeyCode::Up
+                        if model.overlay == crate::app::model::Overlay::None
+                            && pane_focus == MainPaneFocus::Logs =>
+                    {
+                        let area: ratatui::layout::Rect = terminal.size()?.into();
+                        let now = Instant::now();
+                        if log_navigation.cursor().is_none() {
+                            if let Some(viewport) = crate::ui::layout::log_viewport_with_navigation(
+                                model,
+                                area,
+                                Some(&log_navigation),
+                            ) {
+                                log_navigation.select_edge(&viewport, false, now);
+                            }
+                        } else {
+                            crate::ui::layout::sync_log_scroll(model, area, &mut log_navigation);
+                            log_navigation.move_by(-1, model.logs.len(), now);
+                        }
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char('G')
+                        if model.overlay == crate::app::model::Overlay::None
+                            && pane_focus == MainPaneFocus::Logs =>
+                    {
+                        log_navigation.select_buffer_edge(model.logs.len(), false, Instant::now());
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char('V')
+                        if model.overlay == crate::app::model::Overlay::None
+                            && pane_focus == MainPaneFocus::Logs =>
+                    {
+                        let now = Instant::now();
+                        if log_navigation.cursor().is_none() {
+                            let area: ratatui::layout::Rect = terminal.size()?.into();
+                            if let Some(viewport) = crate::ui::layout::log_viewport_with_navigation(
+                                model,
+                                area,
+                                Some(&log_navigation),
+                            ) {
+                                log_navigation.select_edge(&viewport, true, now);
+                            }
+                        }
+                        log_navigation.enter_visual(now);
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char('y')
+                        if model.overlay == crate::app::model::Overlay::None
+                            && pane_focus == MainPaneFocus::Logs =>
+                    {
+                        if let Some((text, count)) = log_navigation.selected_text(model) {
+                            match self::clipboard::write_clipboard_text(&text) {
+                                Ok(()) => {
+                                    log_navigation.copied(Instant::now());
+                                    client.send(&IpcCommand::Copied {
+                                        name: "log".into(),
+                                        count,
+                                    })?;
+                                }
+                                Err(error) => client.send(&IpcCommand::ClientError {
+                                    message: format!("Failed to copy log text: {error:#}"),
+                                })?,
+                            }
+                        }
+                        needs_redraw = true;
+                    }
                     KeyCode::Char('p') => {
                         if let Ok(text) = self::clipboard::read_clipboard_text() {
                             client.send(&IpcCommand::Paste { text })?;
                         }
                     }
-                    KeyCode::Char('y') if model.overlay == crate::app::model::Overlay::None => {
+                    KeyCode::Char('y')
+                        if model.overlay == crate::app::model::Overlay::None
+                            && pane_focus == MainPaneFocus::Sources =>
+                    {
                         if let Some(profile) = model.selected_profile() {
                             if let Ok(link) = crate::config::profile::encode_share_link(profile)
                                 && self::clipboard::write_clipboard_text(&link).is_ok()
@@ -368,6 +572,7 @@ fn run_loop(
                 }
             }
             Msg::StateUpdate(snapshot) => {
+                pane_focus = snapshot.main_pane_focus;
                 apply_snapshot(model, *snapshot);
                 if model.overlay != crate::app::model::Overlay::None {
                     log_selection = None;
@@ -377,11 +582,15 @@ fn run_loop(
                 needs_redraw = true;
             }
             Msg::Tick => {
+                log_navigation.expire_if_idle(Instant::now());
                 let new_lines = log_tailer.tail();
                 if !new_lines.is_empty() && !log_dragging {
                     log_selection = None;
                 }
                 for line in new_lines {
+                    if model.logs.len() == crate::app::model::MAX_LOG_LINES {
+                        log_navigation.oldest_log_evicted();
+                    }
                     model.push_log(line);
                 }
                 needs_redraw = true;
@@ -407,7 +616,13 @@ fn run_loop(
 
         if needs_redraw {
             terminal.draw(|f| {
-                crate::ui::layout::draw_with_log_selection(f, model, log_selection.as_ref())
+                crate::ui::layout::draw_with_interaction(
+                    f,
+                    model,
+                    pane_focus,
+                    Some(&log_navigation),
+                    log_selection.as_ref(),
+                )
             })?;
         }
     }
@@ -461,6 +676,7 @@ fn apply_snapshot(model: &mut Model, snapshot: crate::app::msg::StateSnapshot) {
         .active_profile_id
         .and_then(|s| uuid::Uuid::parse_str(&s).ok());
     model.selected = snapshot.selected;
+    model.main_pane_focus = snapshot.main_pane_focus;
     model.routing_selected = snapshot.routing_selected;
     model.geo_region_selected = snapshot.geo_region_selected;
     model.dns_selected = snapshot.dns_selected;
@@ -546,6 +762,27 @@ mod tests {
         assert!(!tracker.profile_pressed(first, start));
         assert!(!tracker.profile_pressed(other, start + Duration::from_millis(100)));
         assert!(!tracker.profile_pressed(other, start + Duration::from_millis(401)));
+    }
+
+    #[test]
+    fn go_first_sequence_requires_two_consecutive_g_keys() {
+        use crossterm::event::KeyCode;
+
+        let mut sequence = GoFirstSequence::default();
+        assert!(!sequence.feed(&KeyCode::Char('g')));
+        assert!(sequence.feed(&KeyCode::Char('g')));
+        assert!(!sequence.feed(&KeyCode::Char('g')));
+    }
+
+    #[test]
+    fn go_first_sequence_is_cancelled_by_another_key() {
+        use crossterm::event::KeyCode;
+
+        let mut sequence = GoFirstSequence::default();
+        assert!(!sequence.feed(&KeyCode::Char('g')));
+        assert!(!sequence.feed(&KeyCode::Char('j')));
+        assert!(!sequence.feed(&KeyCode::Char('g')));
+        assert!(sequence.feed(&KeyCode::Char('g')));
     }
 
     #[test]

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -3,9 +3,10 @@ use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Row, Table, Wrap};
+use std::time::{Duration, Instant};
 use unicode_width::UnicodeWidthChar;
 
-use crate::app::model::{Model, Overlay, SourceRow};
+use crate::app::model::{MainPaneFocus, Model, Overlay, SourceRow};
 use crate::ui::styles::Theme;
 use crate::ui::widgets::{
     StatusBar, format_bps_field, format_bytes_field, format_connections_field,
@@ -16,6 +17,138 @@ use crate::ui::widgets::{
 /// the very top of the UI when the VPN is connected. One content row plus
 /// top/bottom borders = 3 lines.
 const TRAFFIC_PANEL_HEIGHT: u16 = 3;
+
+pub(crate) const LOG_CURSOR_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// TUI-client-local keyboard state for the log pane. Log contents are local
+/// to the client as well, so none of this belongs in the daemon snapshot.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct LogNavigation {
+    cursor: Option<usize>,
+    anchor: Option<usize>,
+    scroll_top_log: Option<usize>,
+    last_activity: Option<Instant>,
+}
+
+impl LogNavigation {
+    pub(crate) fn cursor(&self) -> Option<usize> {
+        self.cursor
+    }
+
+    pub(crate) fn is_visual(&self) -> bool {
+        self.anchor.is_some()
+    }
+
+    pub(crate) fn select_edge(&mut self, viewport: &LogViewport, from_top: bool, now: Instant) {
+        let cursor = if from_top {
+            viewport.first_log_index()
+        } else {
+            viewport.last_log_index()
+        };
+        if let Some(cursor) = cursor {
+            self.cursor = Some(cursor);
+            self.scroll_top_log = viewport.first_log_index();
+            self.last_activity = Some(now);
+        }
+    }
+
+    pub(crate) fn select_buffer_edge(&mut self, log_count: usize, from_top: bool, now: Instant) {
+        if log_count == 0 {
+            return;
+        }
+        let cursor = if from_top { 0 } else { log_count - 1 };
+        self.cursor = Some(cursor);
+        self.scroll_top_log = Some(cursor);
+        self.last_activity = Some(now);
+    }
+
+    pub(crate) fn move_by(&mut self, delta: isize, log_count: usize, now: Instant) {
+        let Some(cursor) = self.cursor else {
+            return;
+        };
+        if log_count == 0 {
+            self.clear();
+            return;
+        }
+        self.cursor = Some(cursor.saturating_add_signed(delta).min(log_count - 1));
+        self.last_activity = Some(now);
+    }
+
+    pub(crate) fn enter_visual(&mut self, now: Instant) {
+        if let Some(cursor) = self.cursor {
+            self.anchor = Some(cursor);
+            self.last_activity = Some(now);
+        }
+    }
+
+    pub(crate) fn cancel_visual(&mut self) {
+        self.anchor = None;
+    }
+
+    pub(crate) fn selected_range(&self) -> Option<std::ops::RangeInclusive<usize>> {
+        let cursor = self.cursor?;
+        let anchor = self.anchor.unwrap_or(cursor);
+        Some(anchor.min(cursor)..=anchor.max(cursor))
+    }
+
+    pub(crate) fn selected_text(&self, model: &Model) -> Option<(String, usize)> {
+        let range = self.selected_range()?;
+        let lines = range
+            .clone()
+            .filter_map(|index| model.logs.get(index))
+            .cloned()
+            .collect::<Vec<_>>();
+        (!lines.is_empty()).then(|| (lines.join("\n"), lines.len()))
+    }
+
+    pub(crate) fn copied(&mut self, now: Instant) {
+        self.anchor = None;
+        self.last_activity = Some(now);
+    }
+
+    pub(crate) fn expire_if_idle(&mut self, now: Instant) -> bool {
+        if self
+            .last_activity
+            .is_some_and(|last| now.saturating_duration_since(last) >= LOG_CURSOR_TIMEOUT)
+        {
+            self.clear();
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn oldest_log_evicted(&mut self) {
+        if self.cursor == Some(0) {
+            self.clear();
+            return;
+        }
+        self.cursor = self.cursor.map(|index| index - 1);
+        self.anchor = self.anchor.and_then(|index| index.checked_sub(1));
+        self.scroll_top_log = self
+            .scroll_top_log
+            .and_then(|index| index.checked_sub(1))
+            .or(Some(0));
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.cursor = None;
+        self.anchor = None;
+        self.scroll_top_log = None;
+        self.last_activity = None;
+    }
+
+    fn contains(&self, log_index: usize) -> bool {
+        self.selected_range()
+            .is_some_and(|range| range.contains(&log_index))
+    }
+
+    fn set_scroll_top_from(&mut self, viewport: &LogViewport) {
+        if self.cursor.is_some() {
+            self.scroll_top_log = viewport.first_log_index();
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct LogPoint {
@@ -28,6 +161,7 @@ struct LogDisplayRow {
     text: String,
     hard_break_after: bool,
     error: bool,
+    log_index: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -134,14 +268,22 @@ impl LogViewport {
             column: column.saturating_sub(self.area.x).min(max_column),
         }
     }
+
+    fn first_log_index(&self) -> Option<usize> {
+        self.rows.first().map(|row| row.log_index)
+    }
+
+    fn last_log_index(&self) -> Option<usize> {
+        self.rows.last().map(|row| row.log_index)
+    }
 }
 
-fn build_log_viewport(model: &Model, area: Rect) -> LogViewport {
+fn build_all_log_rows(model: &Model, width: usize) -> Vec<LogDisplayRow> {
     let mut rows = Vec::new();
-    if area.width > 0 {
-        for line in &model.logs {
+    if width > 0 {
+        for (log_index, line) in model.logs.iter().enumerate() {
             let error = line.starts_with("[error]");
-            let wrapped = wrap_log_line(line, area.width as usize);
+            let wrapped = wrap_log_line(line, width);
             let last = wrapped.len().saturating_sub(1);
             rows.extend(
                 wrapped
@@ -151,14 +293,51 @@ fn build_log_viewport(model: &Model, area: Rect) -> LogViewport {
                         text,
                         hard_break_after: index == last,
                         error,
+                        log_index,
                     }),
             );
         }
     }
+    rows
+}
+
+fn build_log_viewport(
+    model: &Model,
+    area: Rect,
+    navigation: Option<&LogNavigation>,
+) -> LogViewport {
+    let all_rows = build_all_log_rows(model, area.width as usize);
     let keep = area.height as usize;
-    if rows.len() > keep {
-        rows.drain(..rows.len() - keep);
+    let auto_start = all_rows.len().saturating_sub(keep);
+    let mut start = navigation
+        .and_then(|nav| nav.cursor.map(|_| nav.scroll_top_log.unwrap_or(0)))
+        .and_then(|top_log| all_rows.iter().position(|row| row.log_index == top_log))
+        .unwrap_or(auto_start);
+
+    if let Some(cursor) = navigation.and_then(LogNavigation::cursor)
+        && let Some(first) = all_rows.iter().position(|row| row.log_index == cursor)
+    {
+        let last = all_rows
+            .iter()
+            .rposition(|row| row.log_index == cursor)
+            .unwrap_or(first);
+        if first < start {
+            start = first;
+        } else if last >= start.saturating_add(keep) {
+            let candidate = last.saturating_add(1).saturating_sub(keep);
+            // Prefer the first complete record boundary that still keeps
+            // the cursor visible. This prevents a wrapped log from becoming
+            // several keyboard navigation positions.
+            start = (candidate..=first)
+                .find(|&index| {
+                    index == 0 || all_rows[index - 1].log_index != all_rows[index].log_index
+                })
+                .unwrap_or(first);
+        }
     }
+
+    start = start.min(all_rows.len().saturating_sub(keep));
+    let rows = all_rows.into_iter().skip(start).take(keep).collect();
     LogViewport { area, rows }
 }
 
@@ -199,6 +378,7 @@ fn log_display_line(
     row: &LogDisplayRow,
     row_index: usize,
     selection: Option<&LogSelection>,
+    navigation: Option<&LogNavigation>,
 ) -> Line<'static> {
     let base = if row.error {
         model.theme.error()
@@ -211,8 +391,8 @@ fn log_display_line(
         .chars()
         .map(|character| {
             let width = UnicodeWidthChar::width(character).unwrap_or(0) as u16;
-            let selected =
-                selection.is_some_and(|selection| selection.contains(row_index, column, width));
+            let selected = navigation.is_some_and(|nav| nav.contains(row.log_index))
+                || selection.is_some_and(|selection| selection.contains(row_index, column, width));
             column = column.saturating_add(width);
             Span::styled(
                 character.to_string(),
@@ -251,6 +431,14 @@ fn main_panes(terminal_area: Rect) -> (Rect, Rect) {
 }
 
 pub(crate) fn log_viewport(model: &Model, terminal_area: Rect) -> Option<LogViewport> {
+    log_viewport_with_navigation(model, terminal_area, None)
+}
+
+pub(crate) fn log_viewport_with_navigation(
+    model: &Model,
+    terminal_area: Rect,
+    navigation: Option<&LogNavigation>,
+) -> Option<LogViewport> {
     if model.overlay != Overlay::None {
         return None;
     }
@@ -264,7 +452,13 @@ pub(crate) fn log_viewport(model: &Model, terminal_area: Rect) -> Option<LogView
     if area.width == 0 || area.height == 0 {
         return None;
     }
-    Some(build_log_viewport(model, area))
+    Some(build_log_viewport(model, area, navigation))
+}
+
+pub(crate) fn sync_log_scroll(model: &Model, terminal_area: Rect, navigation: &mut LogNavigation) {
+    if let Some(viewport) = log_viewport_with_navigation(model, terminal_area, Some(navigation)) {
+        navigation.set_scroll_top_from(&viewport);
+    }
 }
 
 /// Return the selectable Sources row under a terminal cell. Borders, group
@@ -316,12 +510,23 @@ pub(crate) fn source_hit_test(
 
 /// Render the full application UI into the terminal frame.
 pub fn draw(frame: &mut Frame, model: &Model) {
-    draw_with_log_selection(frame, model, None);
+    draw_with_interaction(frame, model, MainPaneFocus::Sources, None, None);
 }
 
+#[cfg(test)]
 pub(crate) fn draw_with_log_selection(
     frame: &mut Frame,
     model: &Model,
+    log_selection: Option<&LogSelection>,
+) {
+    draw_with_interaction(frame, model, MainPaneFocus::Sources, None, log_selection);
+}
+
+pub(crate) fn draw_with_interaction(
+    frame: &mut Frame,
+    model: &Model,
+    pane_focus: MainPaneFocus,
+    log_navigation: Option<&LogNavigation>,
     log_selection: Option<&LogSelection>,
 ) {
     let area = frame.area();
@@ -357,7 +562,14 @@ pub(crate) fn draw_with_log_selection(
     if let Some(area) = traffic_area {
         draw_traffic_panel(frame, model, area);
     }
-    draw_main(frame, model, main_area, log_selection);
+    draw_main(
+        frame,
+        model,
+        main_area,
+        pane_focus,
+        log_navigation,
+        log_selection,
+    );
     draw_status_bar(frame, model, status_area);
 
     let theme = &model.theme;
@@ -374,19 +586,35 @@ pub(crate) fn draw_with_log_selection(
 }
 
 /// Draw the main content area with the Sources list and logs.
-fn draw_main(frame: &mut Frame, model: &Model, area: Rect, log_selection: Option<&LogSelection>) {
+fn draw_main(
+    frame: &mut Frame,
+    model: &Model,
+    area: Rect,
+    pane_focus: MainPaneFocus,
+    log_navigation: Option<&LogNavigation>,
+    log_selection: Option<&LogSelection>,
+) {
     let theme = &model.theme;
     let content_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
         .split(area);
 
-    draw_sources(frame, model, content_chunks[0]);
+    draw_sources(
+        frame,
+        model,
+        content_chunks[0],
+        pane_focus == MainPaneFocus::Sources,
+    );
 
     let log_block = Block::default()
         .title(" Logs ")
         .borders(Borders::ALL)
-        .border_style(theme.border());
+        .border_style(if pane_focus == MainPaneFocus::Logs {
+            theme.accent()
+        } else {
+            theme.border()
+        });
 
     let inner = Rect::new(
         content_chunks[1].x.saturating_add(1),
@@ -398,12 +626,14 @@ fn draw_main(frame: &mut Frame, model: &Model, area: Rect, log_selection: Option
         .map(|selection| &selection.viewport)
         .filter(|viewport| viewport.area == inner)
         .cloned()
-        .unwrap_or_else(|| build_log_viewport(model, inner));
+        .unwrap_or_else(|| build_log_viewport(model, inner, log_navigation));
     let log_text: Vec<Line> = viewport
         .rows
         .iter()
         .enumerate()
-        .map(|(row_index, row)| log_display_line(model, row, row_index, log_selection))
+        .map(|(row_index, row)| {
+            log_display_line(model, row, row_index, log_selection, log_navigation)
+        })
         .collect();
 
     let logs = Paragraph::new(log_text).block(log_block);
@@ -454,13 +684,15 @@ fn draw_help(frame: &mut Frame, theme: &Theme, area: Rect) {
     let header = Row::new(vec!["Key", "Action"]).style(theme.accent().add_modifier(Modifier::BOLD));
 
     let rows: Vec<Row> = vec![
+        Row::new(vec!["h / l", "Focus Sources / Logs"]),
         Row::new(vec!["j / Down", "Move down"]),
         Row::new(vec!["k / Up", "Move up"]),
-        Row::new(vec!["g", "Go to first"]),
-        Row::new(vec!["G", "Go to last"]),
+        Row::new(vec!["gg", "Go to first / buffer top"]),
+        Row::new(vec!["G", "Go to last / buffer bottom"]),
         Row::new(vec!["Enter", "Connect to selected profile"]),
         Row::new(vec!["p", "Paste from clipboard"]),
-        Row::new(vec!["y", "Yank share link to clipboard"]),
+        Row::new(vec!["y", "Yank selected source / log"]),
+        Row::new(vec!["Shift+V", "Select multiple logs"]),
         Row::new(vec!["d", "Delete selected source"]),
         Row::new(vec!["m", "Routing mode (popup list)"]),
         Row::new(vec!["o", "Geo region"]),
@@ -824,12 +1056,16 @@ fn draw_selection_modal(
 }
 
 /// Draw the unified Sources list: standalone profiles and subscription trees.
-fn draw_sources(frame: &mut Frame, model: &Model, area: Rect) {
+fn draw_sources(frame: &mut Frame, model: &Model, area: Rect, focused: bool) {
     let theme = &model.theme;
     let block = Block::default()
         .title(" Sources ")
         .borders(Borders::ALL)
-        .border_style(theme.border());
+        .border_style(if focused {
+            theme.accent()
+        } else {
+            theme.border()
+        });
 
     let inner_width = area.width.saturating_sub(2) as usize;
     let mut lines: Vec<Line> = Vec::new();
@@ -1195,11 +1431,155 @@ mod tests {
     }
 
     #[test]
+    fn log_navigation_starts_j_at_top_and_k_at_bottom_of_visible_logs() {
+        let mut model = mouse_model();
+        for index in 0..6 {
+            model.push_log(format!("line {index}"));
+        }
+        let area = Rect::new(0, 0, 80, 9); // three log content rows
+        let viewport = log_viewport(&model, area).unwrap();
+        assert_eq!(viewport.first_log_index(), Some(3));
+        assert_eq!(viewport.last_log_index(), Some(5));
+
+        let now = Instant::now();
+        let mut down = LogNavigation::default();
+        down.select_edge(&viewport, true, now);
+        assert_eq!(down.cursor(), Some(3));
+
+        let mut up = LogNavigation::default();
+        up.select_edge(&viewport, false, now);
+        assert_eq!(up.cursor(), Some(5));
+    }
+
+    #[test]
+    fn log_navigation_moves_by_whole_wrapped_records() {
+        let mut model = mouse_model();
+        model.push_log("abcdefgh".into());
+        model.push_log("next".into());
+        let viewport = build_log_viewport(&model, Rect::new(0, 0, 4, 3), None);
+        assert_eq!(viewport.rows.len(), 3);
+        assert_eq!(viewport.rows[0].log_index, 0);
+        assert_eq!(viewport.rows[1].log_index, 0);
+
+        let now = Instant::now();
+        let mut navigation = LogNavigation::default();
+        navigation.select_edge(&viewport, true, now);
+        assert_eq!(navigation.cursor(), Some(0));
+        navigation.move_by(1, model.logs.len(), now);
+        assert_eq!(navigation.cursor(), Some(1));
+        assert_eq!(navigation.selected_text(&model), Some(("next".into(), 1)));
+    }
+
+    #[test]
+    fn log_visual_selection_copies_complete_records_in_both_directions() {
+        let mut model = mouse_model();
+        for line in ["first", "second", "third"] {
+            model.push_log(line.into());
+        }
+        let viewport = build_log_viewport(&model, Rect::new(0, 0, 20, 3), None);
+        let now = Instant::now();
+        let mut navigation = LogNavigation::default();
+        navigation.select_edge(&viewport, false, now);
+        navigation.enter_visual(now);
+        navigation.move_by(-2, model.logs.len(), now);
+        assert_eq!(
+            navigation.selected_text(&model),
+            Some(("first\nsecond\nthird".into(), 3))
+        );
+
+        navigation.copied(now);
+        assert!(!navigation.is_visual());
+        assert_eq!(navigation.cursor(), Some(0));
+    }
+
+    #[test]
+    fn log_navigation_expires_after_fifteen_seconds() {
+        let mut model = mouse_model();
+        model.push_log("line".into());
+        let viewport = build_log_viewport(&model, Rect::new(0, 0, 20, 1), None);
+        let start = Instant::now();
+        let mut navigation = LogNavigation::default();
+        navigation.select_edge(&viewport, true, start);
+        navigation.enter_visual(start);
+
+        assert!(!navigation.expire_if_idle(start + LOG_CURSOR_TIMEOUT - Duration::from_millis(1)));
+        assert!(navigation.is_visual());
+        assert!(navigation.expire_if_idle(start + LOG_CURSOR_TIMEOUT));
+        assert_eq!(navigation.cursor(), None);
+        assert!(!navigation.is_visual());
+    }
+
+    #[test]
+    fn log_buffer_edge_jumps_scroll_to_full_buffer_bounds() {
+        let mut model = mouse_model();
+        for index in 0..6 {
+            model.push_log(format!("line {index}"));
+        }
+        let now = Instant::now();
+        let mut navigation = LogNavigation::default();
+        navigation.select_buffer_edge(model.logs.len(), true, now);
+        let viewport = build_log_viewport(&model, Rect::new(0, 0, 20, 3), Some(&navigation));
+        assert_eq!(navigation.cursor(), Some(0));
+        assert_eq!(viewport.first_log_index(), Some(0));
+
+        navigation.select_buffer_edge(model.logs.len(), false, now);
+        let viewport = build_log_viewport(&model, Rect::new(0, 0, 20, 3), Some(&navigation));
+        assert_eq!(navigation.cursor(), Some(5));
+        assert_eq!(viewport.last_log_index(), Some(5));
+    }
+
+    #[test]
+    fn log_visual_buffer_jumps_extend_beyond_viewport() {
+        let mut model = mouse_model();
+        for index in 0..6 {
+            model.push_log(format!("line {index}"));
+        }
+        let now = Instant::now();
+        let mut navigation = LogNavigation::default();
+        navigation.select_buffer_edge(model.logs.len(), false, now);
+        navigation.move_by(-1, model.logs.len(), now);
+        navigation.enter_visual(now);
+
+        navigation.select_buffer_edge(model.logs.len(), true, now);
+        assert_eq!(navigation.selected_range(), Some(0..=4));
+        assert_eq!(navigation.selected_text(&model).unwrap().1, 5);
+        navigation.select_buffer_edge(model.logs.len(), false, now);
+        assert_eq!(navigation.selected_range(), Some(4..=5));
+    }
+
+    #[test]
+    fn log_buffer_edge_jump_is_noop_when_empty() {
+        let mut navigation = LogNavigation::default();
+        navigation.select_buffer_edge(0, true, Instant::now());
+        assert_eq!(navigation.cursor(), None);
+    }
+
+    #[test]
+    fn log_navigation_tracks_oldest_buffer_eviction() {
+        let mut model = mouse_model();
+        for line in ["old", "selected", "new"] {
+            model.push_log(line.into());
+        }
+        let viewport = build_log_viewport(&model, Rect::new(0, 0, 20, 3), None);
+        let now = Instant::now();
+        let mut navigation = LogNavigation::default();
+        navigation.select_edge(&viewport, true, now);
+        navigation.move_by(1, model.logs.len(), now);
+        navigation.oldest_log_evicted();
+        model.logs.pop_front();
+        assert_eq!(navigation.cursor(), Some(0));
+        assert_eq!(
+            navigation.selected_text(&model),
+            Some(("selected".into(), 1))
+        );
+    }
+
+    #[test]
     fn log_selection_joins_soft_wraps_and_preserves_real_line_breaks() {
         let mut model = mouse_model();
         model.push_log("abcdef".into());
         model.push_log("ghi".into());
-        let viewport = build_log_viewport(&model, Rect::new(10, 5, 3, 3));
+        let viewport = build_log_viewport(&model, Rect::new(10, 5, 3, 3), None);
         assert_eq!(viewport.rows.len(), 3);
         let mut selection = LogSelection::start(viewport, 10, 5).unwrap();
         selection.update(12, 7);
@@ -1211,7 +1591,7 @@ mod tests {
         let mut model = mouse_model();
         model.push_log("abc".into());
         model.push_log("def".into());
-        let viewport = build_log_viewport(&model, Rect::new(10, 5, 3, 2));
+        let viewport = build_log_viewport(&model, Rect::new(10, 5, 3, 2), None);
         let mut selection = LogSelection::start(viewport, 12, 6).unwrap();
         selection.update(0, 0);
         assert_eq!(selection.text(), "abc\ndef");
@@ -1221,7 +1601,7 @@ mod tests {
     fn log_selection_does_not_split_wide_unicode_characters() {
         let mut model = mouse_model();
         model.push_log("a界b".into());
-        let viewport = build_log_viewport(&model, Rect::new(0, 0, 4, 1));
+        let viewport = build_log_viewport(&model, Rect::new(0, 0, 4, 1), None);
         let mut selection = LogSelection::start(viewport, 1, 0).unwrap();
         selection.update(2, 0);
         assert_eq!(selection.text(), "界");
@@ -1231,7 +1611,7 @@ mod tests {
     fn log_selection_single_click_is_empty() {
         let mut model = mouse_model();
         model.push_log("abc".into());
-        let viewport = build_log_viewport(&model, Rect::new(0, 0, 3, 1));
+        let viewport = build_log_viewport(&model, Rect::new(0, 0, 3, 1), None);
         let selection = LogSelection::start(viewport, 1, 0).unwrap();
         assert!(selection.is_empty());
         assert!(selection.text().is_empty());
@@ -1395,12 +1775,14 @@ mod tests {
 
         let content: String = frame.buffer.content.iter().map(|c| c.symbol()).collect();
         let expected = [
+            ("h / l", "Focus Sources / Logs"),
             ("j / Down", "Move down"),
             ("k / Up", "Move up"),
-            ("g", "Go to first"),
-            ("G", "Go to last"),
+            ("gg", "Go to first / buffer top"),
+            ("G", "Go to last / buffer bottom"),
             ("Enter", "Connect to selected profile"),
             ("p", "Paste from clipboard"),
+            ("Shift+V", "Select multiple logs"),
             ("d", "Delete selected source"),
             ("m", "Routing mode (popup list)"),
             ("u", "Update subscription or geo"),
@@ -1440,6 +1822,28 @@ mod tests {
         model.connection = ConnectionState::Connected;
         model.active_profile_id = Some(model.config.profiles[0].id);
         insta::assert_snapshot!(snapshot_terminal(&model, 80, 20));
+    }
+
+    #[test]
+    fn focused_main_pane_uses_accent_border() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        use ratatui::style::Color;
+
+        let model = mouse_model();
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).unwrap();
+        let navigation = LogNavigation::default();
+        terminal
+            .draw(|frame| {
+                draw_with_interaction(frame, &model, MainPaneFocus::Logs, Some(&navigation), None)
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        let source_border = &buffer.content[3 * 80];
+        let log_border = &buffer.content[3 * 80 + 40];
+        assert_eq!(source_border.style().fg, Some(Color::DarkGray));
+        assert_eq!(log_border.style().fg, Some(Color::Cyan));
     }
 
     #[test]

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -595,6 +595,7 @@ fn draw_main(
     log_selection: Option<&LogSelection>,
 ) {
     let theme = &model.theme;
+    let main_focus_active = model.overlay == Overlay::None;
     let content_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
@@ -604,13 +605,13 @@ fn draw_main(
         frame,
         model,
         content_chunks[0],
-        pane_focus == MainPaneFocus::Sources,
+        main_focus_active && pane_focus == MainPaneFocus::Sources,
     );
 
     let log_block = Block::default()
         .title(" Logs ")
         .borders(Borders::ALL)
-        .border_style(if pane_focus == MainPaneFocus::Logs {
+        .border_style(if main_focus_active && pane_focus == MainPaneFocus::Logs {
             theme.accent()
         } else {
             theme.border()
@@ -723,7 +724,7 @@ fn draw_help(frame: &mut Frame, theme: &Theme, area: Rect) {
     let block = Block::default()
         .title(" Help ")
         .borders(Borders::ALL)
-        .border_style(theme.border())
+        .border_style(theme.accent())
         .style(theme.popup_bg());
 
     let inner = block.inner(popup_area);
@@ -779,7 +780,7 @@ fn draw_modal(
     let block = Block::default()
         .title(title)
         .borders(Borders::ALL)
-        .border_style(theme.border())
+        .border_style(theme.accent())
         .style(theme.popup_bg());
 
     let paragraph = Paragraph::new(lines)
@@ -906,7 +907,7 @@ fn draw_service_routing(frame: &mut Frame, model: &Model, area: Rect) {
     let block = Block::default()
         .title(" Services ")
         .borders(Borders::ALL)
-        .border_style(theme.border())
+        .border_style(theme.accent())
         .style(theme.popup_bg());
     let inner = block.inner(popup_area);
     frame.render_widget(block, popup_area);
@@ -1844,6 +1845,71 @@ mod tests {
         let log_border = &buffer.content[3 * 80 + 40];
         assert_eq!(source_border.style().fg, Some(Color::DarkGray));
         assert_eq!(log_border.style().fg, Some(Color::Cyan));
+    }
+
+    #[test]
+    fn overlay_focus_temporarily_suspends_and_restores_main_pane_focus() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        use ratatui::style::Color;
+
+        for pane_focus in [MainPaneFocus::Sources, MainPaneFocus::Logs] {
+            let mut model = mouse_model();
+            model.overlay = Overlay::ConfirmDelete;
+            let mut terminal = Terminal::new(TestBackend::new(80, 20)).unwrap();
+            terminal
+                .draw(|frame| {
+                    draw_with_interaction(frame, &model, pane_focus, None, None);
+                })
+                .unwrap();
+
+            let buffer = terminal.backend().buffer();
+            assert_eq!(buffer.content[3 * 80].style().fg, Some(Color::DarkGray));
+            assert_eq!(
+                buffer.content[3 * 80 + 79].style().fg,
+                Some(Color::DarkGray)
+            );
+
+            model.overlay = Overlay::None;
+            terminal
+                .draw(|frame| {
+                    draw_with_interaction(frame, &model, pane_focus, None, None);
+                })
+                .unwrap();
+            let buffer = terminal.backend().buffer();
+            let focused_border = match pane_focus {
+                MainPaneFocus::Sources => &buffer.content[3 * 80],
+                MainPaneFocus::Logs => &buffer.content[3 * 80 + 40],
+            };
+            assert_eq!(focused_border.style().fg, Some(Color::Cyan));
+        }
+    }
+
+    #[test]
+    fn every_overlay_border_renderer_uses_accent() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        use ratatui::style::Color;
+
+        for (overlay, height_percent) in [
+            (Overlay::ConfirmDelete, POPUP_HEIGHT_PERCENT),
+            (Overlay::Help, 90),
+            (Overlay::ServiceRouting, POPUP_HEIGHT_PERCENT),
+        ] {
+            let mut model = mouse_model();
+            model.overlay = overlay;
+            let mut terminal = Terminal::new(TestBackend::new(80, 20)).unwrap();
+            terminal
+                .draw(|frame| {
+                    draw_with_interaction(frame, &model, MainPaneFocus::Logs, None, None);
+                })
+                .unwrap();
+
+            let popup = centered_rect(POPUP_WIDTH_PERCENT, height_percent, Rect::new(0, 0, 80, 20));
+            let corner =
+                &terminal.backend().buffer().content[popup.y as usize * 80 + popup.x as usize];
+            assert_eq!(corner.style().fg, Some(Color::Cyan), "overlay: {overlay:?}");
+        }
     }
 
     #[test]

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_help_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_help_overlay_snapshot.snap
@@ -6,16 +6,17 @@ expression: "snapshot_terminal(&model, 80, 40)"
 │↑ 0.0 KB/s  ↓ 0.0 KB/s    Total: ↑ 0.0 KB  ↓ 0.0 KB    0 connections          │
 └──────────────────────────────────────────────────────────────────────────────┘
 ┌ Sources ─────────────────────────────┐┌ Logs ────────────────────────────────┐
-│No sources. Press p to paste a profile││                                      │
-│or subscription┌ Help ────────────────────────────────────────┐               │
-│               │Key          Action                           │               │
+│No sources. Pre┌ Help ────────────────────────────────────────┐               │
+│or subscription│Key          Action                           │               │
+│               │h / l        Focus Sources / Logs             │               │
 │               │j / Down     Move down                        │               │
 │               │k / Up       Move up                          │               │
-│               │g            Go to first                      │               │
-│               │G            Go to last                       │               │
+│               │gg           Go to first / buffer top         │               │
+│               │G            Go to last / buffer bottom       │               │
 │               │Enter        Connect to selected profile      │               │
 │               │p            Paste from clipboard             │               │
-│               │y            Yank share link to clipboard     │               │
+│               │y            Yank selected source / log       │               │
+│               │Shift+V      Select multiple logs             │               │
 │               │d            Delete selected source           │               │
 │               │m            Routing mode (popup list)        │               │
 │               │o            Geo region                       │               │
@@ -37,7 +38,6 @@ expression: "snapshot_terminal(&model, 80, 40)"
 │               │?            Show this help                   │               │
 │               │                                              │               │
 │               └──────────────────────────────────────────────┘               │
-│                                      ││                                      │
 │                                      ││                                      │
 │                                      ││                                      │
 └──────────────────────────────────────┘└──────────────────────────────────────┘


### PR DESCRIPTION
## Summary

  Adds session-aware focus and Vim-style navigation for the Sources, Logs, and overlay panels.

  ## Changes

  - Switch focus between Sources and Logs with `h` / `l`.
  - Preserve the focused panel while the daemon remains active.
  - Restore the focused panel when reopening the TUI.
  - Highlight an open overlay and restore the previous panel focus when it closes.
  - Navigate complete log records with `j` / `k`, regardless of line wrapping.
  - Select the top visible log with the initial `j` and the bottom visible log with the initial `k`.
  - Use `gg` / `G` to jump to the beginning or end of the full buffer in Sources, overlays, and Logs.
  - Copy the focused log with `y`.
  - Enter visual selection mode with `Shift+V` and copy multiple logs with `y`.
  - Extend visual selection to the start with `gg` or to the end with `Shift+G`.
  - Clear inactive log focus after 15 seconds.
  - Restore up to 1,000 logs from the current daemon session when attaching the TUI.
  - Start a new daemon session with an empty log panel and Sources focused.
  - Update the built-in keyboard shortcut help.