### PR TITLE
fix(ui): align overlay confirmation controls

### DIFF
--- a/src/app/update/key.rs
+++ b/src/app/update/key.rs
@@ -416,7 +416,7 @@ pub(super) fn handle_confirm_delete(model: &mut Model, key: KeyEvent) -> Vec<Eff
                 _ => {}
             }
         }
-        KeyCode::Char('n') | KeyCode::Esc => {
+        KeyCode::Char('n') | KeyCode::Char('q') | KeyCode::Esc => {
             model.overlay = Overlay::None;
         }
         _ => {}
@@ -764,7 +764,11 @@ pub(super) fn handle_dns_settings(model: &mut Model, key: KeyEvent) -> Vec<Effec
             let Some(item) = DnsSettingsItem::from_index(model.dns_selected) else {
                 return vec![];
             };
-            return apply_dns_item(model, item);
+            let effects = apply_dns_item(model, item);
+            model.overlay = Overlay::None;
+            model.dns_strategy_draft = None;
+            model.dns_fakeip_draft = None;
+            return effects;
         }
         KeyCode::Char('q') | KeyCode::Esc => {
             model.overlay = Overlay::None;
@@ -1222,6 +1226,7 @@ mod tests {
         let effects = handle_dns_settings(&mut model, enter());
         assert!(effects.is_empty());
         assert_eq!(model.config.settings.dns.strategy, before);
+        assert_eq!(model.overlay, Overlay::None);
     }
 
     #[test]
@@ -1232,12 +1237,15 @@ mod tests {
             .position(|i| *i == DnsSettingsItem::CycleStrategy)
             .unwrap();
         model.dns_strategy_draft = Some(DnsStrategy::OnlyIpv4);
+        model.dns_fakeip_draft = Some(true);
         let effects = handle_dns_settings(&mut model, enter());
         assert_eq!(model.config.settings.dns.strategy, DnsStrategy::OnlyIpv4);
         assert_eq!(model.config.settings.dns_strategy, DnsStrategy::OnlyIpv4);
         assert!(effects.contains(&Effect::SaveConfig));
         assert!(effects.contains(&Effect::BroadcastState));
         assert!(model.dns_strategy_draft.is_none());
+        assert!(model.dns_fakeip_draft.is_none());
+        assert_eq!(model.overlay, Overlay::None);
     }
 
     #[test]
@@ -1254,6 +1262,7 @@ mod tests {
         assert!(effects.is_empty());
         assert!(model.dns_strategy_draft.is_none());
         assert_eq!(model.config.settings.dns.strategy, same);
+        assert_eq!(model.overlay, Overlay::None);
     }
 
     #[test]
@@ -1263,6 +1272,7 @@ mod tests {
         let effects = handle_dns_settings(&mut model, enter());
         assert!(effects.contains(&Effect::SaveConfig));
         assert!(effects.contains(&Effect::BroadcastState));
+        assert_eq!(model.overlay, Overlay::None);
         assert!(final_server_is(&model, |s| matches!(
             s,
             DnsServer::Https { server, .. } if server == "1.1.1.1"
@@ -1659,6 +1669,23 @@ mod tests {
         )]);
         model.overlay = Overlay::ConfirmDelete;
         let effects = handle_confirm_delete(&mut model, esc());
+        assert_eq!(model.config.profiles.len(), 1);
+        assert_eq!(model.overlay, Overlay::None);
+        assert!(effects.is_empty());
+    }
+
+    #[test]
+    fn confirm_delete_q_cancels() {
+        let mut model = model_with_profiles(vec![Profile::new_vless(
+            "A".into(),
+            "1.1.1.1".into(),
+            443,
+            "u".into(),
+        )]);
+        model.overlay = Overlay::ConfirmDelete;
+
+        let effects = handle_confirm_delete(&mut model, key('q'));
+
         assert_eq!(model.config.profiles.len(), 1);
         assert_eq!(model.overlay, Overlay::None);
         assert!(effects.is_empty());

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -751,7 +751,7 @@ fn draw_confirm_delete(frame: &mut Frame, model: &Model, area: Rect) {
         vec![
             Line::from(Span::styled(message, theme.error())),
             Line::from(""),
-            Line::from("Press y to confirm, n to cancel"),
+            Line::from("Press y/Enter to confirm, q/Esc to cancel"),
         ],
         POPUP_HEIGHT_PERCENT,
     );
@@ -809,6 +809,7 @@ fn draw_routing_mode(frame: &mut Frame, model: &Model, area: Rect) {
         model.routing_selected,
         active,
         POPUP_HEIGHT_PERCENT,
+        &["j/k navigate, Enter confirm, q/Esc cancel"],
     );
 }
 
@@ -840,6 +841,11 @@ fn draw_geo_region(frame: &mut Frame, model: &Model, area: Rect) {
         model.geo_region_selected,
         active,
         POPUP_HEIGHT_PERCENT,
+        if model.config.settings.geo_routing.current_region.is_some() {
+            &["j/k navigate, Enter confirm, q/Esc cancel"]
+        } else {
+            &["j/k navigate, Enter confirm"]
+        },
     );
 }
 
@@ -886,6 +892,7 @@ fn draw_dns_settings(frame: &mut Frame, model: &Model, area: Rect) {
         model.dns_selected,
         current_dns_preset_index(dns),
         POPUP_HEIGHT_PERCENT,
+        &["j/k navigate, h/l change", "Enter confirm, q/Esc cancel"],
     );
 }
 
@@ -947,7 +954,8 @@ fn draw_service_routing(frame: &mut Frame, model: &Model, area: Rect) {
     }
 
     lines.push(Line::from(""));
-    lines.push(Line::from("j/k select, h/l change, Enter, Esc").centered());
+    lines.push(Line::from("j/k navigate, h/l change").centered());
+    lines.push(Line::from("Enter confirm, q/Esc cancel").centered());
 
     frame.render_widget(Paragraph::new(lines), inner);
 }
@@ -971,6 +979,7 @@ fn draw_theme_settings(frame: &mut Frame, model: &Model, area: Rect) {
         model.theme_selected,
         active,
         POPUP_HEIGHT_PERCENT_TALL,
+        &["j/k navigate, Enter confirm, q/Esc cancel"],
     );
 }
 
@@ -1019,9 +1028,11 @@ fn draw_selection_modal(
     selected: usize,
     active: Option<usize>,
     height_percent: u16,
+    footer: &[&str],
 ) {
     let popup_area = centered_rect(POPUP_WIDTH_PERCENT, height_percent, area);
-    let max_visible_items = popup_area.height.saturating_sub(6) as usize;
+    let footer_height = footer.len() as u16;
+    let max_visible_items = popup_area.height.saturating_sub(5 + footer_height) as usize;
     let visible_count = items.len().min(max_visible_items);
     let window_start = if items.len() > visible_count {
         selected
@@ -1052,7 +1063,7 @@ fn draw_selection_modal(
         )));
     }
     lines.push(Line::from(""));
-    lines.push(Line::from("j/k navigate, Enter confirm, Esc cancel"));
+    lines.extend(footer.iter().map(|text| Line::from(*text)));
     draw_modal(frame, theme, area, modal_title, lines, height_percent);
 }
 
@@ -1996,6 +2007,24 @@ mod tests {
     }
 
     #[test]
+    fn geo_region_footer_only_offers_cancel_after_initial_selection() {
+        let mut model = model_with_profiles(vec![]);
+        model.overlay = Overlay::GeoRegions;
+
+        let required = snapshot_terminal(&model, 80, 20);
+        assert!(required.contains("j/k navigate, Enter confirm"));
+        assert!(!required.contains("q/Esc cancel"));
+
+        model
+            .config
+            .settings
+            .geo_routing
+            .set_region(crate::config::profile::GeoRegion::Ru);
+        let optional = snapshot_terminal(&model, 80, 20);
+        assert!(optional.contains("j/k navigate, Enter confirm, q/Esc cancel"));
+    }
+
+    #[test]
     fn draw_dns_settings_overlay_snapshot() {
         let mut model = model_with_profiles(vec![]);
         model.geo_last_updated = Some("2026-05-31 13:41".to_string());
@@ -2099,7 +2128,7 @@ mod tests {
 
         let rendered = snapshot_terminal(&model, 80, 24);
         assert!(rendered.contains("> white"));
-        assert!(rendered.contains("j/k navigate, Enter confirm, Esc cancel"));
+        assert!(rendered.contains("j/k navigate, Enter confirm, q/Esc cancel"));
         assert!(!rendered.contains("catppuccin-latte"));
     }
 

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_confirm_delete_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_confirm_delete_overlay_snapshot.snap
@@ -10,7 +10,7 @@ expression: "snapshot_terminal(&model, 80, 20)"
 │└ Alpha        ┌ Confirm ─────────────────────────────────────┐               │
 │               │           Delete selected profile?           │               │
 │               │                                              │               │
-│               │        Press y to confirm, n to cancel       │               │
+│               │   Press y/Enter to confirm, q/Esc to cancel  │               │
 │               │                                              │               │
 │               │                                              │               │
 │               │                                              │               │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_dns_settings_overlay_fakeip_on_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_dns_settings_overlay_fakeip_on_snapshot.snap
@@ -11,14 +11,14 @@ expression: "snapshot_terminal(&model, 80, 24)"
 │               ┌ DNS ─────────────────────────────────────────┐               │
 │               │                 DNS settings                 │               │
 │               │                                              │               │
-│               │       Preset: Cloudflare DoH (1.1.1.1)       │               │
 │               │         Preset: Google DoT (8.8.8.8)         │               │
 │               │          Preset: Quad9 DoH (9.9.9.9)         │               │
 │               │        Preset: System resolver (local)       │               │
 │               │           Strategy: ‹ prefer_ipv4 ›          │               │
 │               │               > Fake-IP: ‹ on ›              │               │
 │               │                                              │               │
-│               │    j/k navigate, Enter confirm, Esc cancel   │               │
+│               │           j/k navigate, h/l change           │               │
+│               │          Enter confirm, q/Esc cancel         │               │
 │               └──────────────────────────────────────────────┘               │
 │                                      ││                                      │
 │                                      ││                                      │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_dns_settings_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_dns_settings_overlay_snapshot.snap
@@ -11,14 +11,14 @@ expression: "snapshot_terminal(&model, 80, 24)"
 │               ┌ DNS ─────────────────────────────────────────┐               │
 │               │                 DNS settings                 │               │
 │               │                                              │               │
-│               │       Preset: Cloudflare DoH (1.1.1.1)       │               │
 │               │         Preset: Google DoT (8.8.8.8)         │               │
 │               │          Preset: Quad9 DoH (9.9.9.9)         │               │
 │               │        Preset: System resolver (local)       │               │
 │               │          > Strategy: ‹ prefer_ipv4 ›         │               │
 │               │               Fake-IP: ‹ off ›               │               │
 │               │                                              │               │
-│               │    j/k navigate, Enter confirm, Esc cancel   │               │
+│               │           j/k navigate, h/l change           │               │
+│               │          Enter confirm, q/Esc cancel         │               │
 │               └──────────────────────────────────────────────┘               │
 │                                      ││                                      │
 │                                      ││                                      │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_geo_region_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_geo_region_overlay_snapshot.snap
@@ -15,7 +15,7 @@ expression: "snapshot_terminal(&model, 80, 20)"
 │               │                    🇮🇷  Iran                   │               │
 │               │           🌍  Global (no geo rules)           │               │
 │               │                                              │               │
-│               │    j/k navigate, Enter confirm, Esc cancel   │               │
+│               │          j/k navigate, Enter confirm         │               │
 │               └──────────────────────────────────────────────┘               │
 │                                      ││                                      │
 │                                      ││                                      │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_routing_mode_overlay_global_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_routing_mode_overlay_global_snapshot.snap
@@ -12,7 +12,7 @@ expression: "snapshot_terminal(&model, 80, 20)"
 │               │                                              │               │
 │               │                   > Global                   │               │
 │               │                                              │               │
-│               │    j/k navigate, Enter confirm, Esc cancel   │               │
+│               │   j/k navigate, Enter confirm, q/Esc cancel  │               │
 │               │                                              │               │
 │               │                                              │               │
 │               │                                              │               │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_routing_mode_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_routing_mode_overlay_snapshot.snap
@@ -14,7 +14,7 @@ expression: "snapshot_terminal(&model, 80, 20)"
 │               │                   Bypass RU                  │               │
 │               │                   > Only RU                  │               │
 │               │                                              │               │
-│               │    j/k navigate, Enter confirm, Esc cancel   │               │
+│               │   j/k navigate, Enter confirm, q/Esc cancel  │               │
 │               │                                              │               │
 │               └──────────────────────────────────────────────┘               │
 │                                      ││                                      │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_service_routing_overlay_no_edits_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_service_routing_overlay_no_edits_snapshot.snap
@@ -14,8 +14,8 @@ expression: "snapshot_terminal(&model, 80, 24)"
 │               │          > Steam     ‹ Disabled ›            │               │
 │               │            Telegram  ‹ Disabled ›            │               │
 │               │                                              │               │
-│               │      j/k select, h/l change, Enter, Esc      │               │
-│               │                                              │               │
+│               │           j/k navigate, h/l change           │               │
+│               │          Enter confirm, q/Esc cancel         │               │
 │               │                                              │               │
 │               │                                              │               │
 │               │                                              │               │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_service_routing_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_service_routing_overlay_snapshot.snap
@@ -14,8 +14,8 @@ expression: "snapshot_terminal(&model, 80, 24)"
 │               │            Steam     ‹  Direct  ›            │               │
 │               │          > Telegram  ‹  Proxy   › *          │               │
 │               │                                              │               │
-│               │      j/k select, h/l change, Enter, Esc      │               │
-│               │                                              │               │
+│               │           j/k navigate, h/l change           │               │
+│               │          Enter confirm, q/Esc cancel         │               │
 │               │                                              │               │
 │               │                                              │               │
 │               │                                              │               │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_theme_settings_overlay_light_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_theme_settings_overlay_light_snapshot.snap
@@ -30,7 +30,7 @@ expression: "snapshot_terminal(&model, 80, 32)"
 │               │                  vantablack                  │               │
 │               │                     white                    │               │
 │               │                                              │               │
-│               │    j/k navigate, Enter confirm, Esc cancel   │               │
+│               │   j/k navigate, Enter confirm, q/Esc cancel  │               │
 │               └──────────────────────────────────────────────┘               │
 └──────────────────────────────────────┘└──────────────────────────────────────┘
 [DISCONNECTED] [DNS: DoH] [Global] [Geo: 2026-05-31 13:41]

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_theme_settings_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_theme_settings_overlay_snapshot.snap
@@ -30,7 +30,7 @@ expression: "snapshot_terminal(&model, 80, 32)"
 │               │                  vantablack                  │               │
 │               │                     white                    │               │
 │               │                                              │               │
-│               │    j/k navigate, Enter confirm, Esc cancel   │               │
+│               │   j/k navigate, Enter confirm, q/Esc cancel  │               │
 │               └──────────────────────────────────────────────┘               │
 └──────────────────────────────────────┘└──────────────────────────────────────┘
 [DISCONNECTED] [DNS: DoH] [Global] [Geo: 2026-05-31 13:41]


### PR DESCRIPTION
## Summary

Make overlay confirmation and cancellation behavior consistent with the commands shown in the TUI.

## Changes

- Allow `q` to cancel the delete confirmation without removing the selected source.
- Close DNS settings after `Enter` applies the selected item and clear any remaining DNS drafts.
- Use concise, consistent navigation and confirmation hints across selection overlays.
- Keep cancellation hidden while the initial geo-region selection is mandatory.
- Adjust selection-list viewport sizing for multi-line command hints.
- Update regression tests and UI snapshots for the new behavior.
