### PR TITLE
feat(omarchy): add kvn-tui to apps menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,9 @@ kvn-tui setup --omarchy
 On **Omarchy 4 (Quattro)** this installs the standalone
 [omakvn](https://github.com/yarikov/omakvn) Quickshell bar plugin (`yarikov.omakvn`):
 it shows live VPN status and provides profile selection and common VPN controls
-directly from the bar. On Omarchy 3 (or builds without the shell plugin
+directly from the bar. It also adds kvn-tui to the **Apps** menu; search for
+`kvn-tui`, `tui`, or `vpn` to open or focus the terminal client. On Omarchy 3
+(or builds without the shell plugin
 registry), setup falls back to a Waybar status module that opens the TUI on
 click.
 

--- a/contrib/clean-omarchy.sh
+++ b/contrib/clean-omarchy.sh
@@ -11,6 +11,8 @@ FILES=(
   "${HOME}/.config/hypr/autostart.conf"
   "${HOME}/.config/hypr/bindings.conf"
   "${HOME}/.config/hypr/hyprland.conf"
+  "${HOME}/.local/share/applications/kvn-tui.desktop"
+  "${HOME}/.local/share/icons/hicolor/scalable/apps/kvn-tui.svg"
 )
 
 removed=0

--- a/contrib/setup-omarchy.sh
+++ b/contrib/setup-omarchy.sh
@@ -109,6 +109,52 @@ EOF
   replace_if_changed "$tmp" "$launcher"
 }
 
+install_desktop_entry() {
+  local desktop_entry="$HOME/.local/share/applications/kvn-tui.desktop"
+
+  echo "Installing or updating Apps launcher..."
+  mkdir -p "$(dirname "$desktop_entry")"
+  local tmp
+  tmp=$(mktemp "${desktop_entry}.tmp.XXXXXX")
+  cat >"$tmp" <<'EOF'
+[Desktop Entry]
+Type=Application
+Name=kvn-tui
+GenericName=VPN Client
+Comment=Terminal VPN client powered by sing-box
+Exec=omarchy-launch-or-focus-tui --app-id=org.omarchy.kvn-tui kvn-tui
+TryExec=kvn-tui
+Terminal=false
+Icon=kvn-tui
+Categories=Network;Utility;
+Keywords=VPN;TUI;Terminal;sing-box;
+StartupNotify=false
+EOF
+  chmod 0644 "$tmp"
+  replace_if_changed "$tmp" "$desktop_entry"
+}
+
+install_app_icon() {
+  local app_icon="$HOME/.local/share/icons/hicolor/scalable/apps/kvn-tui.svg"
+
+  echo "Installing or updating Apps icon..."
+  mkdir -p "$(dirname "$app_icon")"
+  local tmp
+  tmp=$(mktemp "${app_icon}.tmp.XXXXXX")
+  cat >"$tmp" <<'EOF'
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="24" fill="#101010"/>
+  <path d="M64 14 106 30v32c0 26-16 44-42 53C38 106 22 88 22 62V30z" fill="#f5f1e8"/>
+  <rect x="43" y="57" width="42" height="34" rx="8" fill="#101010"/>
+  <path d="M51 58v-7a13 13 0 0 1 26 0v7" fill="none" stroke="#101010" stroke-width="8" stroke-linecap="round"/>
+  <circle cx="64" cy="72" r="5" fill="#f5f1e8"/>
+  <path d="M64 76v7" stroke="#f5f1e8" stroke-width="5" stroke-linecap="round"/>
+</svg>
+EOF
+  chmod 0644 "$tmp"
+  replace_if_changed "$tmp" "$app_icon"
+}
+
 detect_omarchy_major() {
   command -v omarchy >/dev/null 2>&1 || {
     echo "Error: omarchy command not found." >&2
@@ -327,6 +373,8 @@ install_omarchy_v4() {
   local shell_config="$HOME/.config/omarchy/shell.json"
   local hypr_bindings="$HOME/.config/hypr/bindings.lua"
   local hypr_main="$HOME/.config/hypr/hyprland.lua"
+  local desktop_entry="$HOME/.local/share/applications/kvn-tui.desktop"
+  local app_icon="$HOME/.local/share/icons/hicolor/scalable/apps/kvn-tui.svg"
   for file in "$shell_config" "$hypr_bindings" "$hypr_main"; do
     [[ -f $file ]] || {
       echo "Error: required Omarchy 4 config not found: $file" >&2
@@ -337,11 +385,23 @@ install_omarchy_v4() {
   V4_SHELL_CONFIG=$shell_config
   V4_HYPR_BINDINGS=$hypr_bindings
   V4_HYPR_MAIN=$hypr_main
+  V4_DESKTOP_ENTRY=$desktop_entry
+  V4_DESKTOP_ENTRY_EXISTED=0
+  V4_APP_ICON=$app_icon
+  V4_APP_ICON_EXISTED=0
   V4_TRANSACTION_ACTIVE=1
   V4_TRANSACTION_DIR=$(mktemp -d)
   cp -p -- "$shell_config" "$V4_TRANSACTION_DIR/shell.json"
   cp -p -- "$hypr_bindings" "$V4_TRANSACTION_DIR/bindings.lua"
   cp -p -- "$hypr_main" "$V4_TRANSACTION_DIR/hyprland.lua"
+  if [[ -f $desktop_entry ]]; then
+    cp -p -- "$desktop_entry" "$V4_TRANSACTION_DIR/kvn-tui.desktop"
+    V4_DESKTOP_ENTRY_EXISTED=1
+  fi
+  if [[ -f $app_icon ]]; then
+    cp -p -- "$app_icon" "$V4_TRANSACTION_DIR/kvn-tui.svg"
+    V4_APP_ICON_EXISTED=1
+  fi
 
   rollback_v4() {
     local snapshot target tmp
@@ -354,6 +414,20 @@ $V4_TRANSACTION_DIR/shell.json $V4_SHELL_CONFIG
 $V4_TRANSACTION_DIR/bindings.lua $V4_HYPR_BINDINGS
 $V4_TRANSACTION_DIR/hyprland.lua $V4_HYPR_MAIN
 EOF
+    if (( V4_DESKTOP_ENTRY_EXISTED )); then
+      tmp=$(mktemp "${V4_DESKTOP_ENTRY}.tmp.XXXXXX")
+      cp -p -- "$V4_TRANSACTION_DIR/kvn-tui.desktop" "$tmp"
+      atomic_replace "$tmp" "$V4_DESKTOP_ENTRY"
+    else
+      rm -f -- "$V4_DESKTOP_ENTRY"
+    fi
+    if (( V4_APP_ICON_EXISTED )); then
+      tmp=$(mktemp "${V4_APP_ICON}.tmp.XXXXXX")
+      cp -p -- "$V4_TRANSACTION_DIR/kvn-tui.svg" "$tmp"
+      atomic_replace "$tmp" "$V4_APP_ICON"
+    else
+      rm -f -- "$V4_APP_ICON"
+    fi
     if (( plugin_dir_created )); then
       rm -rf -- "$HOME/.config/omarchy/plugins/yarikov.omakvn"
     fi
@@ -426,6 +500,8 @@ EOF
   fi
 
   install_launcher 4
+  install_app_icon
+  install_desktop_entry
 
   if grep -Fq -- "-- kvn-tui keybinding: begin" "$hypr_bindings" ||
     grep -Fq "omarchy-launch-kvn-tui" "$hypr_bindings"; then

--- a/docs/system-integration.md
+++ b/docs/system-integration.md
@@ -173,6 +173,10 @@ The installer updates:
   `kvn-tui` command module on fallback), inserted before `omarchy.bluetooth`;
 - `~/.config/hypr/bindings.lua` — optional launcher binding;
 - `~/.config/hypr/hyprland.lua` — floating-window rule.
+- `~/.local/share/applications/kvn-tui.desktop` — Apps menu entry searchable by
+  `kvn-tui`, `tui`, and `vpn`; it opens or focuses the TUI directly.
+- `~/.local/share/icons/hicolor/scalable/apps/kvn-tui.svg` — high-contrast Apps
+  icon styled like Omarchy's bundled applications for light and dark themes.
 
 When `omarchy-shell` is running, the installer also triggers a plugin rescan
 and an idempotent `omarchy bar put yarikov.omakvn` so the widget appears without a
@@ -203,6 +207,8 @@ and window-rule entries. Remove the launcher separately:
 
 ```bash
 rm ~/.local/bin/omarchy-launch-kvn-tui
+rm ~/.local/share/applications/kvn-tui.desktop
+rm ~/.local/share/icons/hicolor/scalable/apps/kvn-tui.svg
 ```
 
 After confirming the active configuration no longer needs the backups, delete

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -813,6 +813,31 @@ esac
         assert!(launcher.contains("omarchy-shell shell summon yarikov.omakvn '{}'"));
         assert!(launcher.contains("omarchy-launch-or-focus-tui"));
         assert!(launcher.contains("--app-id=org.omarchy.kvn-tui"));
+        let desktop_entry =
+            fs::read_to_string(home.join(".local/share/applications/kvn-tui.desktop")).unwrap();
+        for expected in [
+            "Type=Application",
+            "Name=kvn-tui",
+            "GenericName=VPN Client",
+            "Exec=omarchy-launch-or-focus-tui --app-id=org.omarchy.kvn-tui kvn-tui",
+            "TryExec=kvn-tui",
+            "Terminal=false",
+            "Icon=kvn-tui",
+            "Categories=Network;Utility;",
+            "Keywords=VPN;TUI;Terminal;sing-box;",
+        ] {
+            assert!(desktop_entry.contains(expected), "missing {expected}");
+        }
+        let app_icon =
+            fs::read_to_string(home.join(".local/share/icons/hicolor/scalable/apps/kvn-tui.svg"))
+                .unwrap();
+        for expected in [
+            r#"viewBox="0 0 128 128""#,
+            r##"fill="#101010""##,
+            r##"fill="#f5f1e8""##,
+        ] {
+            assert!(app_icon.contains(expected), "missing {expected}");
+        }
         let shell_backups = backup_files(&omarchy.join("shell.json"));
         assert_eq!(shell_backups.len(), 1);
         assert!(
@@ -868,6 +893,32 @@ esac
         let contents = fs::read_to_string(&launcher).unwrap();
         assert!(contents.contains("omarchy-shell shell summon yarikov.omakvn '{}'"));
         assert_eq!(backup_files(&launcher).len(), 1);
+    }
+
+    #[test]
+    fn omarchy_v4_installer_upgrades_desktop_entry_idempotently() {
+        let (root, home) = installer_fixture(4);
+        write_omarchy_v4_config(&home);
+        let desktop_entry = home.join(".local/share/applications/kvn-tui.desktop");
+        let app_icon = home.join(".local/share/icons/hicolor/scalable/apps/kvn-tui.svg");
+        fs::create_dir_all(desktop_entry.parent().unwrap()).unwrap();
+        fs::create_dir_all(app_icon.parent().unwrap()).unwrap();
+        fs::write(&desktop_entry, "[Desktop Entry]\nName=Old kvn-tui\n").unwrap();
+        fs::write(&app_icon, "<svg>old</svg>\n").unwrap();
+
+        assert_success(&run_installer(&root, &home, "y\n\n"));
+
+        let contents = fs::read_to_string(&desktop_entry).unwrap();
+        assert!(contents.contains("Name=kvn-tui"));
+        assert!(contents.contains("Keywords=VPN;TUI;Terminal;sing-box;"));
+        assert_eq!(backup_files(&desktop_entry).len(), 1);
+        let icon_contents = fs::read_to_string(&app_icon).unwrap();
+        assert!(icon_contents.contains(r##"fill="#f5f1e8""##));
+        assert_eq!(backup_files(&app_icon).len(), 1);
+
+        assert_success(&run_installer(&root, &home, ""));
+        assert_eq!(backup_files(&desktop_entry).len(), 1);
+        assert_eq!(backup_files(&app_icon).len(), 1);
     }
 
     #[test]
@@ -992,6 +1043,48 @@ esac
     }
 
     #[test]
+    fn omarchy_v4_failure_removes_new_desktop_entry() {
+        let (root, home) = installer_fixture(4);
+        write_omarchy_v4_config(&home);
+        write_executable(
+            &root.path().join("bin/hyprctl"),
+            "#!/bin/bash\ncase ${1:-} in\nconfigerrors) marker=$HOME/.hypr-errors-seen; if [[ -e $marker ]]; then echo 'new error'; else touch $marker; fi;;\nreload) exit 0;;\nesac\n",
+        );
+        let desktop_entry = home.join(".local/share/applications/kvn-tui.desktop");
+        let app_icon = home.join(".local/share/icons/hicolor/scalable/apps/kvn-tui.svg");
+
+        let output = run_installer(&root, &home, "n\n");
+
+        assert!(!output.status.success());
+        assert!(!desktop_entry.exists());
+        assert!(!app_icon.exists());
+    }
+
+    #[test]
+    fn omarchy_v4_failure_restores_existing_desktop_entry() {
+        let (root, home) = installer_fixture(4);
+        write_omarchy_v4_config(&home);
+        write_executable(
+            &root.path().join("bin/hyprctl"),
+            "#!/bin/bash\ncase ${1:-} in\nconfigerrors) marker=$HOME/.hypr-errors-seen; if [[ -e $marker ]]; then echo 'new error'; else touch $marker; fi;;\nreload) exit 0;;\nesac\n",
+        );
+        let desktop_entry = home.join(".local/share/applications/kvn-tui.desktop");
+        let app_icon = home.join(".local/share/icons/hicolor/scalable/apps/kvn-tui.svg");
+        fs::create_dir_all(desktop_entry.parent().unwrap()).unwrap();
+        fs::create_dir_all(app_icon.parent().unwrap()).unwrap();
+        let original = "[Desktop Entry]\nName=Personal kvn-tui\n";
+        let original_icon = "<svg>personal</svg>\n";
+        fs::write(&desktop_entry, original).unwrap();
+        fs::write(&app_icon, original_icon).unwrap();
+
+        let output = run_installer(&root, &home, "n\n");
+
+        assert!(!output.status.success());
+        assert_eq!(fs::read_to_string(desktop_entry).unwrap(), original);
+        assert_eq!(fs::read_to_string(app_icon).unwrap(), original_icon);
+    }
+
+    #[test]
     fn omarchy_installer_keeps_only_five_backups_per_changed_file() {
         let (root, home) = installer_fixture(4);
         let shell_config = home.join(".config/omarchy/shell.json");
@@ -1038,6 +1131,17 @@ esac
         fs::write(&legacy, "legacy").unwrap();
         fs::write(&timestamped, "timestamped").unwrap();
         fs::write(&unrelated, "keep").unwrap();
+        let desktop_entry = home.join(".local/share/applications/kvn-tui.desktop");
+        fs::create_dir_all(desktop_entry.parent().unwrap()).unwrap();
+        fs::write(&desktop_entry, "active").unwrap();
+        let desktop_backup =
+            desktop_entry.with_file_name("kvn-tui.desktop.bak.before-kvn-tui.20260821143012");
+        fs::write(&desktop_backup, "backup").unwrap();
+        let app_icon = home.join(".local/share/icons/hicolor/scalable/apps/kvn-tui.svg");
+        fs::create_dir_all(app_icon.parent().unwrap()).unwrap();
+        fs::write(&app_icon, "active").unwrap();
+        let icon_backup = app_icon.with_file_name("kvn-tui.svg.bak.before-kvn-tui.20260821143012");
+        fs::write(&icon_backup, "backup").unwrap();
         let plugin = omarchy.join("plugins/yarikov.omakvn");
         fs::create_dir_all(&plugin).unwrap();
         fs::write(plugin.join("manifest.json"), "{}").unwrap();
@@ -1063,6 +1167,10 @@ esac
         assert!(!legacy.exists());
         assert!(!timestamped.exists());
         assert!(unrelated.exists());
+        assert!(desktop_entry.exists());
+        assert!(!desktop_backup.exists());
+        assert!(app_icon.exists());
+        assert!(!icon_backup.exists());
         assert!(plugin.exists(), "bar plugin directory should be preserved");
         assert!(
             legacy_plugin.exists(),
@@ -1146,6 +1254,16 @@ esac
             fs::read_to_string(hypr.join("hyprland.conf"))
                 .unwrap()
                 .contains("org.omarchy.kvn-tui")
+        );
+        assert!(
+            !home
+                .join(".local/share/applications/kvn-tui.desktop")
+                .exists()
+        );
+        assert!(
+            !home
+                .join(".local/share/icons/hicolor/scalable/apps/kvn-tui.svg")
+                .exists()
         );
     }
 


### PR DESCRIPTION
## Summary

Omarchy 4 users cannot currently find or launch kvn-tui from the Apps menu. This PR installs a searchable desktop entry and a high-contrast icon that remains readable with light and dark themes.

## Changes

- Add a per-user desktop entry searchable by `kvn-tui`, `tui`, and `vpn`.
- Open or focus the TUI directly through `omarchy-launch-or-focus-tui`.
- Install an Omarchy-style SVG icon under the user icon theme.
- Include the desktop entry and icon in atomic backup and rollback handling.
- Extend cleanup support and user-facing documentation.
- Cover installation, upgrades, idempotency, rollback, cleanup, and Omarchy 3 isolation.
