### PR TITLE
feat(logging): add configurable log line retention

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,11 +16,11 @@ with a partial file.
 
 ## File structure
 
-The current schema version is 2. A minimal configuration is:
+The current schema version is 4. A minimal configuration is:
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 4,
   "profiles": [],
   "subscriptions": [],
   "settings": {}
@@ -49,10 +49,22 @@ A subscription contains `id`, `name`, `url`, `auto_update`, and an optional
 | `kill_switch` | `false` | Persisted kill-switch state |
 | `last_connected_profile` | `null` | Last connected profile; maintained by the application |
 | `theme` | `tokyo-night` | Bundled palette slug or `omarchy` |
-| `log_level` | `info` | `trace`, `debug`, `info`, `warn`, or `error` |
+| `logs.level` | `info` | `trace`, `debug`, `info`, `warn`, or `error` |
+| `logs.line_retention.app` | `1000` | Physical lines retained in `app.log` |
+| `logs.line_retention.singbox` | `100000` | Physical lines retained in `sing-box.log` |
+
+```json
+"logs": {
+  "level": "info",
+  "line_retention": {
+    "app": 1000,
+    "singbox": 100000
+  }
+}
+```
 
 `dns_strategy` is a legacy compatibility field mirrored from `dns.strategy`.
-Edit `dns.strategy` instead. `RUST_LOG`, when set, overrides `log_level`.
+Edit `dns.strategy` instead. `RUST_LOG`, when set, overrides `logs.level`.
 
 ## DNS
 
@@ -141,15 +153,21 @@ Press `C` to choose one of the 22 palettes bundled from [`themes/`](../themes/).
 The special `omarchy` value follows the active Omarchy theme. Fresh non-Omarchy
 installations use `tokyo-night`.
 
-`log_level` controls both application and generated sing-box logging. Accepted
+`logs.level` controls both application and generated sing-box logging. Accepted
 values are `trace`, `debug`, `info`, `warn`, and `error`; `RUST_LOG` takes
 precedence when present.
+
+`logs.line_retention.app` and `logs.line_retention.singbox` are line limits for
+the two on-disk log files. Both values must be at least `1000`. Both files are
+checked when the daemon starts; `sing-box.log` is additionally checked at a
+safe reconnect point no more than once every 24 hours. Active sing-box logging
+is never truncated in place.
 
 ## Validation and migrations
 
 Configuration is parsed, migrated, and semantically validated before use.
 Validation checks profile references and required values, DNS tags and server
-references, the TUN interface, theme slug, and log level.
+references, the TUN interface, theme slug, log level, and minimum log limits.
 
 The TUN interface must contain only ASCII letters, digits, `-`, or `_`, and be
 at most 15 characters. `default_profile`, when set, must reference an existing

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -597,7 +597,7 @@ fn connection_settings_changed(
         || old.dns != new.dns
         || old.geo_routing.mode() != new.geo_routing.mode()
         || old.geo_routing.service_routes != new.geo_routing.service_routes
-        || old.log_level != new.log_level
+        || old.logs.level != new.logs.level
 }
 
 fn handle_tick(model: &mut Model) -> Vec<Effect> {
@@ -1663,7 +1663,7 @@ mod tests {
         assert!(connection_settings_changed(&original, &changed));
 
         let mut changed = original.clone();
-        changed.log_level = "debug".into();
+        changed.logs.level = "debug".into();
         assert!(connection_settings_changed(&original, &changed));
 
         let mut changed = original.clone();

--- a/src/config.rs
+++ b/src/config.rs
@@ -159,7 +159,7 @@ mod tests {
             loaded.settings.geo_routing.auto_update,
             profile::GeoAutoUpdate::Every1d
         );
-        assert!(persisted.contains("\"schema_version\": 3"));
+        assert!(persisted.contains("\"schema_version\": 4"));
         assert!(persisted.contains("\"auto_update\": \"every1d\""));
         assert!(!persisted.contains("every1h"));
         assert!(!persisted.contains("every_12h"));

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -1286,6 +1286,43 @@ impl GeoRouting {
     }
 }
 
+/// Per-file on-disk log line limits.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LineRetention {
+    #[serde(default = "default_app_line_retention")]
+    pub app: u32,
+    #[serde(default = "default_singbox_line_retention")]
+    pub singbox: u32,
+}
+
+impl Default for LineRetention {
+    fn default() -> Self {
+        Self {
+            app: default_app_line_retention(),
+            singbox: default_singbox_line_retention(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LogsConfig {
+    #[serde(default = "default_log_level")]
+    pub level: String,
+    #[serde(default)]
+    pub line_retention: LineRetention,
+}
+
+impl Default for LogsConfig {
+    fn default() -> Self {
+        Self {
+            level: default_log_level(),
+            line_retention: LineRetention::default(),
+        }
+    }
+}
+
 /// Application settings stored alongside profiles.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -1314,12 +1351,11 @@ pub struct Settings {
     /// names a bundled palette (see `src/ui/palette.rs`).
     #[serde(default = "default_theme")]
     pub theme: String,
-    /// Tracing filter applied at startup. Accepted values:
-    /// `trace`, `debug`, `info`, `warn`, `error`. Anything else falls back
-    /// to `info` at read time. The `RUST_LOG` env var, if set, wins over
-    /// this field. Edited only via the JSON editor (`e` in the TUI).
-    #[serde(default = "default_log_level")]
-    pub log_level: String,
+    #[serde(default)]
+    pub logs: LogsConfig,
+    /// Pre-v4 compatibility field migrated into `logs.level` on load.
+    #[serde(default, rename = "log_level", skip_serializing)]
+    pub(crate) legacy_log_level: Option<String>,
 }
 
 /// Accept `address` if it parses as a bare IPv4/IPv6 literal or as a hostname.
@@ -1355,10 +1391,20 @@ pub fn default_log_level() -> String {
     "info".to_string()
 }
 
+pub fn default_app_line_retention() -> u32 {
+    1_000
+}
+
+pub fn default_singbox_line_retention() -> u32 {
+    100_000
+}
+
 /// Canonical log-level values accepted by both `tracing_subscriber::EnvFilter`
 /// and sing-box's `log.level`. Also used as the allow-list by
 /// [`Settings::validate`].
 pub const LOG_LEVELS: &[&str] = &["trace", "debug", "info", "warn", "error"];
+
+const MIN_LOG_LINES: u32 = 1_000;
 
 /// Linux IFNAMSIZ − 1 (the kernel reserves one byte for the terminator).
 const MAX_TUN_INTERFACE_LEN: usize = 15;
@@ -1372,7 +1418,7 @@ pub const OMARCHY_THEME_SENTINEL: &str = "omarchy";
 // `ui` depends on `config`, so a dep in the other direction would be circular.
 include!(concat!(env!("OUT_DIR"), "/bundled_theme_names.rs"));
 
-/// Map a `settings.log_level` value to one of the five canonical levels
+/// Map a `settings.logs.level` value to one of the five canonical levels
 /// (`trace`/`debug`/`info`/`warn`/`error`). Anything else returns `"info"`.
 /// Used both by the tracing filter in `main.rs` and by the sing-box config
 /// generator, so the level the user sets in the JSON applies to both.
@@ -1429,12 +1475,19 @@ impl Settings {
             );
         }
 
-        if !LOG_LEVELS.contains(&self.log_level.as_str()) {
+        if !LOG_LEVELS.contains(&self.logs.level.as_str()) {
             anyhow::bail!(
-                "settings.log_level {:?} is not one of {:?}",
-                self.log_level,
+                "settings.logs.level {:?} is not one of {:?}",
+                self.logs.level,
                 LOG_LEVELS,
             );
+        }
+
+        if self.logs.line_retention.app < MIN_LOG_LINES {
+            anyhow::bail!("settings.logs.line_retention.app must be at least {MIN_LOG_LINES}");
+        }
+        if self.logs.line_retention.singbox < MIN_LOG_LINES {
+            anyhow::bail!("settings.logs.line_retention.singbox must be at least {MIN_LOG_LINES}");
         }
 
         Ok(())
@@ -1453,14 +1506,15 @@ impl Default for Settings {
             kill_switch: false,
             last_connected_profile: None,
             theme: default_theme(),
-            log_level: default_log_level(),
+            logs: LogsConfig::default(),
+            legacy_log_level: None,
         }
     }
 }
 
 /// Current schema version for `profiles.json`. Bumped on every breaking
 /// change to the persisted shape; new migrations go in `Config::migrate`.
-pub const CURRENT_SCHEMA_VERSION: u32 = 3;
+pub const CURRENT_SCHEMA_VERSION: u32 = 4;
 
 fn default_schema_version() -> u32 {
     // Files written before the version was introduced are treated as v0
@@ -1561,6 +1615,10 @@ impl Config {
             self.migrate_v2_to_v3();
             self.schema_version = 3;
         }
+        if self.schema_version == 3 {
+            self.migrate_v3_to_v4();
+            self.schema_version = 4;
+        }
         debug_assert_eq!(self.schema_version, CURRENT_SCHEMA_VERSION);
         Ok(())
     }
@@ -1611,6 +1669,12 @@ impl Config {
         }
         if self.settings.geo_routing.auto_update == GeoAutoUpdate::Every12h {
             self.settings.geo_routing.auto_update = GeoAutoUpdate::Every1d;
+        }
+    }
+
+    fn migrate_v3_to_v4(&mut self) {
+        if let Some(level) = self.settings.legacy_log_level.take() {
+            self.settings.logs.level = level;
         }
     }
 }
@@ -1754,19 +1818,22 @@ mod tests {
         assert!(s.geo_routing.selected_region_modes.is_empty());
         assert_eq!(s.geo_routing.auto_update, GeoAutoUpdate::Off);
         assert_eq!(s.geo_routing.mode(), RoutingMode::Global);
-        assert_eq!(s.log_level, "info");
+        assert_eq!(s.logs.level, "info");
+        assert_eq!(s.logs.line_retention.app, 1_000);
+        assert_eq!(s.logs.line_retention.singbox, 100_000);
     }
 
     #[test]
     fn settings_log_level_round_trips_through_json() {
-        let s = Settings {
-            log_level: "debug".to_string(),
-            ..Settings::default()
-        };
+        let mut s = Settings::default();
+        s.logs.level = "debug".to_string();
         let json = serde_json::to_string(&s).unwrap();
-        assert!(json.contains("\"log_level\":\"debug\""));
+        assert!(json.contains("\"logs\":{\"level\":\"debug\""));
+        assert!(!json.contains("\"log_level\""));
         let restored: Settings = serde_json::from_str(&json).unwrap();
-        assert_eq!(restored.log_level, "debug");
+        assert_eq!(restored.logs.level, "debug");
+        assert_eq!(restored.logs.line_retention.app, 1_000);
+        assert_eq!(restored.logs.line_retention.singbox, 100_000);
     }
 
     #[test]
@@ -1792,7 +1859,9 @@ mod tests {
             "auto_connect": false
         }"#;
         let s: Settings = serde_json::from_str(json).unwrap();
-        assert_eq!(s.log_level, "info");
+        assert_eq!(s.logs.level, "info");
+        assert_eq!(s.logs.line_retention.app, 1_000);
+        assert_eq!(s.logs.line_retention.singbox, 100_000);
         assert_eq!(s.geo_routing.auto_update, GeoAutoUpdate::Off);
     }
 
@@ -2356,32 +2425,53 @@ mod tests {
     #[test]
     fn settings_validate_accepts_every_canonical_log_level() {
         for level in LOG_LEVELS {
-            let s = Settings {
-                log_level: (*level).to_string(),
-                ..Settings::default()
-            };
+            let mut s = Settings::default();
+            s.logs.level = (*level).to_string();
             s.validate().unwrap();
         }
     }
 
     #[test]
     fn settings_validate_rejects_unknown_log_level() {
-        let s = Settings {
-            log_level: "verbose".into(),
-            ..Settings::default()
-        };
+        let mut s = Settings::default();
+        s.logs.level = "verbose".into();
         let err = s.validate().unwrap_err().to_string();
-        assert!(err.contains("log_level"), "Error was: {}", err);
+        assert!(err.contains("logs.level"), "Error was: {}", err);
+    }
+
+    #[test]
+    fn settings_validate_rejects_log_line_limits_below_minimum() {
+        for value in [0, 1, 999] {
+            let mut app = Settings::default();
+            app.logs.line_retention.app = value;
+            assert!(app.validate().unwrap_err().to_string().contains(".app"));
+
+            let mut singbox = Settings::default();
+            singbox.logs.line_retention.singbox = value;
+            assert!(
+                singbox
+                    .validate()
+                    .unwrap_err()
+                    .to_string()
+                    .contains(".singbox")
+            );
+        }
+    }
+
+    #[test]
+    fn settings_validate_accepts_minimum_log_line_limits() {
+        let mut settings = Settings::default();
+        settings.logs.line_retention.app = MIN_LOG_LINES;
+        settings.logs.line_retention.singbox = MIN_LOG_LINES;
+        settings.validate().unwrap();
     }
 
     #[test]
     fn settings_validate_rejects_uppercased_log_level() {
         // normalized_log_level lowercases at runtime, but on-disk config is
         // validated case-sensitively so the JSON does not silently drift.
-        let s = Settings {
-            log_level: "INFO".into(),
-            ..Settings::default()
-        };
+        let mut s = Settings::default();
+        s.logs.level = "INFO".into();
         assert!(s.validate().is_err());
     }
 
@@ -3421,9 +3511,25 @@ mod tests {
     }
 
     #[test]
-    fn migrate_chains_v0_through_v2() {
-        // schema_version=0 must arrive at v2 in a single migrate() call,
-        // running both v0→v1 and v1→v2 steps.
+    fn migrate_v3_to_v4_nests_legacy_log_level() {
+        let mut cfg = Config {
+            schema_version: 3,
+            ..Config::default()
+        };
+        cfg.settings.legacy_log_level = Some("debug".into());
+
+        cfg.migrate().unwrap();
+
+        assert_eq!(cfg.schema_version, CURRENT_SCHEMA_VERSION);
+        assert_eq!(cfg.settings.logs.level, "debug");
+        assert!(cfg.settings.legacy_log_level.is_none());
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert!(!json.contains("log_level"));
+    }
+
+    #[test]
+    fn migrate_chains_v0_through_current() {
+        // schema_version=0 must arrive at the current version in one call.
         let mut cfg = Config {
             schema_version: 0,
             ..Config::default()

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -19,14 +19,49 @@ struct ProcessSlot {
     handle: Option<ProcessHandle>,
 }
 
+struct DaemonShared {
+    process_slot: Arc<Mutex<ProcessSlot>>,
+    connect_coordinator: Arc<Mutex<()>>,
+    singbox_log_pruned_at: Arc<Mutex<Option<Instant>>>,
+}
+
+const LOG_PRUNE_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+
 /// Run the daemon main loop.
 pub fn run(mut model: Model) -> Result<()> {
+    let (tx, rx) = channel::<Msg>();
+    let ipc_server = IpcServer::bind(tx.clone())?;
+
+    let app_log_path = crate::paths::app_log_path();
+    if let Err(error) = crate::services::log_tailer::prune_log_to_lines(
+        &app_log_path,
+        model.config.settings.logs.line_retention.app,
+    ) {
+        tracing::warn!(
+            "Failed to enforce log line limit for {:?}: {}",
+            app_log_path,
+            error
+        );
+    }
+    let singbox_log_path = crate::paths::singbox_log_path();
+    let singbox_log_pruned_at = match crate::services::log_tailer::prune_log_to_lines(
+        &singbox_log_path,
+        model.config.settings.logs.line_retention.singbox,
+    ) {
+        Ok(()) => Some(Instant::now()),
+        Err(error) => {
+            tracing::warn!(
+                "Failed to enforce log line limit for {:?}: {}",
+                singbox_log_path,
+                error
+            );
+            None
+        }
+    };
     let log_session_offsets = LogSessionOffsets {
         app: log_file_len(crate::paths::app_log_path()),
         singbox: log_file_len(crate::paths::singbox_log_path()),
     };
-    let (tx, rx) = channel::<Msg>();
-    let ipc_server = IpcServer::bind(tx.clone())?;
 
     spawn_suspend_watcher(tx.clone());
     if let Err(e) = spawn_signal_handler(tx.clone()) {
@@ -35,28 +70,31 @@ pub fn run(mut model: Model) -> Result<()> {
 
     reconcile_kill_switch_state(&mut model);
 
-    let process_slot = Arc::new(Mutex::new(ProcessSlot {
-        attempt_id: model.connect_attempt_id,
-        handle: None,
-    }));
-    spawn_ticker(tx.clone(), Arc::downgrade(&process_slot));
-    let connect_coordinator = Arc::new(Mutex::new(()));
+    let shared = DaemonShared {
+        process_slot: Arc::new(Mutex::new(ProcessSlot {
+            attempt_id: model.connect_attempt_id,
+            handle: None,
+        })),
+        connect_coordinator: Arc::new(Mutex::new(())),
+        singbox_log_pruned_at: Arc::new(Mutex::new(singbox_log_pruned_at)),
+    };
+    spawn_ticker(tx.clone(), Arc::downgrade(&shared.process_slot));
 
     let result = run_loop(
         &mut model,
         rx,
         &tx,
-        process_slot.clone(),
-        connect_coordinator.clone(),
+        &shared,
         &ipc_server,
         log_session_offsets,
     );
 
     // Cleanup
-    let _coordinator = connect_coordinator
+    let _coordinator = shared
+        .connect_coordinator
         .lock()
         .unwrap_or_else(|p| p.into_inner());
-    if let Some(mut handle) = lock_process_slot(&process_slot).handle.take()
+    if let Some(mut handle) = lock_process_slot(&shared.process_slot).handle.take()
         && let Err(e) = handle.kill_and_wait()
     {
         tracing::warn!("Failed to stop sing-box on exit: {}", e);
@@ -75,8 +113,7 @@ fn run_loop(
     model: &mut Model,
     rx: std::sync::mpsc::Receiver<Msg>,
     tx: &Sender<Msg>,
-    process_slot: Arc<Mutex<ProcessSlot>>,
-    connect_coordinator: Arc<Mutex<()>>,
+    shared: &DaemonShared,
     ipc_server: &IpcServer,
     log_session_offsets: LogSessionOffsets,
 ) -> Result<()> {
@@ -86,7 +123,7 @@ fn run_loop(
         // `queue_connect` advances the generation before the next Tick emits
         // `Effect::Connect`. Publish that invalidation immediately so an old
         // worker cannot install its process during the intervening 250 ms.
-        lock_process_slot(&process_slot).attempt_id = model.connect_attempt_id;
+        lock_process_slot(&shared.process_slot).attempt_id = model.connect_attempt_id;
         let mut should_broadcast = false;
 
         for effect in &effects {
@@ -108,7 +145,7 @@ fn run_loop(
         }
 
         for effect in effects {
-            execute_daemon_effect(effect, tx, model, &process_slot, &connect_coordinator)?;
+            execute_daemon_effect(effect, tx, model, shared)?;
         }
 
         if model.should_quit {
@@ -126,8 +163,7 @@ fn execute_daemon_effect(
     effect: Effect,
     tx: &Sender<Msg>,
     model: &mut Model,
-    process_slot: &Arc<Mutex<ProcessSlot>>,
-    connect_coordinator: &Arc<Mutex<()>>,
+    shared: &DaemonShared,
 ) -> Result<()> {
     match effect {
         Effect::Connect {
@@ -136,7 +172,7 @@ fn execute_daemon_effect(
             attempt_id,
         } => {
             let previous = {
-                let mut slot = lock_process_slot(process_slot);
+                let mut slot = lock_process_slot(&shared.process_slot);
                 slot.attempt_id = attempt_id;
                 slot.handle.take()
             };
@@ -147,8 +183,9 @@ fn execute_daemon_effect(
             }
             model.connection = ConnectionState::ConnectPending;
             let tx = tx.clone();
-            let slot = process_slot.clone();
-            let coordinator = connect_coordinator.clone();
+            let slot = shared.process_slot.clone();
+            let coordinator = shared.connect_coordinator.clone();
+            let log_pruned_at = shared.singbox_log_pruned_at.clone();
             let kill_switch = model.config.settings.kill_switch;
             let dns = settings.dns.clone();
             thread::spawn(move || {
@@ -190,6 +227,23 @@ fn execute_daemon_effect(
                 if !is_current_attempt(&slot, attempt_id) {
                     return;
                 }
+                let now = Instant::now();
+                let mut last_pruned = log_pruned_at.lock().unwrap_or_else(|p| p.into_inner());
+                if log_prune_due(*last_pruned, now) {
+                    let log_path = crate::paths::singbox_log_path();
+                    match crate::services::log_tailer::prune_log_to_lines(
+                        &log_path,
+                        settings.logs.line_retention.singbox,
+                    ) {
+                        Ok(()) => *last_pruned = Some(now),
+                        Err(error) => tracing::warn!(
+                            "Failed to enforce log line limit for {:?}: {}",
+                            log_path,
+                            error
+                        ),
+                    }
+                }
+                drop(last_pruned);
                 match crate::singbox::runner::start(&profile, &settings) {
                     Ok(handle) => {
                         let pid = handle.pid;
@@ -232,16 +286,17 @@ fn execute_daemon_effect(
         Effect::Disconnect => {
             model.connect_attempt_id = model.connect_attempt_id.wrapping_add(1);
             {
-                let mut slot = lock_process_slot(process_slot);
+                let mut slot = lock_process_slot(&shared.process_slot);
                 slot.attempt_id = model.connect_attempt_id;
             }
             // Wait for an in-flight setup to observe invalidation and stop
             // before flushing its temporary kill-switch exceptions.
-            let _coordinator = connect_coordinator
+            let _coordinator = shared
+                .connect_coordinator
                 .lock()
                 .unwrap_or_else(|p| p.into_inner());
             let previous = {
-                let mut slot = lock_process_slot(process_slot);
+                let mut slot = lock_process_slot(&shared.process_slot);
                 slot.handle.take()
             };
             if let Some(mut handle) = previous
@@ -577,7 +632,7 @@ fn execute_daemon_effect(
         Effect::BroadcastState => {}
         Effect::Quit => {
             model.connect_attempt_id = model.connect_attempt_id.wrapping_add(1);
-            lock_process_slot(process_slot).attempt_id = model.connect_attempt_id;
+            lock_process_slot(&shared.process_slot).attempt_id = model.connect_attempt_id;
             model.should_quit = true;
         }
         Effect::AppendAppLog { level, message } => {
@@ -1125,6 +1180,10 @@ fn is_current_attempt(slot: &Arc<Mutex<ProcessSlot>>, attempt_id: u64) -> bool {
     lock_process_slot(slot).attempt_id == attempt_id
 }
 
+fn log_prune_due(last_pruned: Option<Instant>, now: Instant) -> bool {
+    last_pruned.is_none_or(|last| now.duration_since(last) >= LOG_PRUNE_INTERVAL)
+}
+
 fn spawn_suspend_watcher(tx: Sender<Msg>) {
     thread::spawn(move || {
         crate::services::suspend::listen_blocking(tx);
@@ -1153,12 +1212,27 @@ fn spawn_signal_handler(tx: Sender<Msg>) -> Result<()> {
 mod tests {
     use super::{
         ProcessSlot, ServiceRefreshResult, finalize_geo_result, handshake_protocols,
-        lock_process_slot, poll_process_exit,
+        lock_process_slot, log_prune_due, poll_process_exit,
     };
     use crate::app::msg::{GeoResult, Msg};
     use crate::config::profile::Protocol;
     use crate::singbox::process_handle::ProcessHandle;
     use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn log_prune_is_due_initially_and_after_twenty_four_hours() {
+        let start = Instant::now();
+        assert!(log_prune_due(None, start));
+        assert!(!log_prune_due(
+            Some(start),
+            start + Duration::from_secs(24 * 60 * 60 - 1)
+        ));
+        assert!(log_prune_due(
+            Some(start),
+            start + Duration::from_secs(24 * 60 * 60)
+        ));
+    }
 
     #[test]
     fn handshake_protocols_match_outbound_transports() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,18 +38,18 @@ fn main() -> Result<()> {
     }
 
     // Ensure configuration directories exist before reading the config so
-    // logging can be initialized from `settings.log_level`.
+    // logging can be initialized from `settings.logs.level`.
     ensure_config_dirs()?;
 
     let cfg = crate::config::load_config().unwrap_or_default();
-    let (filter, bad_level) = resolve_log_filter(cfg.settings.log_level.as_str());
+    let (filter, bad_level) = resolve_log_filter(cfg.settings.logs.level.as_str());
     tracing_subscriber::registry()
         .with(filter)
         .with(tracing_subscriber::fmt::layer().without_time())
         .init();
     if let Some(invalid) = bad_level {
         tracing::warn!(
-            "settings.log_level={:?} is not one of trace/debug/info/warn/error; using info",
+            "settings.logs.level={:?} is not one of trace/debug/info/warn/error; using info",
             invalid
         );
     }
@@ -71,7 +71,7 @@ fn main() -> Result<()> {
 }
 
 /// Resolve the tracing filter from environment and config. Precedence:
-/// `RUST_LOG` > `settings.log_level` (if it parses as one of the five
+/// `RUST_LOG` > `settings.logs.level` (if it parses as one of the five
 /// canonical levels) > `info`. Returns the bad value as the second tuple
 /// element so the caller can warn after the subscriber is live.
 fn resolve_log_filter(level: &str) -> (EnvFilter, Option<String>) {

--- a/src/services/log_tailer.rs
+++ b/src/services/log_tailer.rs
@@ -1,7 +1,61 @@
 use chrono::{DateTime, FixedOffset, Local, TimeZone};
 use std::fs::{File, OpenOptions};
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
+use std::path::Path;
 use std::path::PathBuf;
+
+/// Atomically retain at most the last `max_lines` physical lines of a log.
+/// Scans backward from the end so a large file does not need to be loaded
+/// into memory; only the retained tail is allocated for the atomic rewrite.
+pub fn prune_log_to_lines(path: &Path, max_lines: u32) -> anyhow::Result<()> {
+    let mut file = match File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    let file_len = file.metadata()?.len();
+    if max_lines == 0 {
+        return if file_len == 0 {
+            Ok(())
+        } else {
+            crate::atomic_write::write(path, &[])
+        };
+    }
+    let start = tail_start(&mut file, file_len, max_lines as usize)?;
+    if start == 0 {
+        return Ok(());
+    }
+
+    file.seek(SeekFrom::Start(start))?;
+    let mut retained = Vec::with_capacity((file_len - start) as usize);
+    file.read_to_end(&mut retained)?;
+    crate::atomic_write::write(path, &retained)
+}
+
+fn tail_start(file: &mut File, file_len: u64, max_lines: usize) -> std::io::Result<u64> {
+    const CHUNK_SIZE: u64 = 8 * 1024;
+
+    let mut cursor = file_len;
+    let mut newline_count = 0;
+    while cursor > 0 {
+        let chunk_start = cursor.saturating_sub(CHUNK_SIZE);
+        let mut chunk = vec![0; (cursor - chunk_start) as usize];
+        file.seek(SeekFrom::Start(chunk_start))?;
+        file.read_exact(&mut chunk)?;
+
+        for (index, byte) in chunk.iter().enumerate().rev() {
+            let position = chunk_start + index as u64;
+            if *byte == b'\n' && position != file_len.saturating_sub(1) {
+                newline_count += 1;
+                if newline_count == max_lines {
+                    return Ok(position + 1);
+                }
+            }
+        }
+        cursor = chunk_start;
+    }
+    Ok(0)
+}
 
 /// Append an app-generated log line to the application log file.
 /// Format matches sing-box style: `+HHMM YYYY-MM-DD HH:MM:SS LEVEL message`
@@ -190,6 +244,88 @@ fn parse_timestamp(line: &str) -> Option<(DateTime<FixedOffset>, usize)> {
 mod tests {
     use super::*;
     use std::io::Write;
+
+    #[test]
+    fn prune_keeps_last_physical_lines_verbatim() {
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(temp.path(), b"one\ntwo\nplain continuation\nfour\n").unwrap();
+
+        prune_log_to_lines(temp.path(), 2).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(temp.path()).unwrap(),
+            "plain continuation\nfour\n"
+        );
+    }
+
+    #[test]
+    fn prune_handles_file_without_trailing_newline() {
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(temp.path(), b"one\ntwo\nthree").unwrap();
+
+        prune_log_to_lines(temp.path(), 2).unwrap();
+
+        assert_eq!(std::fs::read_to_string(temp.path()).unwrap(), "two\nthree");
+    }
+
+    #[test]
+    fn prune_leaves_file_at_or_below_limit_unchanged() {
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        let contents = b"one\ntwo\n";
+        std::fs::write(temp.path(), contents).unwrap();
+
+        prune_log_to_lines(temp.path(), 2).unwrap();
+
+        assert_eq!(std::fs::read(temp.path()).unwrap(), contents);
+    }
+
+    #[test]
+    fn prune_finds_boundary_across_read_chunks() {
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        let long = "x".repeat(9_000);
+        std::fs::write(temp.path(), format!("old\n{long}\nlast\n")).unwrap();
+
+        prune_log_to_lines(temp.path(), 2).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(temp.path()).unwrap(),
+            format!("{long}\nlast\n")
+        );
+    }
+
+    #[test]
+    fn prune_handles_missing_and_empty_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing.log");
+        prune_log_to_lines(&missing, 10).unwrap();
+
+        let empty = dir.path().join("empty.log");
+        std::fs::write(&empty, []).unwrap();
+        prune_log_to_lines(&empty, 10).unwrap();
+        assert!(std::fs::read(empty).unwrap().is_empty());
+    }
+
+    #[test]
+    fn prune_zero_limit_empties_file() {
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(temp.path(), b"one\ntwo\n").unwrap();
+
+        prune_log_to_lines(temp.path(), 0).unwrap();
+
+        assert!(std::fs::read(temp.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn prune_replaces_file_atomically_without_leaving_temp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("app.log");
+        std::fs::write(&path, b"old\nrecent\n").unwrap();
+
+        prune_log_to_lines(&path, 1).unwrap();
+
+        assert!(!dir.path().join("app.log.tmp").exists());
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "recent\n");
+    }
 
     #[test]
     fn tail_reads_new_lines() {

--- a/src/singbox/config.rs
+++ b/src/singbox/config.rs
@@ -103,7 +103,7 @@ pub fn generate_config(
 
     let mut config = json!({
         "log": {
-            "level": crate::config::profile::normalized_log_level(&settings.log_level),
+            "level": crate::config::profile::normalized_log_level(&settings.logs.level),
             "output": crate::paths::singbox_log_path().to_string_lossy(),
             "timestamp": true
         },
@@ -474,10 +474,8 @@ mod tests {
     #[test]
     fn generated_config_log_level_follows_settings() {
         let profile = test_profile();
-        let settings = Settings {
-            log_level: "debug".to_string(),
-            ..Settings::default()
-        };
+        let mut settings = Settings::default();
+        settings.logs.level = "debug".to_string();
         let config = generate_config(&profile, &settings, &GeoAvailability::all()).unwrap();
         assert_eq!(config["log"]["level"].as_str(), Some("debug"));
     }
@@ -485,10 +483,8 @@ mod tests {
     #[test]
     fn generated_config_log_level_falls_back_on_garbage() {
         let profile = test_profile();
-        let settings = Settings {
-            log_level: "verbose".to_string(),
-            ..Settings::default()
-        };
+        let mut settings = Settings::default();
+        settings.logs.level = "verbose".to_string();
         let config = generate_config(&profile, &settings, &GeoAvailability::all()).unwrap();
         assert_eq!(config["log"]["level"].as_str(), Some("info"));
     }


### PR DESCRIPTION
## Summary

Prevent app and sing-box log files from growing without bound by introducing configurable line-retention limits.

## Changes

- add separate `settings.logs.line_retention.app` and `singbox` limits
- default to 1,000 app lines and 100,000 sing-box lines
- validate both retention limits with a minimum of 1,000 lines
- atomically retain only the newest physical log lines
- trim both logs when the daemon starts
- trim sing-box logs at safe reconnect points at most once every 24 hours
- migrate the released legacy `settings.log_level` field to `settings.logs.level`
- document the new logging configuration
