### PR TITLE
fix(packaging): restore sing-box capabilities after upgrades

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
           mkdir -p "kvn-tui-${VERSION}-x86_64-linux"
           cp target/release/kvn-tui "kvn-tui-${VERSION}-x86_64-linux/"
           cp contrib/kvn-tui.service "kvn-tui-${VERSION}-x86_64-linux/"
+          cp contrib/kvn-tui-sing-box-capabilities.hook "kvn-tui-${VERSION}-x86_64-linux/"
           cp LICENSE "kvn-tui-${VERSION}-x86_64-linux/"
           tar czf "kvn-tui-${VERSION}-x86_64-linux.tar.gz" "kvn-tui-${VERSION}-x86_64-linux"
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ systemctl --user enable --now kvn-tui.service
 ```
 
 `sing-box` is installed automatically. The user service keeps the daemon
-available after login.
+available after login. The package also restores the TUN capabilities on
+`/usr/bin/sing-box` automatically after pacman upgrades it.
 
 ### Polkit setup (recommended)
 

--- a/contrib/kvn-tui-sing-box-capabilities.hook
+++ b/contrib/kvn-tui-sing-box-capabilities.hook
@@ -1,0 +1,11 @@
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = Path
+Target = usr/bin/sing-box
+
+[Action]
+Description = Restoring sing-box capabilities for kvn-tui...
+When = PostTransaction
+Depends = libcap
+Exec = /usr/bin/setcap cap_net_admin,cap_net_raw+ep /usr/bin/sing-box

--- a/docs/system-integration.md
+++ b/docs/system-integration.md
@@ -12,12 +12,15 @@ The Arch package installs:
 |------|------|---------|
 | `/usr/bin/kvn-tui` | `0755` | Application binary |
 | `/usr/lib/systemd/user/kvn-tui.service` | `0644` | Per-user daemon service |
+| `/usr/share/libalpm/hooks/kvn-tui-sing-box-capabilities.hook` | `0644` | Restores sing-box capabilities after package updates |
 | `/usr/share/licenses/kvn-tui/LICENSE` | `0644` | MIT license for the source package |
 | `/usr/share/licenses/kvn-tui-bin/LICENSE` | `0644` | MIT license for the binary package |
 
 The package post-install hook grants `/usr/bin/sing-box` the
 `cap_net_admin,cap_net_raw+ep` capabilities required for TUN operation. It does
-not enable the daemon service automatically; enable it as your regular user:
+not enable the daemon service automatically. An ALPM hook restores these
+capabilities whenever pacman installs or upgrades `/usr/bin/sing-box`; manually
+replaced binaries are not covered. Enable the daemon as your regular user:
 
 ```bash
 systemctl --user enable --now kvn-tui.service
@@ -29,8 +32,8 @@ Before removing the package, stop and disable the service:
 systemctl --user disable --now kvn-tui.service
 ```
 
-Removing kvn-tui does not remove capabilities from sing-box. If no other
-software needs them, they can be revoked explicitly:
+Removing kvn-tui removes the ALPM hook but does not remove capabilities already
+set on sing-box. If no other software needs them, they can be revoked explicitly:
 
 ```bash
 sudo setcap -r /usr/bin/sing-box

--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -7,7 +7,7 @@ arch=('x86_64')
 url="https://github.com/yarikov/kvn-tui"
 license=('MIT')
 install=kvn-tui.install
-depends=('gcc-libs' 'dbus' 'sing-box')
+depends=('gcc-libs' 'dbus' 'libcap' 'sing-box')
 optdepends=(
     'wl-clipboard: clipboard integration on Wayland'
     'xclip: clipboard integration on X11 (preferred)'
@@ -28,5 +28,7 @@ package() {
     cd "$startdir/../../"
     install -Dm755 "target/release/$pkgname" "$pkgdir/usr/bin/$pkgname"
     install -Dm644 contrib/kvn-tui.service "$pkgdir/usr/lib/systemd/user/kvn-tui.service"
+    install -Dm644 contrib/kvn-tui-sing-box-capabilities.hook \
+        "$pkgdir/usr/share/libalpm/hooks/kvn-tui-sing-box-capabilities.hook"
     install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }

--- a/pkg/aur/PKGBUILD.bin
+++ b/pkg/aur/PKGBUILD.bin
@@ -7,7 +7,7 @@ arch=('x86_64')
 url="https://github.com/yarikov/kvn-tui"
 license=('MIT')
 install=kvn-tui.install
-depends=('gcc-libs' 'dbus' 'sing-box')
+depends=('gcc-libs' 'dbus' 'libcap' 'sing-box')
 optdepends=(
     'wl-clipboard: clipboard integration on Wayland'
     'xclip: clipboard integration on X11 (preferred)'
@@ -22,5 +22,7 @@ package() {
     cd "kvn-tui-{{VERSION}}-x86_64-linux"
     install -Dm755 kvn-tui "$pkgdir/usr/bin/kvn-tui"
     install -Dm644 kvn-tui.service "$pkgdir/usr/lib/systemd/user/kvn-tui.service"
+    install -Dm644 kvn-tui-sing-box-capabilities.hook \
+        "$pkgdir/usr/share/libalpm/hooks/kvn-tui-sing-box-capabilities.hook"
     install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }


### PR DESCRIPTION
  ## Summary

  Automatically restore the network capabilities required for TUN operation after pacman installs or upgrades `sing-box`.

  Previously, capabilities were applied only when `kvn-tui` itself was installed or upgraded. Replacing `/usr/bin/sing-box` during a separate package upgrade removed them and required users to run `setcap` manually.

  ## Changes

  - Add a post-transaction ALPM hook triggered by installation or upgrade of `usr/bin/sing-box`.
  - Reapply `cap_net_admin,cap_net_raw+ep` to `/usr/bin/sing-box`.
  - Include the hook in both source and binary Arch packages.
  - Add `libcap` as an explicit runtime dependency.
  - Include the hook in GitHub release archives used by `kvn-tui-bin`.
  - Document automatic capability restoration and removal behavior.
  - Keep the existing package install script for installations where `sing-box` is already present and unaffected by the transaction.