### PR TITLE
feat(subscription): add opt-in HWID identification

### DIFF
--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -1019,6 +1019,8 @@ fn add_and_fetch_subscription(model: &mut Model, url: &str) -> Vec<Effect> {
         last_updated: None,
         next_auto_update: None,
         retry_state: None,
+        send_hwid: false,
+        hwid: None,
     };
     model.config.subscriptions.push(sub);
     model.selected = crate::app::model::row_for_subscription_header(
@@ -1499,6 +1501,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
         model.selected = 0; // subscription header
         let effects = handle_sources(&mut model, KeyEvent::from(KeyCode::Enter));
@@ -1521,6 +1525,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
         model.selected = 0; // subscription header
         let effects = handle_sources(&mut model, KeyEvent::from(KeyCode::Enter));
@@ -3820,6 +3826,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
 
         let new_sub_id = Uuid::new_v4();
@@ -3831,6 +3839,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
 
         let fetched = Profile::new_vless(
@@ -3872,6 +3882,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
 
         let mut fetched = Profile::new_vless(
@@ -3933,6 +3945,8 @@ mod tests {
             last_updated: Some(last_updated),
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
         model.automatic_subscription_updates.insert(sub_id);
 
@@ -4007,6 +4021,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
         model.config.subscriptions[0].record_fetch_failure(Local::now());
         model.automatic_subscription_updates.insert(sub_id);
@@ -4062,6 +4078,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
         // Start with cursor on the subscription header.
         model.selected = crate::app::model::row_for_subscription_header(&model.config, 0);
@@ -4137,6 +4155,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
         model.connection = ConnectionState::Connected;
         model.active_profile_id = Some(old_profile_id);
@@ -4177,6 +4197,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
         assert!(queue_connect(&mut model, profile_id));
         model.connection = ConnectionState::ConnectPending;
@@ -4226,6 +4248,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
         model.selected = 0;
 
@@ -4258,6 +4282,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
         model.selected = 0;
         model.config.subscriptions[0].record_fetch_failure(Local::now());
@@ -4282,6 +4308,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
         model.selected = 0;
 
@@ -4326,6 +4354,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
         // source_rows: [SubscriptionHeader(0), SubscriptionProfile { sub_idx: 0, profile_idx: 0 }]
         model.selected = 0;
@@ -4358,6 +4388,8 @@ mod tests {
             last_updated: Some(now - chrono::Duration::try_hours(25).unwrap()),
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
 
         let effects = check_due_subscriptions_at(&mut model, now);
@@ -4379,6 +4411,8 @@ mod tests {
             last_updated: Some(now - chrono::Duration::hours(2)),
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         };
         sub.record_fetch_failure(now);
         model.config.subscriptions.push(sub);
@@ -4412,6 +4446,8 @@ mod tests {
                 retry_at: today,
                 attempt_date: Some(today.date_naive()),
             }),
+            send_hwid: false,
+            hwid: None,
         });
 
         assert!(check_due_subscriptions_at(&mut model, today).is_empty());
@@ -4442,6 +4478,8 @@ mod tests {
             last_updated: None,
             next_auto_update: Some(now.date_naive()),
             retry_state: Some(retry.clone()),
+            send_hwid: false,
+            hwid: None,
         });
 
         handle_subscription_result_at(&mut model, id, Ok(Vec::new()), now);
@@ -4465,6 +4503,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         };
         sub.record_fetch_failure(Local::now());
         model.config.subscriptions.push(sub);
@@ -4488,6 +4528,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
         model.config.settings.kill_switch = true;
         let now = after_update_window();
@@ -4521,6 +4563,8 @@ mod tests {
             last_updated: Some(now),
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
 
         let effects = check_due_subscriptions_at(&mut model, now);
@@ -4542,6 +4586,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         };
         sub.record_fetch_failure(now - chrono::Duration::hours(1));
         model.config.subscriptions.push(sub);

--- a/src/app/update/key.rs
+++ b/src/app/update/key.rs
@@ -1455,6 +1455,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
         model.connection = ConnectionState::Connected;
         model.active_profile_id = Some(model.config.profiles[0].id);
@@ -1633,6 +1635,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
         model.overlay = Overlay::ConfirmDelete;
         model.selected = crate::app::model::row_for_subscription_header(&model.config, 0);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -473,9 +473,15 @@ esac
         let _lock = crate::test_helpers::ENV_LOCK.lock().unwrap();
         let script = root.path().join("clean-omarchy.sh");
         fs::write(&script, include_str!("../contrib/clean-omarchy.sh")).unwrap();
+        let path = format!(
+            "{}:{}",
+            root.path().join("bin").display(),
+            std::env::var("PATH").unwrap()
+        );
         ProcessCommand::new("bash")
             .arg(&script)
             .env("HOME", home)
+            .env("PATH", path)
             .output()
             .unwrap()
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,6 +61,10 @@ pub fn save_config_at(path: &Path, config: &Config) -> Result<()> {
 /// automatically follows the system theme instead of always starting on
 /// `tokyo-night`. Existing configs are left untouched — the user's stored
 /// theme choice always wins.
+///
+/// Also generates the installation HWID once (UUID v4) and persists it
+/// immediately through the atomic config write path, so every later start —
+/// and every subscription server — sees the same identifier.
 pub fn load_config() -> Result<Config> {
     let path = crate::paths::profiles_path().context("Failed to determine profiles path")?;
     let is_first_launch = !path.exists();
@@ -68,7 +72,28 @@ pub fn load_config() -> Result<Config> {
     if is_first_launch && crate::omarchy::detect_omarchy_theme().is_some() {
         config.settings.theme = profile::OMARCHY_THEME_SENTINEL.to_string();
     }
+    ensure_hwid(&mut config, &path)?;
     Ok(config)
+}
+
+/// Generate the installation HWID once and persist it immediately through the
+/// existing atomic config write path. Idempotent: an existing non-empty
+/// `settings.hwid` is never regenerated.
+fn ensure_hwid(config: &mut Config, path: &Path) -> Result<()> {
+    if !config.settings.hwid.is_empty() {
+        return Ok(());
+    }
+    config.settings.hwid = subscription::generate_hwid();
+
+    // Validation errors belong to the caller's existing config-validation
+    // path. Do not turn an unrelated invalid profile into an HWID persistence
+    // error merely because this load also generated the missing identifier.
+    if config.validate().is_err() {
+        return Ok(());
+    }
+
+    tracing::info!("Generated installation HWID");
+    save_config_at(path, config).context("Failed to persist generated HWID")
 }
 
 /// Save configuration to disk atomically.
@@ -143,6 +168,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
         config.settings.geo_routing.auto_update = profile::GeoAutoUpdate::Every12h;
         save_config_at(file.path(), &config).unwrap();
@@ -228,6 +255,104 @@ mod tests {
 
         let loaded = load_config().unwrap();
         assert_eq!(loaded.settings.theme, "tokyo-night");
+    }
+
+    #[test]
+    fn load_config_generates_hwid_once_and_persists_it() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", dir.path()) };
+        let _ = std::fs::remove_file(crate::paths::profiles_path().unwrap());
+
+        let config = load_config().unwrap();
+        let hwid = config.settings.hwid.clone();
+        assert!(hwid.starts_with("lnx-"));
+        assert_eq!(hwid.len(), "lnx-".len() + 32);
+
+        // The generated HWID is immediately written through the atomic path.
+        let persisted = std::fs::read_to_string(crate::paths::profiles_path().unwrap()).unwrap();
+        assert!(persisted.contains(&hwid));
+
+        // A second load retains the same installation HWID.
+        let reloaded = load_config().unwrap();
+        assert_eq!(reloaded.settings.hwid, hwid);
+    }
+
+    #[test]
+    fn ensure_hwid_propagates_persistence_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent_file = dir.path().join("not-a-directory");
+        std::fs::write(&parent_file, "occupied").unwrap();
+        let path = parent_file.join("profiles.json");
+        let mut config = Config::default();
+
+        let error = ensure_hwid(&mut config, &path).unwrap_err();
+
+        assert!(
+            format!("{error:#}").contains("Failed to persist generated HWID"),
+            "got: {error:#}"
+        );
+    }
+
+    #[test]
+    fn hwid_survives_save_and_load_roundtrip() {
+        let file = NamedTempFile::new().unwrap();
+        let path = file.path().to_path_buf();
+
+        let mut config = Config::default();
+        config.settings.hwid = "lnx-d415f1264a264924aa76e7f55380b0c7".to_string();
+        save_config_at(&path, &config).unwrap();
+
+        let loaded = load_config_at(&path).unwrap();
+        assert_eq!(loaded.settings.hwid, "lnx-d415f1264a264924aa76e7f55380b0c7");
+    }
+
+    #[test]
+    fn settings_and_subscriptions_without_hwid_fields_are_backward_compatible() {
+        // Pre-HWID config shape: no `settings.hwid`, no `send_hwid`/`hwid` on
+        // subscriptions — and no legacy `subscription_headers` either.
+        let legacy = r#"{
+            "schema_version": 3,
+            "profiles": [],
+            "subscriptions": [
+                {
+                    "id": "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+                    "name": "Regular subscription",
+                    "url": "https://example.com/regular"
+                }
+            ],
+            "settings": {
+                "tun_interface": "tun0",
+                "dns_strategy": "prefer_ipv4",
+                "theme": "tokyo-night",
+                "log_level": "info"
+            }
+        }"#;
+        let mut file = NamedTempFile::new().unwrap();
+        write!(file, "{legacy}").unwrap();
+
+        let config = load_config_at(file.path()).unwrap();
+        assert_eq!(config.settings.hwid, "");
+        assert!(!config.subscriptions[0].send_hwid);
+        assert_eq!(config.subscriptions[0].hwid, None);
+    }
+
+    #[test]
+    fn subscription_send_hwid_fields_roundtrip_through_json() {
+        let json = r#"{
+            "id": "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+            "name": "HWID subscription",
+            "url": "https://example.com/hwid",
+            "send_hwid": true,
+            "hwid": "provider-registered-device-id"
+        }"#;
+        let sub: profile::Subscription = serde_json::from_str(json).unwrap();
+        assert!(sub.send_hwid);
+        assert_eq!(sub.hwid.as_deref(), Some("provider-registered-device-id"));
+
+        let serialized = serde_json::to_string(&sub).unwrap();
+        let back: profile::Subscription = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(back, sub);
     }
 
     #[test]

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -923,6 +923,10 @@ impl SubscriptionAutoUpdate {
 }
 
 /// A subscription URL that can be refreshed to import a set of profiles.
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct Subscription {
@@ -938,6 +942,16 @@ pub struct Subscription {
     pub next_auto_update: Option<NaiveDate>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retry_state: Option<SubscriptionRetryState>,
+    /// When true, HWID identification headers are sent with subscription
+    /// requests (see [`Subscription::effective_hwid`]). Default false: raw
+    /// identifiers must not reach unrelated hosts.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub send_hwid: bool,
+    /// Per-subscription HWID override; requires `send_hwid` to take effect.
+    /// When absent, `settings.hwid` is used. Its presence alone never enables
+    /// sending.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hwid: Option<String>,
 }
 
 /// Persisted retry metadata for an auto-updating subscription.
@@ -951,6 +965,22 @@ pub struct SubscriptionRetryState {
 }
 
 impl Subscription {
+    /// Resolve the HWID to send for this subscription.
+    ///
+    /// Resolution rules:
+    /// - `send_hwid` absent or false → `None` (no device headers are sent);
+    /// - `send_hwid: true` with a per-subscription `hwid` override → the
+    ///   override;
+    /// - otherwise → fall back to `settings.hwid`.
+    ///
+    /// The presence of `self.hwid` alone never enables sending.
+    pub fn effective_hwid<'a>(&'a self, settings: &'a Settings) -> Option<&'a str> {
+        if !self.send_hwid {
+            return None;
+        }
+        self.hwid.as_deref().or(Some(settings.hwid.as_str()))
+    }
+
     /// Record a failed fetch and schedule the next retry using the bounded
     /// 1/5/15/60-minute backoff sequence.
     pub fn record_fetch_failure(&mut self, now: DateTime<Local>) {
@@ -1047,6 +1077,8 @@ fn subscription_retry_backoff_is_bounded_and_serializable() {
         last_updated: None,
         next_auto_update: None,
         retry_state: None,
+        send_hwid: false,
+        hwid: None,
     };
 
     for (failures, delay) in [(1, 1), (2, 5), (3, 15), (4, 60)] {
@@ -1356,6 +1388,13 @@ pub struct Settings {
     /// Pre-v4 compatibility field migrated into `logs.level` on load.
     #[serde(default, rename = "log_level", skip_serializing)]
     pub(crate) legacy_log_level: Option<String>,
+    /// Stable installation identifier (`lnx-` + UUID v4), generated once on
+    /// first launch and persisted via the atomic config write path. Sent as
+    /// `X-Hwid` only by subscriptions with `send_hwid: true` — never derived
+    /// from the subscription URL so rotating a token or changing a domain
+    /// does not make the provider see a new device.
+    #[serde(default)]
+    pub hwid: String,
 }
 
 /// Accept `address` if it parses as a bare IPv4/IPv6 literal or as a hostname.
@@ -1508,6 +1547,7 @@ impl Default for Settings {
             theme: default_theme(),
             logs: LogsConfig::default(),
             legacy_log_level: None,
+            hwid: String::new(),
         }
     }
 }
@@ -1573,6 +1613,23 @@ impl Config {
             }
             if let Err(e) = profile.validate_semantic() {
                 anyhow::bail!("Profile {num}: {e}");
+            }
+        }
+
+        for (idx, subscription) in self.subscriptions.iter().enumerate() {
+            if !subscription.send_hwid {
+                continue;
+            }
+
+            let hwid = subscription
+                .effective_hwid(&self.settings)
+                .unwrap_or_default();
+            if let Err(error) = validate_hwid(hwid) {
+                anyhow::bail!(
+                    "Subscription {} ({:?}): invalid HWID: {error}",
+                    idx + 1,
+                    subscription.name
+                );
             }
         }
 
@@ -1679,9 +1736,179 @@ impl Config {
     }
 }
 
+const MAX_HWID_LEN: usize = 256;
+
+fn validate_hwid(hwid: &str) -> anyhow::Result<()> {
+    if hwid.trim().is_empty() {
+        anyhow::bail!("must not be empty when send_hwid is enabled");
+    }
+    if hwid.len() > MAX_HWID_LEN {
+        anyhow::bail!("must not exceed {MAX_HWID_LEN} bytes");
+    }
+    hwid.parse::<ureq::http::HeaderValue>()
+        .map_err(|_| anyhow::anyhow!("must be a valid HTTP header value"))?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn settings_with_hwid() -> Settings {
+        Settings {
+            hwid: "lnx-installation-hwid".to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn subscription_with_hwid(send_hwid: bool, hwid: Option<&str>) -> Subscription {
+        Subscription {
+            id: Uuid::new_v4(),
+            name: "Test subscription".to_string(),
+            url: "https://example.com/subscription".to_string(),
+            auto_update: SubscriptionAutoUpdate::Off,
+            last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
+            send_hwid,
+            hwid: hwid.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn config_validate_accepts_effective_subscription_hwid() {
+        let mut config = Config::default();
+        config.settings.hwid = "lnx-installation-hwid".to_string();
+        config
+            .subscriptions
+            .push(subscription_with_hwid(true, None));
+        config.validate().unwrap();
+    }
+
+    #[test]
+    fn config_validate_rejects_empty_effective_subscription_hwid() {
+        let mut config = Config::default();
+        config
+            .subscriptions
+            .push(subscription_with_hwid(true, None));
+        let error = config.validate().unwrap_err().to_string();
+        assert!(error.contains("Subscription 1"), "got: {error}");
+        assert!(error.contains("must not be empty"), "got: {error}");
+    }
+
+    #[test]
+    fn config_validate_rejects_empty_subscription_hwid_override() {
+        let mut config = Config::default();
+        config.settings.hwid = "lnx-installation-hwid".to_string();
+        config
+            .subscriptions
+            .push(subscription_with_hwid(true, Some("")));
+        let error = config.validate().unwrap_err().to_string();
+        assert!(error.contains("must not be empty"), "got: {error}");
+    }
+
+    #[test]
+    fn config_validate_rejects_invalid_http_hwid_value() {
+        let mut config = Config::default();
+        config
+            .subscriptions
+            .push(subscription_with_hwid(true, Some("device\r\ninjected")));
+        let error = config.validate().unwrap_err().to_string();
+        assert!(error.contains("HTTP header value"), "got: {error}");
+    }
+
+    #[test]
+    fn config_validate_rejects_overlong_hwid() {
+        let mut config = Config::default();
+        let hwid = "a".repeat(MAX_HWID_LEN + 1);
+        config
+            .subscriptions
+            .push(subscription_with_hwid(true, Some(&hwid)));
+        let error = config.validate().unwrap_err().to_string();
+        assert!(error.contains("must not exceed"), "got: {error}");
+    }
+
+    #[test]
+    fn config_validate_ignores_unused_hwid() {
+        let mut config = Config::default();
+        config
+            .subscriptions
+            .push(subscription_with_hwid(false, Some("device\r\ninjected")));
+        config.validate().unwrap();
+    }
+
+    #[test]
+    fn effective_hwid_absent_send_hwid_sends_nothing() {
+        // Backward compat: `send_hwid` missing from JSON defaults to false.
+        let sub: Subscription =
+            serde_json::from_str(r#"{"name":"S","url":"https://e.com/s"}"#).unwrap();
+        assert!(!sub.send_hwid);
+        assert_eq!(sub.hwid, None);
+        assert_eq!(sub.effective_hwid(&settings_with_hwid()), None);
+    }
+
+    #[test]
+    fn subscription_serialization_omits_disabled_hwid_fields() {
+        let sub = subscription_with_hwid(false, None);
+        let json = serde_json::to_value(sub).unwrap();
+
+        assert!(json.get("send_hwid").is_none());
+        assert!(json.get("hwid").is_none());
+    }
+
+    #[test]
+    fn subscription_serialization_keeps_enabled_hwid_flag() {
+        let sub = subscription_with_hwid(true, None);
+        let json = serde_json::to_value(sub).unwrap();
+
+        assert_eq!(json.get("send_hwid"), Some(&serde_json::Value::Bool(true)));
+        assert!(json.get("hwid").is_none());
+    }
+
+    #[test]
+    fn effective_hwid_false_sends_nothing_even_with_override() {
+        let sub: Subscription = serde_json::from_str(
+            r#"{"name":"S","url":"https://e.com/s","send_hwid":false,"hwid":"custom"}"#,
+        )
+        .unwrap();
+        // The presence of `hwid` alone must not enable sending.
+        assert_eq!(sub.effective_hwid(&settings_with_hwid()), None);
+    }
+
+    #[test]
+    fn effective_hwid_true_falls_back_to_settings_hwid() {
+        let sub: Subscription =
+            serde_json::from_str(r#"{"name":"S","url":"https://e.com/s","send_hwid":true}"#)
+                .unwrap();
+        assert_eq!(
+            sub.effective_hwid(&settings_with_hwid()),
+            Some("lnx-installation-hwid"),
+        );
+    }
+
+    #[test]
+    fn effective_hwid_override_wins_over_settings() {
+        let sub: Subscription = serde_json::from_str(
+            r#"{"name":"S","url":"https://e.com/s","send_hwid":true,"hwid":"provider-registered-device-id"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            sub.effective_hwid(&settings_with_hwid()),
+            Some("provider-registered-device-id"),
+        );
+    }
+
+    #[test]
+    fn effective_hwid_is_never_derived_from_url() {
+        let sub: Subscription = serde_json::from_str(
+            r#"{"name":"S","url":"https://e.com/token-rotated","send_hwid":true}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            sub.effective_hwid(&settings_with_hwid()),
+            Some("lnx-installation-hwid"),
+        );
+    }
 
     #[test]
     fn protocol_display() {
@@ -3496,6 +3723,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
         cfg.settings.geo_routing.auto_update = GeoAutoUpdate::Every12h;
 

--- a/src/config/subscription.rs
+++ b/src/config/subscription.rs
@@ -1,19 +1,207 @@
+use std::{collections::HashMap, env, process::Command};
+
 use anyhow::{Context, Result};
 use base64::Engine;
+use uuid::Uuid;
 
-use crate::config::profile::{Profile, SUPPORTED_SHARE_SCHEMES, parse_share_link};
+use crate::config::profile::{
+    Profile, SUPPORTED_SHARE_SCHEMES, Settings, Subscription, parse_share_link,
+};
 
-/// Fetch a subscription URL, decode its body (Base64 or plain text), and parse
-/// every share link it contains. Mixed-protocol subscriptions are supported;
-/// individual malformed lines are logged and skipped.
-pub fn fetch_subscription(url: &str) -> Result<Vec<Profile>> {
-    let agent = ureq::Agent::new_with_defaults();
-    let resp = agent
-        .get(url)
-        .call()
-        .with_context(|| format!("GET {} failed", url))?;
+const KVN_TUI_USER_AGENT: &str = concat!("kvn-tui/", env!("CARGO_PKG_VERSION"));
+
+/// Generate a stable installation identifier once: `lnx-` + UUID v4.
+/// Never derived from the subscription URL — rotating a token or changing a
+/// domain must not make the provider treat the same installation as a new
+/// device.
+pub(crate) fn generate_hwid() -> String {
+    format!("lnx-{}", Uuid::new_v4().simple())
+}
+
+/// Platform facts read at request time (never persisted) so device headers
+/// cannot go stale in `profiles.json`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeviceEnv {
+    pub kernel_version: String,
+    pub locale: String,
+}
+
+impl DeviceEnv {
+    /// Read platform facts from the running system. Must never be called from
+    /// `app::update` — platform detection stays outside the pure update
+    /// boundary; this module is only invoked by the daemon runtime.
+    pub fn detect() -> Self {
+        Self {
+            kernel_version: kernel_version(),
+            locale: normalize_locale(&system_locale()),
+        }
+    }
+}
+
+/// Build the request headers for a subscription fetch. Every request carries
+/// `User-Agent: kvn-tui/<version>`; when `sub.effective_hwid(settings)` yields
+/// an HWID, the Linux device headers are added as well.
+fn build_request_headers(
+    sub: &Subscription,
+    settings: &Settings,
+    env: &DeviceEnv,
+) -> HashMap<String, String> {
+    let mut headers = HashMap::new();
+    headers.insert("User-Agent".to_string(), KVN_TUI_USER_AGENT.to_string());
+    if let Some(hwid) = sub.effective_hwid(settings) {
+        headers.insert("X-Hwid".to_string(), hwid.to_string());
+        headers.insert("X-Device-Os".to_string(), "Linux".to_string());
+        headers.insert("X-Ver-Os".to_string(), env.kernel_version.clone());
+        headers.insert("X-Device-Model".to_string(), "Desktop".to_string());
+        headers.insert("X-Device-Locale".to_string(), env.locale.clone());
+    }
+    headers
+}
+
+/// Normalize a Linux locale identifier to a compact `language[-REGION]` form
+/// for the `X-Device-Locale` header: `ru_RU.UTF-8` → `ru-RU`,
+/// `de_DE.utf8` → `de-DE`, `sr_RS@latin` → `sr-RS`, `en` → `en`,
+/// `C`/`POSIX`/empty → `en`.
+pub fn normalize_locale(raw: &str) -> String {
+    let base = raw.split('@').next().unwrap_or(raw);
+    let base = base.split('.').next().unwrap_or(base).trim();
+    if base.is_empty() || base.eq_ignore_ascii_case("c") || base.eq_ignore_ascii_case("posix") {
+        return "en".to_string();
+    }
+    let mut parts = base.splitn(2, '_');
+    let lang = parts.next().unwrap_or_default().trim().to_ascii_lowercase();
+    if lang.is_empty() {
+        return "en".to_string();
+    }
+    match parts.next() {
+        Some(region) if !region.trim().is_empty() => {
+            format!("{lang}-{}", region.trim().to_ascii_uppercase())
+        }
+        _ => lang,
+    }
+}
+
+fn system_locale() -> String {
+    env::var("LC_ALL")
+        .or_else(|_| env::var("LC_MESSAGES"))
+        .or_else(|_| env::var("LANG"))
+        .unwrap_or_else(|_| "en_US.UTF-8".to_string())
+}
+
+fn kernel_version() -> String {
+    Command::new("uname")
+        .arg("-r")
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .and_then(|out| String::from_utf8(out.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Decode the Remnawave `Announce` response header value. The documented form
+/// is `base64:<payload>`; anything undecodable is returned as-is so the
+/// provider's text is never silently dropped.
+fn decode_announce(raw: &str) -> String {
+    let payload = raw.strip_prefix("base64:").unwrap_or(raw);
+    base64::engine::general_purpose::STANDARD
+        .decode(payload.trim())
+        .ok()
+        .and_then(|bytes| String::from_utf8(bytes).ok())
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
+        .unwrap_or_else(|| raw.to_string())
+}
+
+/// Inspect the Remnawave HWID response headers *before* parsing the body and
+/// produce the user-facing message when the server rejected the request.
+///
+/// Header semantics:
+/// - `X-Hwid-Not-Supported: true` — HWID identification is required but
+///   missing. When the client did not send HWID headers the message asks to
+///   enable `send_hwid`; when it did, the server simply does not support HWID.
+/// - `X-Hwid-Max-Devices-Reached: true` — the device limit for this HWID is
+///   exhausted.
+/// - `X-Hwid-Active: true` / `X-Hwid-Limit: true` — success/compatibility
+///   markers, nothing to report.
+/// - `Announce: base64:...` — decoded and appended to an HWID rejection, but
+///   never turns an otherwise successful response into an error on its own.
+pub fn hwid_response_error(headers: &HashMap<String, String>, hwid_sent: bool) -> Option<String> {
+    let header_value = |name: &str| {
+        headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.as_str())
+    };
+    let is_true = |name: &str| header_value(name).is_some_and(|v| v.eq_ignore_ascii_case("true"));
+    let announce = header_value("Announce").map(decode_announce);
+    let with_announce = |msg: String| match &announce {
+        Some(text) => format!("{msg}\nProvider announcement: {text}"),
+        None => msg,
+    };
+
+    if is_true("X-Hwid-Not-Supported") {
+        let msg = if hwid_sent {
+            "Subscription server does not support HWID identification; disable 'send HWID' for this subscription."
+        } else {
+            "Subscription requires HWID identification; enable 'send HWID' for this subscription and retry."
+        };
+        return Some(with_announce(msg.to_string()));
+    }
+    if is_true("X-Hwid-Max-Devices-Reached") {
+        return Some(with_announce(
+            "HWID device limit reached for this subscription; deactivate another device or contact the provider."
+                .to_string(),
+        ));
+    }
+    // `X-Hwid-Active` and the legacy `X-Hwid-Limit` compatibility flag mean
+    // the request was accepted. An announcement alone is advisory.
+    None
+}
+
+fn fetch_response(
+    url: &str,
+    headers: &HashMap<String, String>,
+) -> Result<(String, HashMap<String, String>)> {
+    let agent = ureq::Agent::config_builder()
+        .http_status_as_error(false)
+        .build()
+        .new_agent();
+    let mut req = agent.get(url);
+
+    if let Some(headers_map) = req.headers_mut() {
+        for (name, value) in headers {
+            if let (Ok(n), Ok(v)) = (
+                ureq::http::HeaderName::from_bytes(name.as_bytes()),
+                ureq::http::HeaderValue::from_str(value),
+            ) {
+                headers_map.insert(n, v);
+            }
+        }
+    }
+
+    let resp = req.call().with_context(|| format!("GET {} failed", url))?;
+
+    let mut resp_headers = HashMap::new();
+    for (name, value) in resp.headers() {
+        let value = value.to_str().unwrap_or("");
+        match resp_headers.entry(name.as_str().to_string()) {
+            std::collections::hash_map::Entry::Vacant(e) => {
+                e.insert(value.to_string());
+            }
+            std::collections::hash_map::Entry::Occupied(mut e) => {
+                e.insert(format!("{}, {}", e.get(), value));
+            }
+        }
+    }
 
     if resp.status() != 200 {
+        // Remnawave reports HWID problems on non-200 responses too.
+        let hwid_sent = headers.contains_key("X-Hwid");
+        if let Some(message) = hwid_response_error(&resp_headers, hwid_sent) {
+            anyhow::bail!("{} (HTTP {} for {})", message, resp.status(), url);
+        }
         anyhow::bail!("HTTP {} for {}", resp.status(), url);
     }
 
@@ -21,6 +209,27 @@ pub fn fetch_subscription(url: &str) -> Result<Vec<Profile>> {
         .into_body()
         .read_to_string()
         .context("Failed to read subscription body")?;
+    Ok((body, resp_headers))
+}
+
+/// Fetch a subscription URL, decode its body (Base64 or plain text), and parse
+/// every share link it contains. Mixed-protocol subscriptions are supported;
+/// individual malformed lines are logged and skipped.
+///
+/// Every request identifies the client with `User-Agent: kvn-tui/<version>`;
+/// when `send_hwid` is enabled, the HWID + Linux device headers are added.
+/// Remnawave HWID response headers are inspected before the body is parsed so
+/// rejection reasons surface directly instead of failing deep inside body
+/// parsing.
+pub fn fetch_subscription(sub: &Subscription, settings: &Settings) -> Result<Vec<Profile>> {
+    let hwid_sent = sub.effective_hwid(settings).is_some();
+    let env = DeviceEnv::detect();
+    let headers = build_request_headers(sub, settings, &env);
+    let (body, resp_headers) = fetch_response(&sub.url, &headers)?;
+
+    if let Some(message) = hwid_response_error(&resp_headers, hwid_sent) {
+        anyhow::bail!("{message}");
+    }
 
     parse_subscription_body(&body)
 }
@@ -32,12 +241,221 @@ fn line_has_supported_scheme(line: &str) -> bool {
         .any(|prefix| line.starts_with(prefix))
 }
 
+fn try_parse_singbox_json(body: &str) -> Option<Vec<Profile>> {
+    use serde_json::Value;
+    let v: Value = serde_json::from_str(body).ok()?;
+    let items: Vec<serde_json::Value> = match v {
+        serde_json::Value::Array(arr) => arr,
+        serde_json::Value::Object(map) => vec![serde_json::Value::Object(map)],
+        _ => return None,
+    };
+
+    let mut profiles = Vec::new();
+    for item in items {
+        let outbounds = item.get("outbounds").and_then(|x| x.as_array());
+        let objs = match outbounds {
+            Some(a) => a.iter().collect::<Vec<_>>(),
+            None => continue,
+        };
+
+        for ob in objs {
+            let proto = ob.get("protocol").and_then(|x| x.as_str()).unwrap_or("");
+            if proto != "vless" {
+                continue;
+            }
+
+            // settings.vnext[0]: address, port
+            let vnext = ob
+                .get("settings")
+                .and_then(|s| s.get("vnext"))
+                .and_then(|v| v.as_array())
+                .and_then(|a| a.first());
+            let vnext = match vnext {
+                Some(x) => x,
+                None => continue,
+            };
+
+            let addr = vnext.get("address").and_then(|x| x.as_str())?.to_string();
+            let port = vnext.get("port").and_then(|x| x.as_u64())? as u16;
+
+            // settings.vnext[0].users[0]: id, flow, encryption
+            let user = vnext
+                .get("users")
+                .and_then(|u| u.as_array())
+                .and_then(|u| u.first());
+            let user = match user {
+                Some(x) => x,
+                None => continue,
+            };
+            let uuid = user.get("id").and_then(|x| x.as_str())?.to_string();
+            let flow = user
+                .get("flow")
+                .and_then(|x| x.as_str())
+                .map(str::to_string);
+            let encryption = user
+                .get("encryption")
+                .and_then(|x| x.as_str())
+                .unwrap_or("none")
+                .to_string();
+
+            // streamSettings: network, security, + transport / tls / reality
+            let ss = ob.get("streamSettings").cloned().unwrap_or(Value::Null);
+            let network = ss
+                .get("network")
+                .and_then(|x| x.as_str())
+                .unwrap_or("tcp")
+                .to_string();
+            let security = ss
+                .get("security")
+                .and_then(|x| x.as_str())
+                .unwrap_or("")
+                .to_string();
+
+            // собираем query-параметры в порядке, который ждёт парсер share-link
+            let mut q = vec![
+                ("type", network.as_str()),
+                ("encryption", encryption.as_str()),
+            ];
+            let mut fp = None;
+            let mut pbk = None;
+            let mut sid = None;
+            let mut sni = None;
+            if security == "reality" {
+                if let Some(rs) = ss.get("realitySettings") {
+                    sni = rs
+                        .get("serverName")
+                        .and_then(|x| x.as_str())
+                        .map(str::to_string);
+                    pbk = rs
+                        .get("publicKey")
+                        .and_then(|x| x.as_str())
+                        .map(str::to_string);
+                    sid = rs
+                        .get("shortId")
+                        .and_then(|x| x.as_str())
+                        .map(str::to_string);
+                    fp = rs
+                        .get("fingerprint")
+                        .and_then(|x| x.as_str())
+                        .map(str::to_string);
+                }
+                q.push(("security", "reality"));
+            } else if security == "tls" {
+                q.push(("security", "tls"));
+                if let Some(ts) = ss.get("tlsSettings") {
+                    sni = ts
+                        .get("serverName")
+                        .and_then(|x| x.as_str())
+                        .map(str::to_string);
+                    fp = ts
+                        .get("fingerprint")
+                        .and_then(|x| x.as_str())
+                        .map(str::to_string);
+                }
+            }
+            if let Some(ref s) = sni {
+                q.push(("sni", s.as_str()));
+            }
+            if let Some(ref p) = pbk {
+                q.push(("pbk", p.as_str()));
+            }
+            if let Some(ref s) = sid {
+                q.push(("sid", s.as_str()));
+            }
+            if let Some(ref f) = fp {
+                q.push(("fp", f.as_str()));
+            }
+            if let Some(ref f) = flow {
+                q.push(("flow", f.as_str()));
+            }
+
+            let transport = ss.get("wsSettings");
+
+            // транспорт (для ws / grpc / http)
+            match network.as_str() {
+                "ws" => {
+                    if let Some(ws) = transport {
+                        if let Some(path) = ws.get("path").and_then(|x| x.as_str()) {
+                            q.push(("path", path));
+                        }
+                        if let Some(host) = ws
+                            .get("headers")
+                            .and_then(|h| h.get("Host"))
+                            .and_then(|x| x.as_str())
+                        {
+                            q.push(("host", host));
+                        }
+                    }
+                }
+                "grpc" => {
+                    if let Some(g) = ss.get("grpcSettings")
+                        && let Some(sn) = g.get("serviceName")
+                        && let Some(sn) = sn.as_str()
+                    {
+                        q.push(("serviceName", sn));
+                    }
+                }
+                _ => {}
+            }
+
+            let query = q
+                .iter()
+                .map(|(k, v)| format!("{}={}", urlencode(k), urlencode(v)))
+                .collect::<Vec<_>>()
+                .join("&");
+
+            // имя — поле `remarks` если есть, иначе адрес
+            let name = item
+                .get("remarks")
+                .and_then(|x| x.as_str())
+                .map(str::to_string)
+                .unwrap_or_else(|| addr.clone());
+
+            let uri = format!(
+                "vless://{uuid}@{addr}:{port}?{query}#{name}",
+                uuid = uuid,
+                addr = addr,
+                port = port,
+                query = query,
+                name = urlencode(&name),
+            );
+
+            match parse_share_link(&uri) {
+                Ok(p) => profiles.push(p),
+                Err(e) => tracing::warn!("subscription: singbox-json: bad vless URI: {e}"),
+            }
+        }
+    }
+    if profiles.is_empty() {
+        None
+    } else {
+        Some(profiles)
+    }
+}
+
+fn urlencode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for byte in s.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(*byte as char);
+            }
+            _ => out.push_str(&format!("%{:02X}", byte)),
+        }
+    }
+    out
+}
+
 /// Parse a subscription body that is either Base64-encoded or plain text.
 /// Each non-empty line is interpreted as a share link in any supported scheme.
 pub fn parse_subscription_body(body: &str) -> Result<Vec<Profile>> {
     let trimmed = body.trim();
     if trimmed.is_empty() {
         anyhow::bail!("Subscription body is empty");
+    }
+
+    if let Some(profiles) = try_parse_singbox_json(trimmed) {
+        return Ok(profiles);
     }
 
     let decoded = try_decode_base64(trimmed);
@@ -140,5 +558,477 @@ mod tests {
         let encoded = base64::engine::general_purpose::STANDARD.encode(body);
         let profiles = parse_subscription_body(&encoded).unwrap();
         assert_eq!(profiles.len(), 2);
+    }
+
+    #[test]
+    fn generate_hwid_format() {
+        let hwid = generate_hwid();
+        assert!(hwid.starts_with("lnx-"));
+        let uuid_part = &hwid["lnx-".len()..];
+        assert_eq!(uuid_part.len(), 32);
+        assert!(uuid_part.chars().all(|c| c.is_ascii_hexdigit()));
+        // UUID v4: two independent generations must never collide.
+        assert_ne!(generate_hwid(), generate_hwid());
+    }
+
+    #[test]
+    fn normalize_locale_covers_common_linux_formats() {
+        assert_eq!(normalize_locale("ru_RU.UTF-8"), "ru-RU");
+        assert_eq!(normalize_locale("de_DE.utf8"), "de-DE");
+        assert_eq!(normalize_locale("zh_CN.UTF-8"), "zh-CN");
+        assert_eq!(normalize_locale("sr_RS@latin"), "sr-RS");
+        assert_eq!(normalize_locale("ru_RU"), "ru-RU");
+        assert_eq!(normalize_locale("en"), "en");
+        assert_eq!(normalize_locale("C"), "en");
+        assert_eq!(normalize_locale("POSIX"), "en");
+        assert_eq!(normalize_locale(""), "en");
+        assert_eq!(normalize_locale("C.UTF-8"), "en");
+    }
+
+    fn settings_with_hwid() -> Settings {
+        Settings {
+            hwid: "lnx-installation-hwid".to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn sub_with(url: String, send_hwid: bool, hwid: Option<&str>) -> Subscription {
+        Subscription {
+            id: Uuid::new_v4(),
+            name: "Sub".into(),
+            url,
+            auto_update: crate::config::profile::SubscriptionAutoUpdate::Off,
+            last_updated: None,
+            next_auto_update: None,
+            retry_state: None,
+            send_hwid,
+            hwid: hwid.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn build_request_headers_always_set_user_agent() {
+        let env = DeviceEnv {
+            kernel_version: "6.12.0-arch1-1".into(),
+            locale: "ru-RU".into(),
+        };
+        for send_hwid in [false, true] {
+            let sub = sub_with("https://example.com/sub".into(), send_hwid, None);
+            let headers = build_request_headers(&sub, &settings_with_hwid(), &env);
+            assert_eq!(
+                headers.get("User-Agent").map(String::as_str),
+                Some(KVN_TUI_USER_AGENT),
+            );
+            assert!(KVN_TUI_USER_AGENT.starts_with("kvn-tui/"));
+        }
+    }
+
+    #[test]
+    fn build_request_headers_send_hwid_false_sends_no_device_headers() {
+        let env = DeviceEnv {
+            kernel_version: "6.12.0-arch1-1".into(),
+            locale: "ru-RU".into(),
+        };
+        // Even a per-subscription override must not be sent when send_hwid is false.
+        let sub = sub_with(
+            "https://example.com/sub".into(),
+            false,
+            Some("provider-registered-device-id"),
+        );
+        let headers = build_request_headers(&sub, &settings_with_hwid(), &env);
+        assert!(!headers.contains_key("X-Hwid"));
+        assert!(!headers.contains_key("X-Device-Os"));
+        assert!(!headers.contains_key("X-Ver-Os"));
+        assert!(!headers.contains_key("X-Device-Model"));
+        assert!(!headers.contains_key("X-Device-Locale"));
+    }
+
+    #[test]
+    fn build_request_headers_send_hwid_true_sends_all_linux_device_headers() {
+        let env = DeviceEnv {
+            kernel_version: "6.12.0-arch1-1".into(),
+            locale: "ru-RU".into(),
+        };
+        let sub = sub_with("https://example.com/sub".into(), true, None);
+        let headers = build_request_headers(&sub, &settings_with_hwid(), &env);
+        assert_eq!(
+            headers.get("X-Hwid").map(String::as_str),
+            Some("lnx-installation-hwid")
+        );
+        assert_eq!(
+            headers.get("X-Device-Os").map(String::as_str),
+            Some("Linux")
+        );
+        assert_eq!(
+            headers.get("X-Ver-Os").map(String::as_str),
+            Some("6.12.0-arch1-1")
+        );
+        assert_eq!(
+            headers.get("X-Device-Model").map(String::as_str),
+            Some("Desktop")
+        );
+        assert_eq!(
+            headers.get("X-Device-Locale").map(String::as_str),
+            Some("ru-RU")
+        );
+    }
+
+    #[test]
+    fn build_request_headers_subscription_hwid_overrides_settings() {
+        let env = DeviceEnv {
+            kernel_version: "6.12.0-arch1-1".into(),
+            locale: "en".into(),
+        };
+        let sub = sub_with(
+            "https://example.com/sub".into(),
+            true,
+            Some("provider-registered-device-id"),
+        );
+        let headers = build_request_headers(&sub, &settings_with_hwid(), &env);
+        assert_eq!(
+            headers.get("X-Hwid").map(String::as_str),
+            Some("provider-registered-device-id"),
+        );
+    }
+
+    #[test]
+    fn hwid_response_error_not_supported_without_hwid_sent_asks_to_enable() {
+        let headers = HashMap::from([("x-hwid-not-supported".to_string(), "true".to_string())]);
+        let msg = hwid_response_error(&headers, false).unwrap();
+        assert!(msg.contains("enable 'send HWID'"), "got: {msg}");
+    }
+
+    #[test]
+    fn hwid_response_error_not_supported_with_hwid_sent_reports_unsupported() {
+        let headers = HashMap::from([
+            ("X-Hwid-Not-Supported".to_string(), "true".to_string()),
+            ("X-Hwid-Active".to_string(), "false".to_string()),
+        ]);
+        let msg = hwid_response_error(&headers, true).unwrap();
+        assert!(msg.contains("does not support HWID"), "got: {msg}");
+    }
+
+    #[test]
+    fn hwid_response_error_max_devices_reached_reports_limit() {
+        let headers =
+            HashMap::from([("X-Hwid-Max-Devices-Reached".to_string(), "true".to_string())]);
+        let msg = hwid_response_error(&headers, true).unwrap();
+        assert!(msg.contains("device limit reached"), "got: {msg}");
+    }
+
+    #[test]
+    fn hwid_response_error_limit_header_is_compatibility_success() {
+        let headers = HashMap::from([("X-Hwid-Limit".to_string(), "true".to_string())]);
+        assert!(hwid_response_error(&headers, true).is_none());
+    }
+
+    #[test]
+    fn hwid_response_error_active_header_alone_is_success() {
+        let headers = HashMap::from([
+            ("X-Hwid-Active".to_string(), "true".to_string()),
+            ("X-Hwid-Limit".to_string(), "3".to_string()),
+        ]);
+        assert!(hwid_response_error(&headers, true).is_none());
+    }
+
+    #[test]
+    fn hwid_response_error_announce_is_decoded_and_appended() {
+        let announcement = base64::engine::general_purpose::STANDARD
+            .encode("Server maintenance tonight")
+            .to_string();
+        let headers = HashMap::from([
+            ("X-Hwid-Max-Devices-Reached".to_string(), "true".to_string()),
+            ("Announce".to_string(), format!("base64:{announcement}")),
+        ]);
+        let msg = hwid_response_error(&headers, true).unwrap();
+        assert!(msg.contains("device limit reached"), "got: {msg}");
+        assert!(
+            msg.contains("Provider announcement: Server maintenance tonight"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn hwid_response_error_announce_only_is_not_an_error() {
+        let announcement = base64::engine::general_purpose::STANDARD
+            .encode("Welcome!")
+            .to_string();
+        let headers = HashMap::from([("Announce".to_string(), format!("base64:{announcement}"))]);
+        assert!(hwid_response_error(&headers, false).is_none());
+    }
+
+    #[test]
+    fn hwid_response_error_announce_undecodable_falls_back_to_raw() {
+        let headers = HashMap::from([
+            ("X-Hwid-Not-Supported".to_string(), "true".to_string()),
+            ("Announce".to_string(), "not base64!!!".to_string()),
+        ]);
+        let msg = hwid_response_error(&headers, false).unwrap();
+        assert!(msg.contains("not base64!!!"), "got: {msg}");
+    }
+
+    fn singbox_json_body() -> String {
+        r#"{
+            "remarks": "JSON node",
+            "outbounds": [{
+                "protocol": "vless",
+                "settings": {
+                    "vnext": [{
+                        "address": "198.51.100.7",
+                        "port": 8443,
+                        "users": [{
+                            "id": "671c62c7-6768-4b98-ac6b-572c9c707be0",
+                            "flow": "xtls-rprx-vision",
+                            "encryption": "none"
+                        }]
+                    }]
+                },
+                "streamSettings": {
+                    "network": "ws",
+                    "security": "tls",
+                    "tlsSettings": {"serverName": "example.com", "fingerprint": "chrome"},
+                    "wsSettings": {"path": "/wspath", "headers": {"Host": "ws.example.com"}}
+                }
+            }]
+        }"#
+        .to_string()
+    }
+
+    #[test]
+    fn parse_singbox_json_object() {
+        let profiles = parse_subscription_body(&singbox_json_body()).unwrap();
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].name, "JSON node");
+        assert_eq!(profiles[0].address, "198.51.100.7");
+        assert_eq!(profiles[0].port, 8443);
+    }
+
+    #[test]
+    fn parse_singbox_json_array() {
+        let single = singbox_json_body();
+        let body = format!("[{}, {}]", single, single);
+        let profiles = parse_subscription_body(&body).unwrap();
+        assert_eq!(profiles.len(), 2);
+    }
+
+    #[test]
+    fn parse_singbox_json_malformed_falls_back_to_text_and_fails() {
+        let body = "{not valid json, and not share links either}";
+        assert!(parse_subscription_body(body).is_err());
+    }
+
+    #[test]
+    fn parse_singbox_json_without_vless_outbounds_fails() {
+        let body = r#"{"outbounds": [{"protocol": "shadowsocks"}]}"#;
+        assert!(parse_subscription_body(body).is_err());
+    }
+
+    #[test]
+    fn parse_singbox_json_malformed_outbound_fields_are_skipped() {
+        // vless outbound missing `settings.vnext` — must not panic; the body
+        // falls through to text parsing and fails cleanly.
+        let body = r#"{"outbounds": [{"protocol": "vless"}]}"#;
+        assert!(parse_subscription_body(body).is_err());
+    }
+
+    /// Minimal one-shot HTTP server for request tests: captures the request
+    /// headers and replies with a fixed status line, extra headers and body.
+    /// Keeps request tests independent of any external subscription provider.
+    fn spawn_http_server(
+        status_line: &str,
+        extra_headers: &[(&str, String)],
+        body: &str,
+    ) -> (String, std::sync::mpsc::Receiver<HashMap<String, String>>) {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let status_line = status_line.to_string();
+        let extra_headers: Vec<(String, String)> = extra_headers
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect();
+        let body = body.to_string();
+        std::thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            let mut buf = Vec::new();
+            let mut chunk = [0u8; 1024];
+            loop {
+                match stream.read(&mut chunk) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        buf.extend_from_slice(&chunk[..n]);
+                        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                }
+            }
+            let text = String::from_utf8_lossy(&buf);
+            let mut req_headers = HashMap::new();
+            for line in text.lines().skip(1) {
+                if line.is_empty() {
+                    break;
+                }
+                if let Some((k, v)) = line.split_once(':') {
+                    req_headers.insert(k.trim().to_ascii_lowercase(), v.trim().to_string());
+                }
+            }
+            let _ = tx.send(req_headers);
+
+            let mut resp = format!(
+                "{status_line}\r\nContent-Length: {}\r\nConnection: close\r\n",
+                body.len()
+            );
+            for (k, v) in &extra_headers {
+                resp.push_str(&format!("{k}: {v}\r\n"));
+            }
+            resp.push_str("\r\n");
+            resp.push_str(&body);
+            let _ = stream.write_all(resp.as_bytes());
+        });
+        (format!("http://{addr}/sub"), rx)
+    }
+
+    fn captured_request(
+        rx: std::sync::mpsc::Receiver<HashMap<String, String>>,
+    ) -> HashMap<String, String> {
+        rx.recv_timeout(std::time::Duration::from_secs(5)).unwrap()
+    }
+
+    #[test]
+    fn fetch_always_sends_kvntui_user_agent() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let (url, rx) = spawn_http_server("HTTP/1.1 200 OK", &[], sample_vless());
+        let sub = sub_with(url, false, None);
+        fetch_subscription(&sub, &settings_with_hwid()).unwrap();
+        let req = captured_request(rx);
+        assert_eq!(
+            req.get("user-agent").map(String::as_str),
+            Some(KVN_TUI_USER_AGENT),
+        );
+    }
+
+    #[test]
+    fn fetch_send_hwid_false_does_not_send_device_headers() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let (url, rx) = spawn_http_server("HTTP/1.1 200 OK", &[], sample_vless());
+        let sub = sub_with(url, false, Some("provider-registered-device-id"));
+        fetch_subscription(&sub, &settings_with_hwid()).unwrap();
+        let req = captured_request(rx);
+        assert!(!req.contains_key("x-hwid"));
+        assert!(!req.contains_key("x-device-os"));
+        assert!(!req.contains_key("x-device-locale"));
+    }
+
+    #[test]
+    fn fetch_send_hwid_true_uses_settings_hwid_and_device_headers() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let (url, rx) = spawn_http_server("HTTP/1.1 200 OK", &[], sample_vless());
+        let sub = sub_with(url, true, None);
+        fetch_subscription(&sub, &settings_with_hwid()).unwrap();
+        let req = captured_request(rx);
+        assert_eq!(
+            req.get("x-hwid").map(String::as_str),
+            Some("lnx-installation-hwid")
+        );
+        assert_eq!(req.get("x-device-os").map(String::as_str), Some("Linux"));
+        assert_eq!(
+            req.get("x-device-model").map(String::as_str),
+            Some("Desktop")
+        );
+        assert!(req.get("x-ver-os").is_some_and(|v| !v.is_empty()));
+        assert!(req.get("x-device-locale").is_some_and(|v| !v.is_empty()));
+    }
+
+    #[test]
+    fn fetch_subscription_hwid_overrides_settings_hwid() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let (url, rx) = spawn_http_server("HTTP/1.1 200 OK", &[], sample_vless());
+        let sub = sub_with(url, true, Some("provider-registered-device-id"));
+        fetch_subscription(&sub, &settings_with_hwid()).unwrap();
+        let req = captured_request(rx);
+        assert_eq!(
+            req.get("x-hwid").map(String::as_str),
+            Some("provider-registered-device-id"),
+        );
+    }
+
+    #[test]
+    fn fetch_one_subscriptions_override_is_never_sent_to_another() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let settings = settings_with_hwid();
+
+        // Subscription A carries a provider-registered HWID override...
+        let (url_a, rx_a) = spawn_http_server("HTTP/1.1 200 OK", &[], sample_vless());
+        let sub_a = sub_with(url_a, true, Some("provider-registered-device-id"));
+        fetch_subscription(&sub_a, &settings).unwrap();
+        assert_eq!(
+            captured_request(rx_a).get("x-hwid").map(String::as_str),
+            Some("provider-registered-device-id"),
+        );
+
+        // ...and subscription B (no override) falls back to settings.hwid,
+        // never to A's override.
+        let (url_b, rx_b) = spawn_http_server("HTTP/1.1 200 OK", &[], sample_vless());
+        let sub_b = sub_with(url_b, true, None);
+        fetch_subscription(&sub_b, &settings).unwrap();
+        assert_eq!(
+            captured_request(rx_b).get("x-hwid").map(String::as_str),
+            Some("lnx-installation-hwid"),
+        );
+
+        // ...and subscription C (send_hwid: false) sends no HWID at all.
+        let (url_c, rx_c) = spawn_http_server("HTTP/1.1 200 OK", &[], sample_vless());
+        let sub_c = sub_with(url_c, false, None);
+        fetch_subscription(&sub_c, &settings).unwrap();
+        assert!(!captured_request(rx_c).contains_key("x-hwid"));
+    }
+
+    #[test]
+    fn fetch_hwid_not_supported_response_reports_enable_send_hwid() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let (url, _rx) = spawn_http_server(
+            "HTTP/1.1 200 OK",
+            &[("X-Hwid-Not-Supported", "true".to_string())],
+            sample_vless(),
+        );
+        let sub = sub_with(url, false, None);
+        let err = fetch_subscription(&sub, &settings_with_hwid()).unwrap_err();
+        assert!(err.to_string().contains("enable 'send HWID'"), "got: {err}");
+    }
+
+    #[test]
+    fn fetch_hwid_max_devices_reached_response_reports_limit() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let (url, _rx) = spawn_http_server(
+            "HTTP/1.1 200 OK",
+            &[("X-Hwid-Max-Devices-Reached", "true".to_string())],
+            sample_vless(),
+        );
+        let sub = sub_with(url, true, None);
+        let err = fetch_subscription(&sub, &settings_with_hwid()).unwrap_err();
+        assert!(
+            err.to_string().contains("device limit reached"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn fetch_hwid_rejection_on_http_403_is_reported() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let (url, _rx) = spawn_http_server(
+            "HTTP/1.1 403 Forbidden",
+            &[("X-Hwid-Not-Supported", "true".to_string())],
+            "forbidden",
+        );
+        let sub = sub_with(url, false, None);
+        let err = fetch_subscription(&sub, &settings_with_hwid()).unwrap_err();
+        assert!(err.to_string().contains("enable 'send HWID'"), "got: {err}");
+        assert!(err.to_string().contains("HTTP 403"), "got: {err}");
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -620,10 +620,11 @@ fn execute_daemon_effect(
         }
         Effect::UpdateSubscription { id } => {
             if let Some(sub) = model.config.subscriptions.iter().find(|s| s.id == id) {
-                let url = sub.url.clone();
+                let sub = sub.clone();
+                let settings = model.config.settings.clone();
                 let tx = tx.clone();
                 thread::spawn(move || {
-                    let result = crate::config::subscription::fetch_subscription(&url)
+                    let result = crate::config::subscription::fetch_subscription(&sub, &settings)
                         .map_err(crate::app::msg::IpcError::from);
                     let _ = tx.send(Msg::SubscriptionFetched { id, result });
                 });

--- a/src/tui_client/editor.rs
+++ b/src/tui_client/editor.rs
@@ -413,6 +413,8 @@ mod tests {
                     last_updated: None,
                     next_auto_update: None,
                     retry_state: None,
+                    send_hwid: false,
+                    hwid: None,
                 },
                 Subscription {
                     id: Uuid::new_v4(),
@@ -422,6 +424,8 @@ mod tests {
                     last_updated: None,
                     next_auto_update: None,
                     retry_state: None,
+                    send_hwid: false,
+                    hwid: None,
                 },
             ],
             ..Default::default()

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1370,6 +1370,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
         model
     }
@@ -2171,6 +2173,8 @@ mod tests {
             last_updated: None,
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
         model.selected = 0;
         insta::assert_snapshot!(snapshot_terminal(&model, 80, 20));
@@ -2444,6 +2448,8 @@ mod tests {
             last_updated: Some(last_updated),
             next_auto_update: None,
             retry_state: None,
+            send_hwid: false,
+            hwid: None,
         });
         model.selected = 0;
         insta::assert_snapshot!(snapshot_terminal(&model, 80, 20));


### PR DESCRIPTION
## Summary

Add opt-in HWID identification for subscription providers that require a stable device identifier, including Remnawave-based services.

HWID data is sent only for subscriptions with `send_hwid: true`; regular subscriptions continue to receive only the kvn-tui User-Agent.

## Changes

- Generate one stable installation HWID and persist it through the existing validated atomic config-write path.
- Add the per-subscription `send_hwid` flag and optional `hwid` override.
- Send `User-Agent: kvn-tui/<version>` with every subscription request.
- Send Linux device headers only when HWID support is enabled:
  - `X-Hwid`
  - `X-Device-Os`
  - `X-Ver-Os`
  - `X-Device-Model`
  - `X-Device-Locale`
- Detect the kernel version and locale from the current system instead of imitating another platform.
- Validate effective HWIDs through `Config::validate()` and reject empty, oversized, or invalid HTTP header values.
- Handle Remnawave HWID response headers without treating `X-Hwid-Limit` or an advisory `Announce` as request failures.
- Support VLESS subscriptions returned as Xray JSON in addition to share-link lists.
- Keep existing configurations backward-compatible and omit disabled HWID fields when serializing subscriptions.
