### PR TITLE
feat(geo): show last synchronization time

### DIFF
--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -1123,7 +1123,7 @@ fn handle_geo_result(model: &mut Model, result: GeoResult) -> Vec<Effect> {
     let mut effects = match result {
         GeoResult::Updated {
             parts,
-            last_updated,
+            last_updated: _,
             checked_at,
             retry_state,
             service_retry_states,
@@ -1137,7 +1137,7 @@ fn handle_geo_result(model: &mut Model, result: GeoResult) -> Vec<Effect> {
             model.service_checked_at = service_checked_at;
             model.geo_next_update = next_update;
             model.service_next_updates = service_next_updates;
-            model.geo_last_updated = last_updated;
+            model.geo_last_updated = Some(checked_at.format("%d %b %H:%M").to_string());
             model.geo_last_checked_at = Some(checked_at);
             let mut log_effects = Vec::new();
             for part in &parts {
@@ -1188,6 +1188,9 @@ fn handle_geo_result(model: &mut Model, result: GeoResult) -> Vec<Effect> {
             model.geo_next_update = next_update;
             model.service_next_updates = service_next_updates;
             model.geo_last_checked_at = checked_at;
+            if let Some(checked_at) = checked_at {
+                model.geo_last_updated = Some(checked_at.format("%d %b %H:%M").to_string());
+            }
             let mut effects = Vec::new();
             let status = if warnings.is_empty() {
                 AppStatus::Info("Geo databases are up to date".into())

--- a/src/geo.rs
+++ b/src/geo.rs
@@ -377,13 +377,14 @@ impl GeoManager {
         }
     }
 
-    /// Return a human-readable string of the last update time for the given region, or None.
+    /// Return a human-readable string of the last successful synchronization
+    /// time for the given region, or `None`.
     pub fn last_updated(&self, region: GeoRegion) -> Option<String> {
         if matches!(region, GeoRegion::Global) {
             return None;
         }
         let meta = self.load_metadata().ok()?;
-        meta.updated_at
+        meta.checked_at
             .get(&region)
             .map(|dt| dt.format("%d %b %H:%M").to_string())
     }
@@ -1357,16 +1358,16 @@ mod tests {
     }
 
     #[test]
-    fn last_updated_returns_formatted_string_after_save() {
+    fn last_updated_returns_last_check_formatted_after_save() {
         let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
         unsafe { std::env::set_var("XDG_CONFIG_HOME", dir.path()) };
         let gm = GeoManager::new().unwrap();
-        let mut updated_at = HashMap::new();
+        let mut checked_at = HashMap::new();
         let dt = Local::now();
-        updated_at.insert(GeoRegion::Ru, dt);
+        checked_at.insert(GeoRegion::Ru, dt);
         let meta = GeoMetadata {
-            updated_at,
+            checked_at,
             ..GeoMetadata::default()
         };
         gm.save_metadata(&meta).unwrap();


### PR DESCRIPTION
  ## Summary

  Show the time of the latest successful Geo synchronization in the status bar instead of the time when rule-set files were last downloaded.

  This avoids displaying a stale timestamp after a successful check finds that the local Geo databases are already up to date. Failed checks do not change the displayed timestamp.

  ## Changes

  - Use the latest successful Geo check timestamp for `[Geo: …]`.
  - Refresh the timestamp when remote rule sets are already up to date.
  - Keep the previous timestamp when synchronization fails.
  - Update the Geo metadata test to cover synchronization time.