### PR TITLE
fix(omarchy): open installed plugin from shortcut

### DIFF
--- a/contrib/setup-omarchy.sh
+++ b/contrib/setup-omarchy.sh
@@ -78,15 +78,24 @@ append_atomic() {
 install_launcher() {
   local generation="$1"
   local launcher="$HOME/.local/bin/omarchy-launch-kvn-tui"
-  [[ -f $launcher ]] && { echo "Launcher script already present."; return; }
+  if (( generation < 4 )) && [[ -f $launcher ]]; then
+    echo "Launcher script already present."
+    return
+  fi
 
-  echo "Installing launcher script..."
+  echo "Installing or updating launcher script..."
   mkdir -p "$(dirname "$launcher")"
   local tmp
   tmp=$(mktemp "${launcher}.tmp.XXXXXX")
   if (( generation >= 4 )); then
     cat >"$tmp" <<'EOF'
 #!/bin/bash
+plugin_dir="${XDG_CONFIG_HOME:-$HOME/.config}/omarchy/plugins/yarikov.omakvn"
+if [[ -f "$plugin_dir/manifest.json" ]] && command -v omarchy-shell >/dev/null 2>&1; then
+  if [[ $(omarchy-shell shell summon yarikov.omakvn '{}' 2>/dev/null) == "ok" ]]; then
+    exit 0
+  fi
+fi
 exec omarchy-launch-or-focus-tui --app-id=org.omarchy.kvn-tui kvn-tui
 EOF
   else
@@ -97,7 +106,7 @@ exec omarchy-launch-or-focus "org.omarchy.kvn-tui" \
 EOF
   fi
   chmod 0755 "$tmp"
-  atomic_replace "$tmp" "$launcher"
+  replace_if_changed "$tmp" "$launcher"
 }
 
 detect_omarchy_major() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -808,6 +808,9 @@ esac
         assert!(rules.contains(r#"o.window("^org\\.omarchy\\.kvn-tui$""#));
 
         let launcher = fs::read_to_string(home.join(".local/bin/omarchy-launch-kvn-tui")).unwrap();
+        assert!(launcher.contains("omarchy/plugins/yarikov.omakvn"));
+        assert!(launcher.contains("$plugin_dir/manifest.json"));
+        assert!(launcher.contains("omarchy-shell shell summon yarikov.omakvn '{}'"));
         assert!(launcher.contains("omarchy-launch-or-focus-tui"));
         assert!(launcher.contains("--app-id=org.omarchy.kvn-tui"));
         let shell_backups = backup_files(&omarchy.join("shell.json"));
@@ -846,6 +849,25 @@ esac
             .expect("legacy command module entry");
         assert_eq!(entry["exec"], "kvn-tui --waybar-status");
         assert!(!home.join(".config/omarchy/plugins/yarikov.omakvn").exists());
+    }
+
+    #[test]
+    fn omarchy_v4_installer_upgrades_existing_tui_launcher() {
+        let (root, home) = installer_fixture(4);
+        write_omarchy_v4_config(&home);
+        let launcher = home.join(".local/bin/omarchy-launch-kvn-tui");
+        fs::create_dir_all(launcher.parent().unwrap()).unwrap();
+        fs::write(
+            &launcher,
+            "#!/bin/bash\nexec omarchy-launch-or-focus-tui --app-id=org.omarchy.kvn-tui kvn-tui\n",
+        )
+        .unwrap();
+
+        assert_success(&run_installer(&root, &home, "n\n"));
+
+        let contents = fs::read_to_string(&launcher).unwrap();
+        assert!(contents.contains("omarchy-shell shell summon yarikov.omakvn '{}'"));
+        assert_eq!(backup_files(&launcher).len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Make the Omarchy 4 launcher shortcut open the installed `yarikov.omakvn` plugin instead of starting the full TUI. The TUI remains the fallback when the plugin or Omarchy Shell is unavailable.

## Changes

- Summon the `yarikov.omakvn` panel through Omarchy Shell when its manifest is present.
- Fall back to `omarchy-launch-or-focus-tui` when the plugin cannot be opened.
- Update an existing Omarchy 4 launcher during repeated setup runs.
- Add installer regression coverage for launcher upgrades.
