### PR TITLE
docs(contributing): add contribution guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- What user-visible problem does this PR solve, and how? -->
+
+## Changes
+
+<!-- List the changes included in this PR. -->
+
+## Testing
+
+<!-- List the automated tests added and the commands run. -->
+
+- [ ] I added or updated tests for every behavior change and regression.
+- [ ] `cargo fmt --check` passes.
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes.
+- [ ] `cargo test --locked` passes.
+- [ ] Region and line coverage remain at or above 85%.
+
+## Contribution checklist
+
+- [ ] This PR is based on the latest `develop` branch.
+- [ ] This PR contains one logical change.
+- [ ] The title follows `type(scope): imperative description` and is in English.
+- [ ] The title is suitable for inclusion in generated release notes.
+- [ ] The description is in English and documents the complete scope.
+- [ ] No secrets, real subscription URLs, credentials, or device identifiers are included.
+- [ ] User-facing documentation is updated where necessary.
+
+<!-- See CONTRIBUTING.md for the complete guidelines. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,119 @@
+# Contributing to kvn-tui
+
+Thank you for contributing. These guidelines keep changes reviewable and make
+the generated changelog useful to users.
+
+## Before You Start
+
+- Open an issue before beginning a large feature or architectural change.
+- Base your work on the latest `develop` branch.
+- Keep each pull request focused on one logical change. Unrelated refactors,
+  parsers, dependency changes, and behavior changes belong in separate pull
+  requests.
+- Do not commit subscription URLs, access tokens, credentials, real server
+  addresses, device identifiers, or other private data. Use clearly fictional
+  values in tests and examples.
+
+## Branch Names
+
+Use a lowercase `<type>/<short-description>` name. Recommended types match
+Conventional Commits:
+
+```text
+feat/subscription-headers
+fix/subscription-retry
+docs/contributing-guidelines
+refactor/config-parser
+test/subscription-import
+```
+
+Avoid vague names such as `changes`, `updates`, or `add-stuff`.
+
+## Commits
+
+Write commit messages in English and follow
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):
+
+```text
+type(scope): imperative description
+```
+
+Examples:
+
+```text
+fix(subscription): send headers only to their configured source
+feat(ui): add subscription settings overlay
+test(subscription): cover HTTP retry behavior
+docs: document custom DNS servers
+```
+
+Use one of `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`,
+`ci`, `chore`, or `revert`. Keep the summary specific and imperative: use
+`add`, `fix`, or `prevent`, not `added`, `fixed`, or `misc changes`.
+
+## Pull Requests
+
+Pull request titles and descriptions must be written in English. The title
+must use the same Conventional Commits format as a commit message:
+
+```text
+fix(subscription): support per-source request headers
+```
+
+GitHub uses merged pull request titles to generate release notes. Write the
+title as a concise, user-facing changelog entry. A title such as `update code`
+will become an unhelpful public release note.
+
+The description must explain:
+
+- the user-visible problem or motivation;
+- what the pull request changes;
+- important design and security decisions;
+- how the change was tested;
+- related issues, when applicable.
+
+Update the pull request when its scope changes. Reviewers should not have to
+infer important behavior from the diff.
+
+## Code and Architecture
+
+- Follow the architecture and project conventions in `AGENTS.md`.
+- Keep `app::update::update` free of I/O, threads, and system calls. Declare
+  side effects as `Effect` values and execute them in the daemon.
+- Use atomic writes for configuration and persistent state.
+- Use `tracing` for logging; do not use `println!`.
+- Support Arch Linux unless an issue explicitly expands the platform scope.
+- Use the existing `src/foo.rs` plus `src/foo/bar.rs` module layout; do not add
+  `mod.rs` files.
+
+## Tests and Quality Checks
+
+Every behavior change and bug fix must include tests that fail without the
+change and pass with it. Exercise error paths and boundary cases as well as the
+happy path. Network-dependent logic should use a local test server or be split
+so that its decisions can be tested as pure functions; tests must not depend on
+an external subscription provider.
+
+Total region and line coverage must remain at or above 85%. Before opening a
+pull request, run:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --locked
+cargo llvm-cov --locked --summary-only
+```
+
+The last command requires `cargo-llvm-cov`. CI runs the same formatting,
+linting, test, and coverage gates.
+
+## Review Checklist
+
+- The branch starts from the current `develop` branch.
+- The pull request contains one logical change.
+- The title follows Conventional Commits and is suitable for release notes.
+- The title and description are in English.
+- Tests cover all new behavior and regressions.
+- Formatting, Clippy, tests, and coverage pass without warnings.
+- No secrets or real subscription data are included.
+- User-facing documentation is updated when behavior or configuration changes.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - [Architecture Highlights](#architecture-highlights)
 - [Upgrading to v0.22.0 on Omarchy](#upgrading-to-v0220-on-omarchy)
 - [Upgrading to v0.20.0](#upgrading-to-v0200)
+- [Contributing](#contributing)
 - [Author](#author)
 - [License](#license)
 
@@ -316,16 +317,16 @@ Version 0.20.0 moved daemon startup from Hyprland autostart to a systemd user se
 
 ---
 
-## Author
-
-Created and maintained by [Dmitry Yarikov](https://github.com/yarikov) — <dmitry@yarikov.com>.
-
 ## Contributing
 
 Contributions are welcome. Before opening a pull request, read
 [CONTRIBUTING.md](CONTRIBUTING.md) for branch naming, Conventional Commit and
 pull request title requirements, testing, and coverage expectations. Pull
 request titles are used in generated release notes.
+
+## Author
+
+Created and maintained by [Dmitry Yarikov](https://github.com/yarikov) — <dmitry@yarikov.com>.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -320,6 +320,13 @@ Version 0.20.0 moved daemon startup from Hyprland autostart to a systemd user se
 
 Created and maintained by [Dmitry Yarikov](https://github.com/yarikov) — <dmitry@yarikov.com>.
 
+## Contributing
+
+Contributions are welcome. Before opening a pull request, read
+[CONTRIBUTING.md](CONTRIBUTING.md) for branch naming, Conventional Commit and
+pull request title requirements, testing, and coverage expectations. Pull
+request titles are used in generated release notes.
+
 ## License
 
 MIT


### PR DESCRIPTION
 ## Summary

  Add contributor guidelines to keep pull requests consistent, reviewable, and suitable for generated GitHub release notes.

  ## Changes

  - add `CONTRIBUTING.md` with branch naming and Conventional Commit requirements
  - require pull request titles and descriptions to be written in English
  - document that merged PR titles are used in generated release notes
  - define testing, Clippy, formatting, and minimum coverage expectations
  - add security guidance for subscription URLs, credentials, and device identifiers
  - add a GitHub pull request template with contribution and testing checklists
  - link the contribution guide from the README