### PR TITLE
fix(security): harden credentials, runtime files, and privileged helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,7 +182,7 @@ The **TUI client** (`tui_client.rs`) additionally spawns:
 
 ### sing-box Config Generation
 - `singbox::config::generate_config` builds a complete sing-box 1.12+ JSON object from a `Profile` and `Settings`.
-- The config is written to a temp file (`/tmp/kvn-tui-singbox.json` or `$XDG_RUNTIME_DIR`), validated with `sing-box check`, and only then is `sing-box run` spawned.
+- The config is written atomically with mode `0600` to `$XDG_RUNTIME_DIR/kvn-tui/singbox.json`, validated with `sing-box check`, and only then is `sing-box run` spawned. The private `kvn-tui/` runtime directory has mode `0700`; a desktop user session with `XDG_RUNTIME_DIR` is required.
 - If the process exits immediately, stderr is captured and surfaced to the user.
 - `build_outbound(profile)` dispatches to a per-protocol builder and returns `Vec<serde_json::Value>` (most protocols return one outbound; ShadowTLS returns two — a `shadowtls` wrapper tagged `shadowtls-wrap` plus a `shadowsocks` detour tagged `proxy`).
 - Shared helpers: `build_tls_block` (TLS + ECH + REALITY), `build_transport_block` (WebSocket / gRPC / HTTP upgrade). No deprecated sing-box fields (no `obfs_password`, no `aes-128-cfb`, no top-level `dns.fakeip`, no WireGuard outbound).
@@ -294,9 +294,9 @@ If you need to add a new side effect from `update`, add a new `Effect` variant a
 | Profiles & settings | `~/.config/kvn-tui/profiles.json` |
 | Geo rule-sets | `~/.config/kvn-tui/geo/` |
 | sing-box logs | `~/.config/kvn-tui/logs/sing-box.log` |
-| Temp sing-box config | `$XDG_RUNTIME_DIR/kvn-tui-singbox.json` or `/tmp/kvn-tui-singbox.json` |
+| Temp sing-box config | `$XDG_RUNTIME_DIR/kvn-tui/singbox.json` |
 | Runtime state (waybar) | `~/.config/kvn-tui/state.json` |
-| IPC socket (daemon ↔ TUI) | `~/.config/kvn-tui/kvn-tui.sock` or `$XDG_RUNTIME_DIR/kvn-tui.sock` |
+| IPC socket (daemon ↔ TUI) | `$XDG_RUNTIME_DIR/kvn-tui.sock` |
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,6 +1255,7 @@ dependencies = [
  "libc",
  "notify",
  "ratatui",
+ "rustls",
  "serde",
  "serde_json",
  "signal-hook 0.4.4",
@@ -1267,6 +1268,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
+ "webpki-roots",
  "zbus",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ uuid = { version = "1.9", features = ["v4", "serde"] }
 
 # HTTP client for geo database downloads
 ureq = { version = "3", features = ["rustls"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+webpki-roots = "1"
 
 # Logging
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - [First Connection](#first-connection)
 - [Installation (Arch Linux)](#installation-arch-linux)
   - [AUR](#aur-recommended)
-  - [Polkit setup](#polkit-setup-recommended)
+  - [Polkit setup](#polkit-setup-optional-recommended-for-unattended-reconnects)
   - [Kill switch setup](#kill-switch-setup-optional)
   - [Omarchy integration](#omarchy-integration-optional)
   - [Build from source](#build-from-source)
@@ -113,18 +113,23 @@ systemctl --user enable --now kvn-tui.service
 available after login. The package also restores the TUN capabilities on
 `/usr/bin/sing-box` automatically after pacman upgrades it.
 
-### Polkit setup (recommended)
+### Polkit setup (optional, recommended for unattended reconnects)
 
 Install the polkit rule to avoid repeated authentication prompts when sing-box
-changes DNS settings or routes:
+configures per-link DNS through systemd-resolved. The rule grants only the
+three required resolved actions to members of the dedicated `kvn-tui` group;
+it does not grant NetworkManager permissions:
 
 ```bash
 sudo pacman -S --needed polkit
 sudo kvn-tui setup --polkit
 ```
 
-If setup adds you to the `network` group, run `newgrp network` or log out and
-back in.
+If setup adds you to the `kvn-tui` group, log out and back in, then restart the
+user daemon. Because authorization is group-wide, every process running as an
+enrolled user can request those three DNS operations. Skip this setup if you
+prefer interactive polkit authorization and do not need unattended auto-connect
+or resume reconnects.
 
 ### Kill switch setup (optional)
 
@@ -136,8 +141,9 @@ sudo pacman -S --needed nftables
 sudo kvn-tui setup --killswitch
 ```
 
-If setup adds you to the `network` group, run `newgrp network` or log out and
-back in.
+The kill-switch sudoers rule uses the same dedicated `kvn-tui` group and allows
+only the validating helper installed at `/usr/lib/kvn-tui/killswitch-helper.sh`.
+Log out and back in if setup newly adds you to the group.
 
 Toggle it with `K`; the status bar shows `[KS]` while it is enabled. Polkit and
 the kill switch can also be installed together:
@@ -145,6 +151,16 @@ the kill switch can also be installed together:
 ```bash
 sudo kvn-tui setup --polkit --killswitch
 ```
+
+Remove either system integration with:
+
+```bash
+sudo kvn-tui clean --polkit
+sudo kvn-tui clean --killswitch
+```
+
+Cleanup deliberately preserves the `kvn-tui` group and user membership because
+the other integration may still need them.
 
 ### Omarchy integration (optional)
 

--- a/README.md
+++ b/README.md
@@ -160,8 +160,9 @@ sudo kvn-tui clean --polkit
 sudo kvn-tui clean --killswitch
 ```
 
-Cleanup deliberately preserves the `kvn-tui` group and user membership because
-the other integration may still need them.
+Cleanup preserves the `kvn-tui` group while either integration still uses it.
+After both integrations are removed, the now-unused group and its membership
+records are removed automatically.
 
 ### Omarchy integration (optional)
 

--- a/README.md
+++ b/README.md
@@ -90,9 +90,10 @@ Choose a regional routing preset on first launch, then:
 Clipboard import requires `wl-clipboard` on Wayland or `xclip` / `xsel` on X11.
 Press `?` at any time to see the full key map.
 
-Subscription URLs must use HTTPS. Plain HTTP subscriptions are rejected because
-their access tokens and returned VPN credentials would otherwise cross the
-network without transport encryption.
+New installations require HTTPS for subscriptions. Existing configurations
+migrated to schema v5 retain deprecated HTTP support for compatibility with
+self-hosted servers. Set `settings.allow_insecure_http_subscriptions` to `false`
+after migrating those servers to HTTPS.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Choose a regional routing preset on first launch, then:
 Clipboard import requires `wl-clipboard` on Wayland or `xclip` / `xsel` on X11.
 Press `?` at any time to see the full key map.
 
+Subscription URLs must use HTTPS. Plain HTTP subscriptions are rejected because
+their access tokens and returned VPN credentials would otherwise cross the
+network without transport encryption.
+
 ---
 
 ## Installation (Arch Linux)

--- a/README.md
+++ b/README.md
@@ -312,6 +312,9 @@ their physical US key positions regardless of the active keyboard layout.
 
 Configuration is stored in `~/.config/kvn-tui/profiles.json`. Press `e` to edit
 it in `$EDITOR`; invalid configuration is rejected when reloaded.
+Manual latency tests use an HTTPS connectivity endpoint by default. Set
+`settings.connectivity_probe.url` to another HTTP(S) URL, or set
+`settings.connectivity_probe.enabled` to `false` to disable active probing.
 
 See the [configuration guide](docs/configuration.md) for the JSON structure,
 advanced DNS and routing, validation, migrations, and runtime file locations.

--- a/contrib/clean-killswitch.sh
+++ b/contrib/clean-killswitch.sh
@@ -6,6 +6,24 @@ RULESET="/etc/kvn-tui/killswitch.nft"
 HELPER="/usr/lib/kvn-tui/killswitch-helper.sh"
 UNIT_FILE="/etc/systemd/system/$UNIT"
 SUDOERS="/etc/sudoers.d/kvn-tui-killswitch"
+POLKIT_RULE="/etc/polkit-1/rules.d/49-kvn-tui.rules"
+GROUP_NAME="kvn-tui"
+
+cleanup_group_if_unused() {
+    if [[ -e "$POLKIT_RULE" ]]; then
+        echo "The '$GROUP_NAME' group was preserved because the polkit rule still uses it."
+        return
+    fi
+    if ! getent group "$GROUP_NAME" >/dev/null; then
+        echo "The '$GROUP_NAME' group is not present."
+        return
+    fi
+    if groupdel "$GROUP_NAME"; then
+        echo "Removed unused '$GROUP_NAME' group and its membership records."
+    else
+        echo "Warning: could not remove unused '$GROUP_NAME' group; remove it manually." >&2
+    fi
+}
 
 if [[ $EUID -ne 0 ]]; then
     echo "This cleanup must be run as root (e.g. sudo kvn-tui clean --killswitch)" >&2
@@ -32,5 +50,5 @@ systemctl daemon-reload
 systemctl reset-failed "$UNIT" >/dev/null 2>&1 || true
 
 echo "Removed kvn-tui kill-switch system integration."
-echo "The 'kvn-tui' group and memberships were preserved."
+cleanup_group_if_unused
 echo "Restart the user kvn-tui daemon so its persisted state is reconciled."

--- a/contrib/clean-killswitch.sh
+++ b/contrib/clean-killswitch.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+UNIT="kvn-tui-killswitch.service"
+RULESET="/etc/kvn-tui/killswitch.nft"
+HELPER="/usr/lib/kvn-tui/killswitch-helper.sh"
+UNIT_FILE="/etc/systemd/system/$UNIT"
+SUDOERS="/etc/sudoers.d/kvn-tui-killswitch"
+
+if [[ $EUID -ne 0 ]]; then
+    echo "This cleanup must be run as root (e.g. sudo kvn-tui clean --killswitch)" >&2
+    exit 1
+fi
+
+if systemctl is-active --quiet "$UNIT"; then
+    systemctl disable --now "$UNIT"
+    if systemctl is-active --quiet "$UNIT"; then
+        echo "Failed to stop $UNIT; refusing to remove its files." >&2
+        exit 1
+    fi
+else
+    systemctl disable "$UNIT" >/dev/null 2>&1 || true
+fi
+
+# Remove a table left behind after a prior interrupted service stop.
+nft delete table inet kvn_tui_killswitch >/dev/null 2>&1 || true
+
+rm -f -- "$SUDOERS" "$HELPER" "$UNIT_FILE" "$RULESET"
+rmdir /usr/lib/kvn-tui 2>/dev/null || true
+rmdir /etc/kvn-tui 2>/dev/null || true
+systemctl daemon-reload
+systemctl reset-failed "$UNIT" >/dev/null 2>&1 || true
+
+echo "Removed kvn-tui kill-switch system integration."
+echo "The 'kvn-tui' group and memberships were preserved."
+echo "Restart the user kvn-tui daemon so its persisted state is reconciled."

--- a/contrib/clean-polkit.sh
+++ b/contrib/clean-polkit.sh
@@ -2,6 +2,24 @@
 set -euo pipefail
 
 RULE_FILE="/etc/polkit-1/rules.d/49-kvn-tui.rules"
+KILLSWITCH_SUDOERS="/etc/sudoers.d/kvn-tui-killswitch"
+GROUP_NAME="kvn-tui"
+
+cleanup_group_if_unused() {
+    if [[ -e "$KILLSWITCH_SUDOERS" ]]; then
+        echo "The '$GROUP_NAME' group was preserved because the kill switch still uses it."
+        return
+    fi
+    if ! getent group "$GROUP_NAME" >/dev/null; then
+        echo "The '$GROUP_NAME' group is not present."
+        return
+    fi
+    if groupdel "$GROUP_NAME"; then
+        echo "Removed unused '$GROUP_NAME' group and its membership records."
+    else
+        echo "Warning: could not remove unused '$GROUP_NAME' group; remove it manually." >&2
+    fi
+}
 
 if [[ $EUID -ne 0 ]]; then
     echo "This cleanup must be run as root (e.g. sudo kvn-tui clean --polkit)" >&2
@@ -15,5 +33,4 @@ else
     echo "kvn-tui polkit rule is not installed."
 fi
 
-echo "The 'kvn-tui' group and memberships were preserved."
-echo "Remove them manually only after both optional system integrations are gone."
+cleanup_group_if_unused

--- a/contrib/clean-polkit.sh
+++ b/contrib/clean-polkit.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+RULE_FILE="/etc/polkit-1/rules.d/49-kvn-tui.rules"
+
+if [[ $EUID -ne 0 ]]; then
+    echo "This cleanup must be run as root (e.g. sudo kvn-tui clean --polkit)" >&2
+    exit 1
+fi
+
+if [[ -e "$RULE_FILE" ]]; then
+    rm -- "$RULE_FILE"
+    echo "Removed $RULE_FILE"
+else
+    echo "kvn-tui polkit rule is not installed."
+fi
+
+echo "The 'kvn-tui' group and memberships were preserved."
+echo "Remove them manually only after both optional system integrations are gone."

--- a/contrib/killswitch-helper.sh
+++ b/contrib/killswitch-helper.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Narrow privileged API used by the kvn-tui daemon through sudoers.
+set -euo pipefail
+
+UNIT="kvn-tui-killswitch.service"
+RULESET="/etc/kvn-tui/killswitch.nft"
+UNIT_FILE="/etc/systemd/system/$UNIT"
+SUDOERS="/etc/sudoers.d/kvn-tui-killswitch"
+
+validate_ip() {
+    local ip=$1
+    if [[ $ip =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+        local octet
+        local -a octets
+        IFS=. read -r -a octets <<<"$ip"
+        for octet in "${octets[@]}"; do
+            (( 10#$octet <= 255 )) || return 1
+        done
+        return 0
+    fi
+
+    [[ $ip == *:* && $ip =~ ^[0-9a-fA-F:]+$ ]] || return 1
+    getent ahosts "$ip" >/dev/null 2>&1
+}
+
+validate_allow_args() {
+    [[ $# -eq 3 ]] || return 1
+    validate_ip "$1" || return 1
+    [[ $2 == "tcp" || $2 == "udp" ]] || return 1
+    [[ $3 =~ ^[0-9]{1,5}$ ]] || return 1
+    (( 10#$3 >= 1 && 10#$3 <= 65535 ))
+}
+
+validate_command_args() {
+    [[ $# -ge 1 ]] || return 1
+    case $1 in
+        check|enable|disable|revoke) [[ $# -eq 1 ]] ;;
+        allow) validate_allow_args "${@:2}" ;;
+        *) return 1 ;;
+    esac
+}
+
+check_root_file() {
+    local path=$1 expected_mode=$2 owner mode
+    read -r owner mode < <(stat -c '%u %a' "$path") || return 1
+    [[ $owner == 0 && $mode == "$expected_mode" ]]
+}
+
+check_installation() {
+    command -v nft >/dev/null
+    command -v systemctl >/dev/null
+    command -v getent >/dev/null
+    check_root_file "$0" 755
+    check_root_file "$RULESET" 644
+    check_root_file "$UNIT_FILE" 644
+    check_root_file "$SUDOERS" 440
+}
+
+main() {
+    if [[ $EUID -ne 0 ]]; then
+        echo "kvn-tui kill-switch helper must run as root" >&2
+        exit 1
+    fi
+    if [[ "$(stat -c %u "$0")" != "0" ]]; then
+        echo "kvn-tui kill-switch helper is not root-owned; refusing to run" >&2
+        exit 1
+    fi
+    if ! validate_command_args "$@"; then
+        echo "usage: $0 {check|enable|disable|revoke|allow <ip> <tcp|udp> <port>}" >&2
+        exit 2
+    fi
+
+    case "$1" in
+        check)
+            check_installation
+            ;;
+        enable|disable)
+            exec systemctl "$1" --now "$UNIT"
+            ;;
+        revoke)
+            nft flush set inet kvn_tui_killswitch handshake_v4 2>/dev/null || true
+            nft flush set inet kvn_tui_killswitch handshake_v6 2>/dev/null || true
+            ;;
+        allow)
+            if [[ $2 == *:* ]]; then
+                exec nft add element inet kvn_tui_killswitch handshake_v6 "{ $2 . $3 . $4 }"
+            else
+                exec nft add element inet kvn_tui_killswitch handshake_v4 "{ $2 . $3 . $4 }"
+            fi
+            ;;
+    esac
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+    main "$@"
+fi

--- a/contrib/setup-killswitch.sh
+++ b/contrib/setup-killswitch.sh
@@ -3,9 +3,9 @@
 #   - /etc/kvn-tui/killswitch.nft           (nftables ruleset)
 #   - /usr/lib/kvn-tui/killswitch-helper.sh (privileged helper)
 #   - /etc/systemd/system/kvn-tui-killswitch.service
-#   - /etc/sudoers.d/kvn-tui-killswitch     (NOPASSWD for group `network`)
+#   - /etc/sudoers.d/kvn-tui-killswitch     (NOPASSWD for group `kvn-tui`)
 #
-# After install, members of the `network` group can toggle the kill switch
+# After install, members of the `kvn-tui` group can toggle the kill switch
 # from kvn-tui without a password prompt.
 set -euo pipefail
 
@@ -15,12 +15,19 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 USER_NAME="${SUDO_USER:-${USER:-}}"
-if [[ -z "$USER_NAME" || "$USER_NAME" == "root" ]]; then
-    echo "Could not detect invoking user — set SUDO_USER or run via sudo." >&2
+if [[ -z "$USER_NAME" || "$USER_NAME" == "root" ]] || ! id "$USER_NAME" >/dev/null 2>&1; then
+    echo "Could not identify a non-root invoking user; run this command via sudo." >&2
     exit 1
 fi
+HELPER_SOURCE="${1:?missing embedded kill-switch helper source}"
+GROUP_NAME="kvn-tui"
 
 echo "Installing kvn-tui kill switch for user '$USER_NAME'…"
+
+if ! getent group "$GROUP_NAME" >/dev/null; then
+    groupadd --system "$GROUP_NAME"
+    echo "Created system group '$GROUP_NAME'."
+fi
 
 # ── 1. nftables ruleset ────────────────────────────────────────────────
 install -dm755 /etc/kvn-tui
@@ -93,56 +100,12 @@ fi
 
 # ── 2. Helper script ───────────────────────────────────────────────────
 install -dm755 /usr/lib/kvn-tui
-cat > /usr/lib/kvn-tui/killswitch-helper.sh <<'HELPER_EOF'
-#!/bin/bash
-# kvn-tui kill switch privileged helper.
-# Invoked via sudo from the kvn-tui daemon. Validates input strictly.
-set -euo pipefail
-
-if [[ "$(stat -c %u "$0")" != "0" ]]; then
-    echo "kvn-tui killswitch helper is not root-owned; refusing to run" >&2
-    exit 1
-fi
-
-UNIT="kvn-tui-killswitch.service"
-
-case "${1:-}" in
-    enable)
-        exec systemctl enable --now "$UNIT"
-        ;;
-    disable)
-        exec systemctl disable --now "$UNIT"
-        ;;
-    revoke)
-        nft flush set inet kvn_tui_killswitch handshake_v4 2>/dev/null || true
-        nft flush set inet kvn_tui_killswitch handshake_v6 2>/dev/null || true
-        ;;
-    allow)
-        ip="${2:?missing ip}"
-        proto="${3:?missing proto}"
-        port="${4:?missing port}"
-        [[ "$proto" =~ ^(tcp|udp)$ ]] || { echo "bad proto: $proto" >&2; exit 2; }
-        [[ "$port" =~ ^[0-9]{1,5}$ ]] || { echo "bad port: $port" >&2; exit 2; }
-        if (( port < 1 || port > 65535 )); then
-            echo "port out of range: $port" >&2; exit 2
-        fi
-        if [[ "$ip" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]]; then
-            exec nft add element inet kvn_tui_killswitch handshake_v4 "{ $ip . $proto . $port }"
-        elif [[ "$ip" =~ ^[0-9a-fA-F:]+$ ]]; then
-            exec nft add element inet kvn_tui_killswitch handshake_v6 "{ $ip . $proto . $port }"
-        else
-            echo "bad ip: $ip" >&2
-            exit 2
-        fi
-        ;;
-    *)
-        echo "usage: $0 {enable|disable|revoke|allow <ip> <tcp|udp> <port>}" >&2
-        exit 2
-        ;;
-esac
-HELPER_EOF
-chown root:root /usr/lib/kvn-tui/killswitch-helper.sh
-chmod 755 /usr/lib/kvn-tui/killswitch-helper.sh
+HELPER_TMP="$(mktemp)"
+SUDOERS_TMP=""
+trap 'rm -f "$HELPER_TMP" "$SUDOERS_TMP"' EXIT
+printf '%s\n' "$HELPER_SOURCE" >"$HELPER_TMP"
+bash -n "$HELPER_TMP"
+install -m 0755 -o root -g root "$HELPER_TMP" /usr/lib/kvn-tui/killswitch-helper.sh
 
 # ── 3. systemd unit ────────────────────────────────────────────────────
 cat > /etc/systemd/system/kvn-tui-killswitch.service <<'UNIT_EOF'
@@ -169,13 +132,12 @@ chmod 644 /etc/systemd/system/kvn-tui-killswitch.service
 
 # ── 4. sudoers fragment (validated before installing) ──────────────────
 SUDOERS_TMP="$(mktemp)"
-trap 'rm -f "$SUDOERS_TMP"' EXIT
 cat > "$SUDOERS_TMP" <<'SUDOERS_EOF'
-# Allow group `network` to invoke the kvn-tui kill switch helper without a
+# Allow group `kvn-tui` to invoke the kvn-tui kill-switch helper without a
 # password. The helper itself validates its arguments; nothing else is
 # whitelisted, and the helper path is fixed.
 Defaults!/usr/lib/kvn-tui/killswitch-helper.sh env_reset, secure_path="/usr/sbin:/usr/bin"
-%network ALL=(root) NOPASSWD: /usr/lib/kvn-tui/killswitch-helper.sh
+%kvn-tui ALL=(root) NOPASSWD: /usr/lib/kvn-tui/killswitch-helper.sh
 SUDOERS_EOF
 if ! visudo -cf "$SUDOERS_TMP" >/dev/null; then
     echo "FATAL: sudoers fragment failed validation" >&2
@@ -183,10 +145,10 @@ if ! visudo -cf "$SUDOERS_TMP" >/dev/null; then
 fi
 install -m 0440 -o root -g root "$SUDOERS_TMP" /etc/sudoers.d/kvn-tui-killswitch
 
-# ── 5. Ensure user is in network group ─────────────────────────────────
-if ! id -nG "$USER_NAME" | tr ' ' '\n' | grep -qx network; then
-    echo "Adding user '$USER_NAME' to the 'network' group…"
-    usermod -aG network "$USER_NAME"
+# ── 5. Ensure user is in the dedicated group ──────────────────────────
+if ! id -nG "$USER_NAME" | tr ' ' '\n' | grep -Fxq "$GROUP_NAME"; then
+    echo "Adding user '$USER_NAME' to the '$GROUP_NAME' group…"
+    usermod -aG "$GROUP_NAME" "$USER_NAME"
     NEW_GROUP=1
 else
     NEW_GROUP=0
@@ -211,6 +173,11 @@ echo "  /etc/sudoers.d/kvn-tui-killswitch"
 echo
 echo "Toggle the kill switch from the TUI with Shift+K."
 if [[ "$NEW_GROUP" == "1" ]]; then
-    echo "User '$USER_NAME' was added to the 'network' group — log out and back"
-    echo "in (or run 'newgrp network') before toggling from the TUI."
+    echo "User '$USER_NAME' was added to '$GROUP_NAME' — log out and back in,"
+    echo "then restart kvn-tui.service before toggling from the TUI."
+fi
+if id -nG "$USER_NAME" | tr ' ' '\n' | grep -Fxq network; then
+    echo
+    echo "Note: kvn-tui no longer uses the 'network' group. Existing membership"
+    echo "was preserved because another application may rely on it."
 fi

--- a/contrib/setup-polkit.sh
+++ b/contrib/setup-polkit.sh
@@ -1,50 +1,60 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 RULE_FILE="/etc/polkit-1/rules.d/49-kvn-tui.rules"
-USER_NAME="${SUDO_USER:-$USER}"
+GROUP_NAME="kvn-tui"
 
-echo "Installing kvn-tui polkit rule..."
-
-# ── Ensure user is in the 'network' group ──
-if ! groups "$USER_NAME" | grep -qw network; then
-    echo "Adding user '$USER_NAME' to the 'network' group..."
-    usermod -aG network "$USER_NAME"
-    echo "Group added. You may need to log out and back in for it to take full effect."
-else
-    echo "User '$USER_NAME' is already in the 'network' group."
+if [[ $EUID -ne 0 ]]; then
+    echo "This installer must be run as root (e.g. sudo kvn-tui setup --polkit)" >&2
+    exit 1
 fi
 
-# ── Create polkit rule ──
-echo "Creating polkit rule at $RULE_FILE..."
-cat > "$RULE_FILE" <<'EOF'
+USER_NAME="${SUDO_USER:-}"
+if [[ -z "$USER_NAME" || "$USER_NAME" == "root" ]] || ! id "$USER_NAME" >/dev/null 2>&1; then
+    echo "Could not identify a non-root invoking user; run this command via sudo." >&2
+    exit 1
+fi
+
+if ! getent group "$GROUP_NAME" >/dev/null; then
+    groupadd --system "$GROUP_NAME"
+    echo "Created system group '$GROUP_NAME'."
+fi
+
+if ! id -nG "$USER_NAME" | tr ' ' '\n' | grep -Fxq "$GROUP_NAME"; then
+    usermod -aG "$GROUP_NAME" "$USER_NAME"
+    ADDED_TO_GROUP=1
+else
+    ADDED_TO_GROUP=0
+fi
+
+RULE_TMP="$(mktemp)"
+trap 'rm -f "$RULE_TMP"' EXIT
+cat >"$RULE_TMP" <<'EOF'
+// kvn-tui: allow unattended sing-box DNS setup for explicitly enrolled users.
 polkit.addRule(function(action, subject) {
     if (
         (
-            action.id == "org.freedesktop.resolve1.set-dns-servers"   ||
-            action.id == "org.freedesktop.resolve1.set-domains"       ||
-            action.id == "org.freedesktop.resolve1.set-default-route" ||
-            action.id == "org.freedesktop.NetworkManager.network-control" ||
-            action.id == "org.freedesktop.NetworkManager.settings.modify.system"
+            action.id == "org.freedesktop.resolve1.set-dns-servers" ||
+            action.id == "org.freedesktop.resolve1.set-domains" ||
+            action.id == "org.freedesktop.resolve1.set-default-route"
         ) &&
-        subject.isInGroup("network")
+        subject.isInGroup("kvn-tui")
     ) {
         return polkit.Result.YES;
     }
 });
 EOF
 
-chmod 644 "$RULE_FILE"
+install -m 0644 -o root -g root "$RULE_TMP" "$RULE_FILE"
 
-# ── Restart polkit ──
-echo "Restarting polkit..."
-if systemctl is-active --quiet polkit; then
-    systemctl restart polkit
-else
-    echo "Warning: polkit service is not active. Please start it manually."
+echo "Installed $RULE_FILE with three systemd-resolved permissions."
+echo "NetworkManager permissions are not granted."
+if [[ "$ADDED_TO_GROUP" == "1" ]]; then
+    echo "User '$USER_NAME' was added to '$GROUP_NAME'. Log out and back in,"
+    echo "then restart kvn-tui.service before using unattended DNS setup."
 fi
-
-echo "Done."
-echo ""
-echo "If you were just added to the 'network' group, run 'newgrp network'"
-echo "in your current shell or log out and back in before testing kvn-tui."
+if id -nG "$USER_NAME" | tr ' ' '\n' | grep -Fxq network; then
+    echo
+    echo "Note: kvn-tui no longer uses the 'network' group. Existing membership"
+    echo "was preserved because another application may rely on it."
+fi

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -195,5 +195,11 @@ upgrade kvn-tui instead of downgrading the version manually.
 | Application log | `~/.config/kvn-tui/logs/app.log` |
 | sing-box log | `~/.config/kvn-tui/logs/sing-box.log` |
 | Waybar and recovery state | `~/.config/kvn-tui/state.json` |
-| IPC socket | `$XDG_RUNTIME_DIR/kvn-tui.sock` or `/tmp/kvn-tui-<uid>.sock` |
-| Generated sing-box config | `$XDG_RUNTIME_DIR/kvn-tui-singbox.json`, `$XDG_CACHE_HOME/kvn-tui/singbox.json`, or `/tmp/kvn-tui-singbox.json` |
+| IPC socket | `$XDG_RUNTIME_DIR/kvn-tui.sock` |
+| Generated sing-box config | `$XDG_RUNTIME_DIR/kvn-tui/singbox.json` |
+
+The application-owned runtime directory is created with mode `0700`; generated
+sing-box configs and the IPC socket use mode `0600`. No secret-bearing config is
+written directly into the shared `/tmp` namespace. `XDG_RUNTIME_DIR` is required;
+kvn-tui fails with a clear error outside a desktop user session instead of
+falling back to a shared or persistent location.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,7 @@ A subscription contains `id`, `name`, `url`, `auto_update`, and an optional
 | `kill_switch` | `false` | Persisted kill-switch state |
 | `last_connected_profile` | `null` | Last connected profile; maintained by the application |
 | `theme` | `tokyo-night` | Bundled palette slug or `omarchy` |
+| `allow_insecure_http_subscriptions` | `false` (`true` after migration from v4) | Temporarily allow deprecated HTTP subscription URLs for backward compatibility |
 | `connectivity_probe.enabled` | `true` | Enable the HTTP(S) endpoint used only by manual `t` / `T` latency tests |
 | `connectivity_probe.url` | `https://connectivitycheck.gstatic.com/generate_204` | Probe endpoint; required and validated only when the probe is enabled |
 | `logs.level` | `info` | `trace`, `debug`, `info`, `warn`, or `error` |
@@ -69,6 +70,12 @@ response byte through the tested VPN profile. The probe runs only when `t` or
 
 Set `enabled` to `false` to disable active probing. While disabled, `url` may
 be absent or retain any value; it is ignored until probing is enabled again.
+
+New configurations reject HTTP subscription URLs by default. Configurations
+migrated from schema v4 enable them to preserve compatibility with self-hosted
+servers and emit a warning on every HTTP update. Set
+`allow_insecure_http_subscriptions` to `false` after enabling HTTPS to reject
+HTTP before any network request is made.
 
 ```json
 "logs": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,11 +16,11 @@ with a partial file.
 
 ## File structure
 
-The current schema version is 4. A minimal configuration is:
+The current schema version is 5. A minimal configuration is:
 
 ```json
 {
-  "schema_version": 4,
+  "schema_version": 5,
   "profiles": [],
   "subscriptions": [],
   "settings": {}
@@ -49,9 +49,26 @@ A subscription contains `id`, `name`, `url`, `auto_update`, and an optional
 | `kill_switch` | `false` | Persisted kill-switch state |
 | `last_connected_profile` | `null` | Last connected profile; maintained by the application |
 | `theme` | `tokyo-night` | Bundled palette slug or `omarchy` |
+| `connectivity_probe.enabled` | `true` | Enable the HTTP(S) endpoint used only by manual `t` / `T` latency tests |
+| `connectivity_probe.url` | `https://connectivitycheck.gstatic.com/generate_204` | Probe endpoint; required and validated only when the probe is enabled |
 | `logs.level` | `info` | `trace`, `debug`, `info`, `warn`, or `error` |
 | `logs.line_retention.app` | `1000` | Physical lines retained in `app.log` |
 | `logs.line_retention.singbox` | `100000` | Physical lines retained in `sing-box.log` |
+
+The latency value is an end-to-end probe rather than a raw network RTT. For an
+HTTPS endpoint it includes the TLS handshake, request, and time to the first
+response byte through the tested VPN profile. The probe runs only when `t` or
+`T` is pressed and does not affect normal VPN connection health.
+
+```json
+"connectivity_probe": {
+  "enabled": true,
+  "url": "https://connectivitycheck.gstatic.com/generate_204"
+}
+```
+
+Set `enabled` to `false` to disable active probing. While disabled, `url` may
+be absent or retain any value; it is ignored until probing is enabled again.
 
 ```json
 "logs": {

--- a/docs/system-integration.md
+++ b/docs/system-integration.md
@@ -70,10 +70,11 @@ To remove the rule:
 sudo kvn-tui clean --polkit
 ```
 
-Cleanup preserves the group and membership because the kill switch may still
-use them. Existing membership in the legacy `network` group is also never
-removed automatically; verify that no other software needs it before changing
-it manually.
+Cleanup preserves the group while the kill switch still uses it. If neither
+integration remains, cleanup removes the now-unused group and its membership
+records automatically. Existing membership in the legacy `network` group is
+never removed automatically; verify that no other software needs it before
+changing it manually.
 
 ## Kill switch setup
 
@@ -122,17 +123,10 @@ sudo kvn-tui clean --killswitch
 ```
 
 If the active unit cannot be stopped, cleanup aborts before removing its files.
-The command leaves the `kvn-tui` group and membership unchanged and asks you to
-restart the user daemon so persisted state is reconciled.
-
-After removing both polkit and kill-switch integration, the now-unused group can
-optionally be removed after confirming its membership:
-
-```bash
-getent group kvn-tui
-sudo gpasswd -d "$USER" kvn-tui
-sudo groupdel kvn-tui
-```
+The command preserves the `kvn-tui` group while the polkit integration still
+uses it. If neither integration remains, cleanup removes the group and its
+membership records automatically. Restart the user daemon afterward so its
+persisted state is reconciled.
 
 ## Omarchy setup
 

--- a/docs/system-integration.md
+++ b/docs/system-integration.md
@@ -49,32 +49,31 @@ sudo kvn-tui setup --polkit
 
 The command:
 
-- adds the invoking user to the `network` group if necessary;
+- creates the dedicated system group `kvn-tui` and adds the invoking user if
+  necessary;
 - writes `/etc/polkit-1/rules.d/49-kvn-tui.rules` with mode `0644`;
-- restarts polkit when its service is active.
+- leaves polkit to reload the changed rule automatically.
 
-The rule allows every member of `network` to perform these actions without an
+The rule allows every member of `kvn-tui` to perform these actions without an
 authentication prompt:
 
 - `org.freedesktop.resolve1.set-dns-servers`
 - `org.freedesktop.resolve1.set-domains`
 - `org.freedesktop.resolve1.set-default-route`
-- `org.freedesktop.NetworkManager.network-control`
-- `org.freedesktop.NetworkManager.settings.modify.system`
-
-This authorization is group-wide and is not restricted to the kvn-tui process.
-After being added to `network`, log out and back in or run `newgrp network`.
+No NetworkManager actions are granted. This authorization is group-wide and is
+not restricted to the kvn-tui process. After being added to `kvn-tui`, log out
+and back in and restart `kvn-tui.service`.
 
 To remove the rule:
 
 ```bash
-sudo rm /etc/polkit-1/rules.d/49-kvn-tui.rules
-sudo systemctl try-restart polkit
+sudo kvn-tui clean --polkit
 ```
 
-The setup command does not provide an uninstall action. Do not remove yourself
-from `network` without checking whether NetworkManager or other tools use that
-membership.
+Cleanup preserves the group and membership because the kill switch may still
+use them. Existing membership in the legacy `network` group is also never
+removed automatically; verify that no other software needs it before changing
+it manually.
 
 ## Kill switch setup
 
@@ -82,8 +81,8 @@ membership.
 sudo kvn-tui setup --killswitch
 ```
 
-The command requires `nftables`, adds the invoking user to `network` when
-needed, and installs:
+The command requires `nftables`, adds the invoking user to the dedicated
+`kvn-tui` group when needed, and installs:
 
 | Path | Owner / mode | Purpose |
 |------|--------------|---------|
@@ -92,10 +91,11 @@ needed, and installs:
 | `/etc/systemd/system/kvn-tui-killswitch.service` | `root`, `0644` | System kill-switch unit |
 | `/etc/sudoers.d/kvn-tui-killswitch` | `root:root`, `0440` | Restricted NOPASSWD rule |
 
-The sudoers rule permits members of `network` to invoke only the fixed helper
+The sudoers rule permits members of `kvn-tui` to invoke only the fixed helper
 path without a password. The root-owned helper rejects unknown operations and
 accepts only:
 
+- `check` (read-only authorization/installation probe)
 - `enable`
 - `disable`
 - `revoke`
@@ -115,18 +115,24 @@ Toggling the kill switch with `K` runs `systemctl enable --now` or
 
 ### Remove the kill switch
 
-Stop the unit before deleting any files:
+Use the cleanup command, which stops the active unit before deleting any files:
 
 ```bash
-sudo systemctl disable --now kvn-tui-killswitch.service
-sudo rm /etc/kvn-tui/killswitch.nft
-sudo rm /usr/lib/kvn-tui/killswitch-helper.sh
-sudo rm /etc/systemd/system/kvn-tui-killswitch.service
-sudo rm /etc/sudoers.d/kvn-tui-killswitch
-sudo systemctl daemon-reload
+sudo kvn-tui clean --killswitch
 ```
 
-These commands leave the shared `network` group membership unchanged.
+If the active unit cannot be stopped, cleanup aborts before removing its files.
+The command leaves the `kvn-tui` group and membership unchanged and asks you to
+restart the user daemon so persisted state is reconciled.
+
+After removing both polkit and kill-switch integration, the now-unused group can
+optionally be removed after confirming its membership:
+
+```bash
+getent group kvn-tui
+sudo gpasswd -d "$USER" kvn-tui
+sudo groupdel kvn-tui
+```
 
 ## Omarchy setup
 

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -5003,6 +5003,24 @@ mod tests {
     }
 
     #[test]
+    fn profile_tests_report_when_connectivity_probe_is_disabled() {
+        let mut model = model_with_profiles(sample_profiles());
+        model.config.settings.connectivity_probe.enabled = false;
+
+        for code in [KeyCode::Char('t'), KeyCode::Char('T')] {
+            let effects = update(
+                &mut model,
+                Msg::Key(KeyEvent::new(code, crossterm::event::KeyModifiers::NONE)),
+            );
+            assert!(model.pending_tests.is_empty());
+            assert!(effects.iter().any(|effect| matches!(
+                effect,
+                Effect::AppendAppLog { message, .. } if message.contains("latency testing is disabled")
+            )));
+        }
+    }
+
+    #[test]
     fn t_key_does_not_duplicate_already_queued_profile() {
         let profiles = sample_profiles();
         let id = profiles[0].id;

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -1009,6 +1009,16 @@ fn handle_clipboard_text(model: &mut Model, text: &str) -> Vec<Effect> {
 }
 
 fn add_and_fetch_subscription(model: &mut Model, url: &str) -> Vec<Effect> {
+    if let Err(error) = crate::config::subscription::validate_subscription_url(url) {
+        let mut effects = Vec::new();
+        push_status(
+            &mut effects,
+            model,
+            crate::app::model::AppStatus::Error(error.to_string()),
+        );
+        return effects;
+    }
+
     let name = derive_subscription_name(url);
     let id = Uuid::new_v4();
     let sub = Subscription {
@@ -3695,7 +3705,7 @@ mod tests {
     #[test]
     fn paste_subscription_url_creates_subscription_and_fetches() {
         let mut model = model_with_profiles(vec![]);
-        let url = "http://31.58.134.29:2096/sub/xrkjeq2mhwes0i8f";
+        let url = "https://192.0.2.10:2096/sub/test-token";
 
         let effects = handle_clipboard_text(&mut model, url);
 
@@ -3718,8 +3728,24 @@ mod tests {
                 Effect::UpdateSubscription {
                     id: model.config.subscriptions[0].id
                 },
-                app_log_info("Added subscription '31.58.134.29' and fetching profiles…")
+                app_log_info("Added subscription '192.0.2.10' and fetching profiles…")
             ]
+        );
+    }
+
+    #[test]
+    fn paste_http_subscription_is_rejected_before_save() {
+        let mut model = model_with_profiles(vec![]);
+
+        let effects = handle_clipboard_text(&mut model, "http://example.com/secret-token");
+
+        assert!(model.config.subscriptions.is_empty());
+        assert!(!model.subscription_fetching);
+        assert_eq!(
+            effects,
+            vec![app_log_error(
+                "Insecure HTTP subscriptions are blocked; use HTTPS"
+            )]
         );
     }
 

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -1009,7 +1009,10 @@ fn handle_clipboard_text(model: &mut Model, text: &str) -> Vec<Effect> {
 }
 
 fn add_and_fetch_subscription(model: &mut Model, url: &str) -> Vec<Effect> {
-    if let Err(error) = crate::config::subscription::validate_subscription_url(url) {
+    if let Err(error) = crate::config::subscription::validate_subscription_url(
+        url,
+        model.config.settings.allow_insecure_http_subscriptions,
+    ) {
         let mut effects = Vec::new();
         push_status(
             &mut effects,
@@ -3734,7 +3737,24 @@ mod tests {
     }
 
     #[test]
-    fn paste_http_subscription_is_rejected_before_save() {
+    fn paste_http_subscription_is_allowed_with_compatibility_flag() {
+        let mut model = model_with_profiles(vec![]);
+        model.config.settings.allow_insecure_http_subscriptions = true;
+
+        let effects = handle_clipboard_text(&mut model, "http://example.com/secret-token");
+
+        assert_eq!(model.config.subscriptions.len(), 1);
+        assert!(model.subscription_fetching);
+        assert!(effects.contains(&Effect::SaveConfig));
+        assert!(effects.iter().any(|effect| matches!(
+            effect,
+            Effect::UpdateSubscription { id }
+                if *id == model.config.subscriptions[0].id
+        )));
+    }
+
+    #[test]
+    fn paste_http_subscription_is_rejected_for_new_users() {
         let mut model = model_with_profiles(vec![]);
 
         let effects = handle_clipboard_text(&mut model, "http://example.com/secret-token");

--- a/src/app/update/key.rs
+++ b/src/app/update/key.rs
@@ -219,6 +219,16 @@ pub(super) fn handle_sources(model: &mut Model, key: KeyEvent) -> Vec<Effect> {
                 Some(model.config.settings.geo_routing.service_routes.clone());
         }
         KeyCode::Char('t') => {
+            if !model.config.settings.connectivity_probe.enabled {
+                push_status(
+                    &mut effects,
+                    model,
+                    crate::app::model::AppStatus::Info(
+                        "Profile latency testing is disabled in profiles.json".into(),
+                    ),
+                );
+                return effects;
+            }
             if let Some(p) = model.selected_profile() {
                 let id = p.id;
                 if !model.testing_profiles.contains(&id) && !model.pending_tests.contains(&id) {
@@ -227,6 +237,16 @@ pub(super) fn handle_sources(model: &mut Model, key: KeyEvent) -> Vec<Effect> {
             }
         }
         KeyCode::Char('T') => {
+            if !model.config.settings.connectivity_probe.enabled {
+                push_status(
+                    &mut effects,
+                    model,
+                    crate::app::model::AppStatus::Info(
+                        "Profile latency testing is disabled in profiles.json".into(),
+                    ),
+                );
+                return effects;
+            }
             for p in &model.config.profiles {
                 if !model.testing_profiles.contains(&p.id) && !model.pending_tests.contains(&p.id) {
                     model.pending_tests.push_back(p.id);

--- a/src/atomic_write.rs
+++ b/src/atomic_write.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::io::Write;
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -22,12 +22,16 @@ pub fn write(dest: &Path, data: &[u8]) -> Result<()> {
     let temp = dir.join(format!("{}.tmp", name.to_string_lossy()));
 
     {
-        let mut file = fs::File::create(&temp)
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&temp)
             .with_context(|| format!("Failed to create temp file {:?}", temp))?;
-        // 0600 on the temp file so the rename preserves owner-only access on
-        // the destination — `profiles.json` carries credentials (VLESS UUIDs,
-        // Trojan/SS passwords, REALITY public keys) that must not be readable
-        // by other local users.
+        // `mode` applies at creation time, avoiding a window where a new
+        // secret-bearing file has umask-derived permissions. chmod as well so
+        // a pre-existing temp file from an interrupted write is tightened.
         file.set_permissions(fs::Permissions::from_mode(0o600))
             .with_context(|| format!("Failed to chmod temp file {:?}", temp))?;
         file.write_all(data)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -688,6 +688,17 @@ esac
     }
 
     #[test]
+    fn cleanup_scripts_remove_group_only_after_both_integrations_are_gone() {
+        let polkit = include_str!("../contrib/clean-polkit.sh");
+        assert!(polkit.contains("/etc/sudoers.d/kvn-tui-killswitch"));
+        assert!(polkit.contains("groupdel \"$GROUP_NAME\""));
+
+        let killswitch = include_str!("../contrib/clean-killswitch.sh");
+        assert!(killswitch.contains("/etc/polkit-1/rules.d/49-kvn-tui.rules"));
+        assert!(killswitch.contains("groupdel \"$GROUP_NAME\""));
+    }
+
+    #[test]
     fn polkit_rule_is_narrow_and_uses_dedicated_group() {
         let script = include_str!("../contrib/setup-polkit.sh");
         for action in [

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,74 +81,90 @@ enum Command {
         ArgGroup::new("targets")
             .required(true)
             .multiple(true)
-            .args(["omarchy"])
+            .args(["omarchy", "polkit", "killswitch"])
     ))]
     Clean {
         /// Remove backup files created by `setup --omarchy`.
-        #[arg(long)]
+        #[arg(long, conflicts_with_all = ["polkit", "killswitch"])]
         omarchy: bool,
+
+        /// Remove the optional passwordless DNS polkit rule.
+        #[arg(long)]
+        polkit: bool,
+
+        /// Disable and remove the nftables-based kill switch.
+        #[arg(long)]
+        killswitch: bool,
     },
+}
+
+/// Run a trusted, compile-time embedded shell script without materializing it
+/// in a predictable temporary file. `bash -c` preserves the caller's stdin,
+/// which the interactive Omarchy installer needs for its prompts.
+fn run_embedded_script(name: &str, script: &str, args: &[&str]) -> Result<()> {
+    let status = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(script)
+        .arg(name)
+        .args(args)
+        .status()
+        .with_context(|| format!("failed to run {name}"))?;
+    if !status.success() {
+        anyhow::bail!("{name} exited with status {status}");
+    }
+    Ok(())
 }
 
 /// Run the embedded Omarchy integration installer script.
 fn install_omarchy() -> Result<()> {
-    let script = include_str!("../contrib/setup-omarchy.sh");
-    let tmp = std::env::temp_dir().join("kvn-tui-setup-omarchy.sh");
-    std::fs::write(&tmp, script)?;
-    let status = std::process::Command::new("bash").arg(&tmp).status()?;
-    std::fs::remove_file(&tmp).ok();
-    if !status.success() {
-        anyhow::bail!("setup-omarchy.sh exited with status {}", status);
-    }
-    Ok(())
+    run_embedded_script(
+        "setup-omarchy.sh",
+        include_str!("../contrib/setup-omarchy.sh"),
+        &[],
+    )
 }
 
 /// Run the embedded Omarchy integration cleanup script.
 fn clean_omarchy() -> Result<()> {
-    let script = include_str!("../contrib/clean-omarchy.sh");
-    let tmp = std::env::temp_dir().join("kvn-tui-clean-omarchy.sh");
-    std::fs::write(&tmp, script)?;
-    let status = std::process::Command::new("bash")
-        .arg(&tmp)
-        .status()
-        .context("failed to run clean-omarchy.sh")?;
-    std::fs::remove_file(&tmp).ok();
-    if !status.success() {
-        anyhow::bail!("clean-omarchy.sh exited with status {}", status);
-    }
-    Ok(())
+    run_embedded_script(
+        "clean-omarchy.sh",
+        include_str!("../contrib/clean-omarchy.sh"),
+        &[],
+    )
 }
 
 /// Run the embedded polkit rule installer script.
 fn install_polkit() -> Result<()> {
-    let script = include_str!("../contrib/setup-polkit.sh");
-    let tmp = std::env::temp_dir().join("kvn-tui-setup-polkit.sh");
-    std::fs::write(&tmp, script)?;
-    let status = std::process::Command::new("bash")
-        .arg(&tmp)
-        .status()
-        .context("failed to run setup-polkit.sh")?;
-    std::fs::remove_file(&tmp).ok();
-    if !status.success() {
-        anyhow::bail!("setup-polkit.sh exited with status {}", status);
-    }
-    Ok(())
+    run_embedded_script(
+        "setup-polkit.sh",
+        include_str!("../contrib/setup-polkit.sh"),
+        &[],
+    )
 }
 
 /// Run the embedded kill switch installer script.
 fn install_killswitch() -> Result<()> {
-    let script = include_str!("../contrib/setup-killswitch.sh");
-    let tmp = std::env::temp_dir().join("kvn-tui-setup-killswitch.sh");
-    std::fs::write(&tmp, script)?;
-    let status = std::process::Command::new("bash")
-        .arg(&tmp)
-        .status()
-        .context("failed to run setup-killswitch.sh")?;
-    std::fs::remove_file(&tmp).ok();
-    if !status.success() {
-        anyhow::bail!("setup-killswitch.sh exited with status {}", status);
-    }
-    Ok(())
+    run_embedded_script(
+        "setup-killswitch.sh",
+        include_str!("../contrib/setup-killswitch.sh"),
+        &[include_str!("../contrib/killswitch-helper.sh")],
+    )
+}
+
+fn clean_polkit() -> Result<()> {
+    run_embedded_script(
+        "clean-polkit.sh",
+        include_str!("../contrib/clean-polkit.sh"),
+        &[],
+    )
+}
+
+fn clean_killswitch() -> Result<()> {
+    run_embedded_script(
+        "clean-killswitch.sh",
+        include_str!("../contrib/clean-killswitch.sh"),
+        &[],
+    )
 }
 
 // ---- one-shot IPC clients (CLI + Omarchy bar module backends) ----
@@ -367,10 +383,22 @@ pub fn try_run_from_parsed(cli: &Cli) -> Option<Result<()>> {
             })();
             return Some(result);
         }
-        Some(Command::Clean { omarchy }) => {
+        Some(Command::Clean {
+            omarchy,
+            polkit,
+            killswitch,
+        }) => {
             let result = (|| {
                 if *omarchy {
                     clean_omarchy()?;
+                }
+                // Stop and remove the firewall before removing the shared
+                // group's remaining polkit authorization.
+                if *killswitch {
+                    clean_killswitch()?;
+                }
+                if *polkit {
+                    clean_polkit()?;
                 }
                 Ok(())
             })();
@@ -600,13 +628,168 @@ esac
         let cli = Cli::parse_from(["kvn-tui", "clean", "--omarchy"]);
         assert!(matches!(
             cli.command,
-            Some(Command::Clean { omarchy: true })
+            Some(Command::Clean {
+                omarchy: true,
+                polkit: false,
+                killswitch: false,
+            })
         ));
+    }
+
+    #[test]
+    fn clean_system_options_can_be_combined() {
+        let cli = Cli::parse_from(["kvn-tui", "clean", "--polkit", "--killswitch"]);
+        assert!(matches!(
+            cli.command,
+            Some(Command::Clean {
+                omarchy: false,
+                polkit: true,
+                killswitch: true,
+            })
+        ));
+    }
+
+    #[test]
+    fn clean_omarchy_conflicts_with_system_cleanup() {
+        assert!(Cli::try_parse_from(["kvn-tui", "clean", "--omarchy", "--polkit"]).is_err());
+        assert!(Cli::try_parse_from(["kvn-tui", "clean", "--omarchy", "--killswitch"]).is_err());
     }
 
     #[test]
     fn clean_requires_at_least_one_option() {
         assert!(Cli::try_parse_from(["kvn-tui", "clean"]).is_err());
+    }
+
+    #[test]
+    fn embedded_system_scripts_have_valid_bash_syntax() {
+        let _lock = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        for (name, script) in [
+            ("setup-polkit", include_str!("../contrib/setup-polkit.sh")),
+            (
+                "setup-killswitch",
+                include_str!("../contrib/setup-killswitch.sh"),
+            ),
+            ("clean-polkit", include_str!("../contrib/clean-polkit.sh")),
+            (
+                "clean-killswitch",
+                include_str!("../contrib/clean-killswitch.sh"),
+            ),
+            (
+                "killswitch-helper",
+                include_str!("../contrib/killswitch-helper.sh"),
+            ),
+        ] {
+            let status = ProcessCommand::new("bash")
+                .args(["-n", "-c", script])
+                .status()
+                .unwrap();
+            assert!(status.success(), "invalid bash syntax in {name}");
+        }
+    }
+
+    #[test]
+    fn polkit_rule_is_narrow_and_uses_dedicated_group() {
+        let script = include_str!("../contrib/setup-polkit.sh");
+        for action in [
+            "org.freedesktop.resolve1.set-dns-servers",
+            "org.freedesktop.resolve1.set-domains",
+            "org.freedesktop.resolve1.set-default-route",
+        ] {
+            assert!(script.contains(action));
+        }
+        assert!(script.contains("subject.isInGroup(\"kvn-tui\")"));
+        assert!(!script.contains("org.freedesktop.NetworkManager"));
+        assert!(!script.contains("subject.isInGroup(\"network\")"));
+    }
+
+    #[test]
+    fn killswitch_sudoers_uses_dedicated_group() {
+        let script = include_str!("../contrib/setup-killswitch.sh");
+        assert!(script.contains("%kvn-tui ALL=(root) NOPASSWD:"));
+        assert!(!script.contains("%network ALL=(root) NOPASSWD:"));
+    }
+
+    fn helper_accepts_allow_args(args: &[&str]) -> bool {
+        let _lock = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        ProcessCommand::new("bash")
+            .args([
+                "-c",
+                "source \"$1\"; shift; validate_allow_args \"$@\"",
+                "helper-test",
+                concat!(env!("CARGO_MANIFEST_DIR"), "/contrib/killswitch-helper.sh"),
+            ])
+            .args(args)
+            .status()
+            .unwrap()
+            .success()
+    }
+
+    fn helper_accepts_command_args(args: &[&str]) -> bool {
+        let _lock = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        ProcessCommand::new("bash")
+            .args([
+                "-c",
+                "source \"$1\"; shift; validate_command_args \"$@\"",
+                "helper-test",
+                concat!(env!("CARGO_MANIFEST_DIR"), "/contrib/killswitch-helper.sh"),
+            ])
+            .args(args)
+            .status()
+            .unwrap()
+            .success()
+    }
+
+    #[test]
+    fn killswitch_helper_enforces_the_command_surface() {
+        for args in [
+            &["check"][..],
+            &["enable"][..],
+            &["disable"][..],
+            &["revoke"][..],
+            &["allow", "192.0.2.1", "tcp", "443"][..],
+        ] {
+            assert!(helper_accepts_command_args(args), "rejected {args:?}");
+        }
+        for args in [
+            &[][..],
+            &["unknown"][..],
+            &["check", "extra"][..],
+            &["enable", "extra"][..],
+            &["disable", "extra"][..],
+            &["revoke", "extra"][..],
+            &["allow", "192.0.2.1", "tcp", "443", "extra"][..],
+        ] {
+            assert!(!helper_accepts_command_args(args), "accepted {args:?}");
+        }
+    }
+
+    #[test]
+    fn killswitch_helper_validates_allow_arguments() {
+        for args in [
+            &["192.0.2.1", "tcp", "443"][..],
+            &["255.255.255.255", "udp", "65535"][..],
+            &["2001:db8::1", "tcp", "1"][..],
+            &["::1", "udp", "53"][..],
+        ] {
+            assert!(helper_accepts_allow_args(args), "rejected {args:?}");
+        }
+
+        for args in [
+            &[][..],
+            &["192.0.2.1", "tcp"][..],
+            &["192.0.2.1", "tcp", "443", "extra"][..],
+            &["256.1.1.1", "tcp", "443"][..],
+            &["::::", "tcp", "443"][..],
+            &["example.com", "tcp", "443"][..],
+            &["192.0.2.1;id", "tcp", "443"][..],
+            &["192.0.2.1", "sctp", "443"][..],
+            &["192.0.2.1", "tcp", "0"][..],
+            &["192.0.2.1", "tcp", "65536"][..],
+            &["192.0.2.1", "tcp", "$(id)"][..],
+            &["192.0.2.1\n127.0.0.1", "tcp", "443"][..],
+        ] {
+            assert!(!helper_accepts_allow_args(args), "accepted {args:?}");
+        }
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -186,7 +186,7 @@ mod tests {
             loaded.settings.geo_routing.auto_update,
             profile::GeoAutoUpdate::Every1d
         );
-        assert!(persisted.contains("\"schema_version\": 4"));
+        assert!(persisted.contains("\"schema_version\": 5"));
         assert!(persisted.contains("\"auto_update\": \"every1d\""));
         assert!(!persisted.contains("every1h"));
         assert!(!persisted.contains("every_12h"));

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -1355,6 +1355,25 @@ impl Default for LogsConfig {
     }
 }
 
+/// Endpoint used only by manual profile latency tests (`t` / `T`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ConnectivityProbeConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub url: Option<String>,
+}
+
+impl Default for ConnectivityProbeConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            url: Some("https://connectivitycheck.gstatic.com/generate_204".to_string()),
+        }
+    }
+}
+
 /// Application settings stored alongside profiles.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -1395,6 +1414,8 @@ pub struct Settings {
     /// does not make the provider see a new device.
     #[serde(default)]
     pub hwid: String,
+    #[serde(default)]
+    pub connectivity_probe: ConnectivityProbeConfig,
 }
 
 /// Accept `address` if it parses as a bare IPv4/IPv6 literal or as a hostname.
@@ -1424,6 +1445,35 @@ fn default_dns_strategy() -> DnsStrategy {
 /// switch to `"omarchy"` via the in-TUI picker to auto-follow the system.
 pub fn default_theme() -> String {
     "tokyo-night".to_string()
+}
+
+/// Parse and validate the endpoint used by manual latency tests.
+pub fn parse_connectivity_probe_url(input: &str) -> anyhow::Result<url::Url> {
+    const MAX_PROBE_URL_LEN: usize = 2_048;
+
+    anyhow::ensure!(
+        input.len() <= MAX_PROBE_URL_LEN,
+        "settings.connectivity_probe.url exceeds {MAX_PROBE_URL_LEN} bytes"
+    );
+    let url = url::Url::parse(input)
+        .map_err(|_| anyhow::anyhow!("settings.connectivity_probe.url is not a valid URL"))?;
+    anyhow::ensure!(
+        matches!(url.scheme(), "http" | "https"),
+        "settings.connectivity_probe.url must use HTTP or HTTPS"
+    );
+    anyhow::ensure!(
+        url.host_str().is_some(),
+        "settings.connectivity_probe.url must include a host"
+    );
+    anyhow::ensure!(
+        url.username().is_empty() && url.password().is_none(),
+        "settings.connectivity_probe.url must not contain credentials"
+    );
+    anyhow::ensure!(
+        url.fragment().is_none(),
+        "settings.connectivity_probe.url must not contain a fragment"
+    );
+    Ok(url)
 }
 
 pub fn default_log_level() -> String {
@@ -1529,6 +1579,15 @@ impl Settings {
             anyhow::bail!("settings.logs.line_retention.singbox must be at least {MIN_LOG_LINES}");
         }
 
+        if self.connectivity_probe.enabled {
+            let url = self.connectivity_probe.url.as_deref().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "settings.connectivity_probe.url is required when connectivity probing is enabled"
+                )
+            })?;
+            parse_connectivity_probe_url(url)?;
+        }
+
         Ok(())
     }
 }
@@ -1548,13 +1607,14 @@ impl Default for Settings {
             logs: LogsConfig::default(),
             legacy_log_level: None,
             hwid: String::new(),
+            connectivity_probe: ConnectivityProbeConfig::default(),
         }
     }
 }
 
 /// Current schema version for `profiles.json`. Bumped on every breaking
 /// change to the persisted shape; new migrations go in `Config::migrate`.
-pub const CURRENT_SCHEMA_VERSION: u32 = 4;
+pub const CURRENT_SCHEMA_VERSION: u32 = 5;
 
 fn default_schema_version() -> u32 {
     // Files written before the version was introduced are treated as v0
@@ -1676,6 +1736,10 @@ impl Config {
             self.migrate_v3_to_v4();
             self.schema_version = 4;
         }
+        if self.schema_version == 4 {
+            self.migrate_v4_to_v5();
+            self.schema_version = 5;
+        }
         debug_assert_eq!(self.schema_version, CURRENT_SCHEMA_VERSION);
         Ok(())
     }
@@ -1733,6 +1797,12 @@ impl Config {
         if let Some(level) = self.settings.legacy_log_level.take() {
             self.settings.logs.level = level;
         }
+    }
+
+    /// v4 → v5: preserve the historical always-on latency probe while moving
+    /// its endpoint into an explicit nested configuration object.
+    fn migrate_v4_to_v5(&mut self) {
+        self.settings.connectivity_probe = ConnectivityProbeConfig::default();
     }
 }
 
@@ -2578,6 +2648,71 @@ mod tests {
     #[test]
     fn settings_validate_default_ok() {
         Settings::default().validate().unwrap();
+    }
+
+    #[test]
+    fn connectivity_probe_defaults_to_https_and_missing_field_is_backward_compatible() {
+        let default = Settings::default();
+        assert!(default.connectivity_probe.enabled);
+        assert_eq!(
+            default.connectivity_probe.url.as_deref(),
+            Some("https://connectivitycheck.gstatic.com/generate_204")
+        );
+
+        let restored: Settings = serde_json::from_str("{}").unwrap();
+        assert_eq!(restored.connectivity_probe, default.connectivity_probe);
+    }
+
+    #[test]
+    fn connectivity_probe_disabled_preserves_url_without_validating_it() {
+        let settings: Settings =
+            serde_json::from_str(r#"{"connectivity_probe":{"enabled":false,"url":"not a URL"}}"#)
+                .unwrap();
+        assert!(!settings.connectivity_probe.enabled);
+        assert_eq!(
+            settings.connectivity_probe.url.as_deref(),
+            Some("not a URL")
+        );
+        settings.validate().unwrap();
+        assert!(
+            serde_json::to_string(&settings)
+                .unwrap()
+                .contains("\"connectivity_probe\":{\"enabled\":false,\"url\":\"not a URL\"}")
+        );
+    }
+
+    #[test]
+    fn connectivity_probe_enabled_requires_url() {
+        let settings: Settings =
+            serde_json::from_str(r#"{"connectivity_probe":{"enabled":true}}"#).unwrap();
+        let error = settings.validate().unwrap_err().to_string();
+        assert!(error.contains("url is required"), "got: {error}");
+    }
+
+    #[test]
+    fn connectivity_probe_validation_accepts_http_and_https() {
+        for endpoint in [
+            "https://example.com/generate_204?source=kvn",
+            "http://127.0.0.1:8080/health",
+            "https://[2001:db8::1]/",
+        ] {
+            parse_connectivity_probe_url(endpoint).unwrap();
+        }
+    }
+
+    #[test]
+    fn connectivity_probe_validation_rejects_unsafe_or_unsupported_urls() {
+        for endpoint in [
+            "ftp://example.com/file",
+            "https://user:password@example.com/",
+            "https://example.com/#fragment",
+            "not a URL",
+        ] {
+            assert!(
+                parse_connectivity_probe_url(endpoint).is_err(),
+                "accepted {endpoint}"
+            );
+        }
     }
 
     #[test]
@@ -3754,6 +3889,27 @@ mod tests {
         assert!(cfg.settings.legacy_log_level.is_none());
         let json = serde_json::to_string(&cfg).unwrap();
         assert!(!json.contains("log_level"));
+    }
+
+    #[test]
+    fn migrate_v4_to_v5_enables_default_connectivity_probe() {
+        let mut cfg = Config {
+            schema_version: 4,
+            ..Config::default()
+        };
+        cfg.settings.connectivity_probe = ConnectivityProbeConfig {
+            enabled: false,
+            url: None,
+        };
+
+        cfg.migrate().unwrap();
+
+        assert_eq!(cfg.schema_version, CURRENT_SCHEMA_VERSION);
+        assert!(cfg.settings.connectivity_probe.enabled);
+        assert_eq!(
+            cfg.settings.connectivity_probe.url.as_deref(),
+            Some("https://connectivitycheck.gstatic.com/generate_204")
+        );
     }
 
     #[test]

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -1415,6 +1415,8 @@ pub struct Settings {
     #[serde(default)]
     pub hwid: String,
     #[serde(default)]
+    pub allow_insecure_http_subscriptions: bool,
+    #[serde(default)]
     pub connectivity_probe: ConnectivityProbeConfig,
 }
 
@@ -1607,6 +1609,7 @@ impl Default for Settings {
             logs: LogsConfig::default(),
             legacy_log_level: None,
             hwid: String::new(),
+            allow_insecure_http_subscriptions: false,
             connectivity_probe: ConnectivityProbeConfig::default(),
         }
     }
@@ -1799,10 +1802,11 @@ impl Config {
         }
     }
 
-    /// v4 → v5: preserve the historical always-on latency probe while moving
-    /// its endpoint into an explicit nested configuration object.
+    /// v4 → v5: preserve the historical always-on latency probe and HTTP
+    /// subscription support while making both behaviors configurable.
     fn migrate_v4_to_v5(&mut self) {
         self.settings.connectivity_probe = ConnectivityProbeConfig::default();
+        self.settings.allow_insecure_http_subscriptions = true;
     }
 }
 
@@ -2661,6 +2665,15 @@ mod tests {
 
         let restored: Settings = serde_json::from_str("{}").unwrap();
         assert_eq!(restored.connectivity_probe, default.connectivity_probe);
+    }
+
+    #[test]
+    fn new_settings_disable_http_subscriptions_by_default() {
+        let default = Settings::default();
+        let restored: Settings = serde_json::from_str("{}").unwrap();
+
+        assert!(!default.allow_insecure_http_subscriptions);
+        assert!(!restored.allow_insecure_http_subscriptions);
     }
 
     #[test]
@@ -3901,6 +3914,7 @@ mod tests {
             enabled: false,
             url: None,
         };
+        cfg.settings.allow_insecure_http_subscriptions = false;
 
         cfg.migrate().unwrap();
 
@@ -3910,6 +3924,7 @@ mod tests {
             cfg.settings.connectivity_probe.url.as_deref(),
             Some("https://connectivitycheck.gstatic.com/generate_204")
         );
+        assert!(cfg.settings.allow_insecure_http_subscriptions);
     }
 
     #[test]
@@ -3925,6 +3940,7 @@ mod tests {
         cfg.migrate().unwrap();
         assert_eq!(cfg.schema_version, CURRENT_SCHEMA_VERSION);
         assert_eq!(cfg.settings.dns.strategy, DnsStrategy::OnlyIpv6);
+        assert!(cfg.settings.allow_insecure_http_subscriptions);
         let vc = vless_cfg(&cfg.profiles[0]);
         assert_eq!(vc.tls.utls_fingerprint.as_deref(), Some("chrome"));
     }

--- a/src/config/subscription.rs
+++ b/src/config/subscription.rs
@@ -21,15 +21,42 @@ fn ensure_subscription_size(bytes: usize, kind: &str) -> Result<()> {
     Ok(())
 }
 
-/// Validate that a subscription URL uses encrypted transport.
-pub fn validate_subscription_url(input: &str) -> Result<()> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SubscriptionUrlTransport {
+    Https,
+    DeprecatedHttp,
+}
+
+/// Validate a subscription URL against the configured transport policy.
+pub(crate) fn validate_subscription_url(
+    input: &str,
+    allow_insecure_http: bool,
+) -> Result<SubscriptionUrlTransport> {
     let url = url::Url::parse(input).map_err(|_| anyhow::anyhow!("Invalid subscription URL"))?;
     match url.scheme() {
-        "https" if url.host_str().is_some() => Ok(()),
-        "https" => anyhow::bail!("Invalid subscription URL: missing host"),
-        "http" => anyhow::bail!("Insecure HTTP subscriptions are blocked; use HTTPS"),
+        "https" if url.host_str().is_some() => Ok(SubscriptionUrlTransport::Https),
+        "http" if url.host_str().is_some() && allow_insecure_http => {
+            Ok(SubscriptionUrlTransport::DeprecatedHttp)
+        }
+        "http" if url.host_str().is_some() => {
+            anyhow::bail!("Insecure HTTP subscriptions are blocked; use HTTPS")
+        }
+        "https" | "http" => anyhow::bail!("Invalid subscription URL: missing host"),
         scheme => anyhow::bail!("Unsupported subscription URL scheme: {scheme}"),
     }
+}
+
+pub(crate) fn deprecated_http_warning(sub: &Subscription, settings: &Settings) -> Option<String> {
+    matches!(
+        validate_subscription_url(&sub.url, settings.allow_insecure_http_subscriptions),
+        Ok(SubscriptionUrlTransport::DeprecatedHttp)
+    )
+    .then(|| {
+        format!(
+            "HTTP subscription '{}' uses deprecated insecure transport; migrate it to HTTPS",
+            sub.name
+        )
+    })
 }
 
 /// Generate a stable installation identifier once: `lnx-` + UUID v4.
@@ -260,7 +287,7 @@ fn fetch_response(
 /// rejection reasons surface directly instead of failing deep inside body
 /// parsing.
 pub fn fetch_subscription(sub: &Subscription, settings: &Settings) -> Result<Vec<Profile>> {
-    validate_subscription_url(&sub.url)?;
+    validate_subscription_url(&sub.url, settings.allow_insecure_http_subscriptions)?;
     fetch_subscription_after_validation(sub, settings)
 }
 
@@ -692,26 +719,60 @@ mod tests {
 
     #[test]
     fn subscription_url_policy_accepts_https() {
-        assert!(validate_subscription_url("https://example.com/sub").is_ok());
+        for allow_http in [false, true] {
+            assert_eq!(
+                validate_subscription_url("https://example.com/sub", allow_http).unwrap(),
+                SubscriptionUrlTransport::Https
+            );
+        }
     }
 
     #[test]
-    fn subscription_url_policy_rejects_http() {
-        let error = validate_subscription_url("http://example.com/sub").unwrap_err();
+    fn subscription_url_policy_allows_http_only_when_configured() {
+        assert_eq!(
+            validate_subscription_url("http://example.com/sub", true).unwrap(),
+            SubscriptionUrlTransport::DeprecatedHttp
+        );
+        let error = validate_subscription_url("http://example.com/sub", false).unwrap_err();
         assert!(error.to_string().contains("HTTP subscriptions are blocked"));
     }
 
     #[test]
     fn fetch_rejects_http_before_request() {
         let sub = sub_with("http://example.invalid/secret-token".into(), false, None);
-        let error = fetch_subscription(&sub, &settings_with_hwid()).unwrap_err();
+        let mut settings = settings_with_hwid();
+        settings.allow_insecure_http_subscriptions = false;
+        let error = fetch_subscription(&sub, &settings).unwrap_err();
         assert!(error.to_string().contains("HTTP subscriptions are blocked"));
     }
 
     #[test]
+    fn deprecated_http_warning_omits_subscription_url() {
+        let sub = sub_with("http://example.com/secret-token".into(), false, None);
+        let mut settings = settings_with_hwid();
+        settings.allow_insecure_http_subscriptions = true;
+
+        let warning = deprecated_http_warning(&sub, &settings).unwrap();
+
+        assert!(warning.contains(&sub.name));
+        assert!(warning.contains("deprecated"));
+        assert!(!warning.contains(&sub.url));
+        assert!(
+            deprecated_http_warning(
+                &sub,
+                &Settings {
+                    allow_insecure_http_subscriptions: false,
+                    ..settings.clone()
+                }
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
     fn subscription_url_policy_rejects_unsupported_and_invalid_urls() {
-        assert!(validate_subscription_url("ftp://example.com/sub").is_err());
-        assert!(validate_subscription_url("not a URL").is_err());
+        assert!(validate_subscription_url("ftp://example.com/sub", true).is_err());
+        assert!(validate_subscription_url("not a URL", true).is_err());
     }
 
     #[test]
@@ -996,7 +1057,9 @@ mod tests {
         let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
         let (url, rx) = spawn_http_server("HTTP/1.1 200 OK", &[], sample_vless());
         let sub = sub_with(url, false, None);
-        fetch_subscription_after_validation(&sub, &settings_with_hwid()).unwrap();
+        let mut settings = settings_with_hwid();
+        settings.allow_insecure_http_subscriptions = true;
+        fetch_subscription(&sub, &settings).unwrap();
         let req = captured_request(rx);
         assert_eq!(
             req.get("user-agent").map(String::as_str),

--- a/src/config/subscription.rs
+++ b/src/config/subscription.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, env, process::Command};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use base64::Engine;
 use uuid::Uuid;
 
@@ -9,6 +9,17 @@ use crate::config::profile::{
 };
 
 const KVN_TUI_USER_AGENT: &str = concat!("kvn-tui/", env!("CARGO_PKG_VERSION"));
+const MAX_SUBSCRIPTION_BYTES: usize = 2 * 1024 * 1024;
+
+fn ensure_subscription_size(bytes: usize, kind: &str) -> Result<()> {
+    if bytes > MAX_SUBSCRIPTION_BYTES {
+        anyhow::bail!(
+            "Subscription {kind} exceeds the {} MiB limit",
+            MAX_SUBSCRIPTION_BYTES / (1024 * 1024)
+        );
+    }
+    Ok(())
+}
 
 /// Validate that a subscription URL uses encrypted transport.
 pub fn validate_subscription_url(input: &str) -> Result<()> {
@@ -221,10 +232,21 @@ fn fetch_response(
         anyhow::bail!("HTTP {} for {}", resp.status(), redacted_url);
     }
 
+    // Read one byte beyond the application limit so an exact-limit body is
+    // accepted while any larger response is rejected deterministically.
     let body = resp
         .into_body()
+        .into_with_config()
+        .limit((MAX_SUBSCRIPTION_BYTES + 1) as u64)
         .read_to_string()
-        .context("Failed to read subscription body")?;
+        .map_err(|error| match error {
+            ureq::Error::BodyExceedsLimit(_) => anyhow::anyhow!(
+                "Subscription response exceeds the {} MiB limit",
+                MAX_SUBSCRIPTION_BYTES / (1024 * 1024)
+            ),
+            error => anyhow::Error::new(error).context("Failed to read subscription body"),
+        })?;
+    ensure_subscription_size(body.len(), "response")?;
     Ok((body, resp_headers))
 }
 
@@ -475,6 +497,7 @@ fn urlencode(s: &str) -> String {
 /// Parse a subscription body that is either Base64-encoded or plain text.
 /// Each non-empty line is interpreted as a share link in any supported scheme.
 pub fn parse_subscription_body(body: &str) -> Result<Vec<Profile>> {
+    ensure_subscription_size(body.len(), "body")?;
     let trimmed = body.trim();
     if trimmed.is_empty() {
         anyhow::bail!("Subscription body is empty");
@@ -484,7 +507,7 @@ pub fn parse_subscription_body(body: &str) -> Result<Vec<Profile>> {
         return Ok(profiles);
     }
 
-    let decoded = try_decode_base64(trimmed);
+    let decoded = try_decode_base64(trimmed)?;
     let text = decoded.as_deref().unwrap_or(trimmed);
 
     let mut profiles = Vec::new();
@@ -509,18 +532,21 @@ pub fn parse_subscription_body(body: &str) -> Result<Vec<Profile>> {
 /// Attempt to Base64-decode `text`. Returns `Some(decoded)` only when decoding
 /// succeeds and the result looks like a subscription (contains at least one
 /// supported scheme prefix). This prevents treating plain text as binary garbage.
-fn try_decode_base64(text: &str) -> Option<String> {
-    let decoded_bytes = base64::engine::general_purpose::STANDARD
-        .decode(text)
-        .ok()?;
-    let decoded = String::from_utf8(decoded_bytes).ok()?;
+fn try_decode_base64(text: &str) -> Result<Option<String>> {
+    let Some(decoded_bytes) = base64::engine::general_purpose::STANDARD.decode(text).ok() else {
+        return Ok(None);
+    };
+    ensure_subscription_size(decoded_bytes.len(), "decoded body")?;
+    let Some(decoded) = String::from_utf8(decoded_bytes).ok() else {
+        return Ok(None);
+    };
     if decoded.lines().any(|line| {
         let l = line.trim();
         line_has_supported_scheme(l)
     }) {
-        Some(decoded)
+        Ok(Some(decoded))
     } else {
-        None
+        Ok(None)
     }
 }
 
@@ -559,6 +585,21 @@ mod tests {
     #[test]
     fn parse_empty_body_fails() {
         assert!(parse_subscription_body("   ").is_err());
+    }
+
+    #[test]
+    fn subscription_size_limit_accepts_boundary_and_rejects_larger_values() {
+        assert!(ensure_subscription_size(MAX_SUBSCRIPTION_BYTES - 1, "body").is_ok());
+        assert!(ensure_subscription_size(MAX_SUBSCRIPTION_BYTES, "body").is_ok());
+        let error = ensure_subscription_size(MAX_SUBSCRIPTION_BYTES + 1, "body").unwrap_err();
+        assert!(error.to_string().contains("2 MiB limit"));
+    }
+
+    #[test]
+    fn oversized_subscription_body_fails_before_parsing() {
+        let body = "x".repeat(MAX_SUBSCRIPTION_BYTES + 1);
+        let error = parse_subscription_body(&body).unwrap_err();
+        assert!(error.to_string().contains("Subscription body exceeds"));
     }
 
     #[test]

--- a/src/config/subscription.rs
+++ b/src/config/subscription.rs
@@ -175,6 +175,7 @@ fn fetch_response(
     url: &str,
     headers: &HashMap<String, String>,
 ) -> Result<(String, HashMap<String, String>)> {
+    let redacted_url = crate::redaction::redact_url_for_log(url);
     let agent = ureq::Agent::config_builder()
         .http_status_as_error(false)
         .build()
@@ -192,7 +193,11 @@ fn fetch_response(
         }
     }
 
-    let resp = req.call().with_context(|| format!("GET {} failed", url))?;
+    // Do not retain ureq's error as a source: its Display output may contain
+    // the complete request URL, including subscription credentials.
+    let resp = req
+        .call()
+        .map_err(|_| anyhow::anyhow!("GET {redacted_url} failed"))?;
 
     let mut resp_headers = HashMap::new();
     for (name, value) in resp.headers() {
@@ -211,9 +216,9 @@ fn fetch_response(
         // Remnawave reports HWID problems on non-200 responses too.
         let hwid_sent = headers.contains_key("X-Hwid");
         if let Some(message) = hwid_response_error(&resp_headers, hwid_sent) {
-            anyhow::bail!("{} (HTTP {} for {})", message, resp.status(), url);
+            anyhow::bail!("{} (HTTP {} for {})", message, resp.status(), redacted_url);
         }
-        anyhow::bail!("HTTP {} for {}", resp.status(), url);
+        anyhow::bail!("HTTP {} for {}", resp.status(), redacted_url);
     }
 
     let body = resp

--- a/src/config/subscription.rs
+++ b/src/config/subscription.rs
@@ -10,6 +10,17 @@ use crate::config::profile::{
 
 const KVN_TUI_USER_AGENT: &str = concat!("kvn-tui/", env!("CARGO_PKG_VERSION"));
 
+/// Validate that a subscription URL uses encrypted transport.
+pub fn validate_subscription_url(input: &str) -> Result<()> {
+    let url = url::Url::parse(input).map_err(|_| anyhow::anyhow!("Invalid subscription URL"))?;
+    match url.scheme() {
+        "https" if url.host_str().is_some() => Ok(()),
+        "https" => anyhow::bail!("Invalid subscription URL: missing host"),
+        "http" => anyhow::bail!("Insecure HTTP subscriptions are blocked; use HTTPS"),
+        scheme => anyhow::bail!("Unsupported subscription URL scheme: {scheme}"),
+    }
+}
+
 /// Generate a stable installation identifier once: `lnx-` + UUID v4.
 /// Never derived from the subscription URL — rotating a token or changing a
 /// domain must not make the provider treat the same installation as a new
@@ -222,6 +233,16 @@ fn fetch_response(
 /// rejection reasons surface directly instead of failing deep inside body
 /// parsing.
 pub fn fetch_subscription(sub: &Subscription, settings: &Settings) -> Result<Vec<Profile>> {
+    validate_subscription_url(&sub.url)?;
+    fetch_subscription_after_validation(sub, settings)
+}
+
+/// Perform the request after the caller has enforced the subscription URL
+/// policy. Request-level tests call this directly to use a local HTTP fixture.
+fn fetch_subscription_after_validation(
+    sub: &Subscription,
+    settings: &Settings,
+) -> Result<Vec<Profile>> {
     let hwid_sent = sub.effective_hwid(settings).is_some();
     let env = DeviceEnv::detect();
     let headers = build_request_headers(sub, settings, &env);
@@ -624,6 +645,30 @@ mod tests {
     }
 
     #[test]
+    fn subscription_url_policy_accepts_https() {
+        assert!(validate_subscription_url("https://example.com/sub").is_ok());
+    }
+
+    #[test]
+    fn subscription_url_policy_rejects_http() {
+        let error = validate_subscription_url("http://example.com/sub").unwrap_err();
+        assert!(error.to_string().contains("HTTP subscriptions are blocked"));
+    }
+
+    #[test]
+    fn fetch_rejects_http_before_request() {
+        let sub = sub_with("http://example.invalid/secret-token".into(), false, None);
+        let error = fetch_subscription(&sub, &settings_with_hwid()).unwrap_err();
+        assert!(error.to_string().contains("HTTP subscriptions are blocked"));
+    }
+
+    #[test]
+    fn subscription_url_policy_rejects_unsupported_and_invalid_urls() {
+        assert!(validate_subscription_url("ftp://example.com/sub").is_err());
+        assert!(validate_subscription_url("not a URL").is_err());
+    }
+
+    #[test]
     fn build_request_headers_send_hwid_false_sends_no_device_headers() {
         let env = DeviceEnv {
             kernel_version: "6.12.0-arch1-1".into(),
@@ -905,7 +950,7 @@ mod tests {
         let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
         let (url, rx) = spawn_http_server("HTTP/1.1 200 OK", &[], sample_vless());
         let sub = sub_with(url, false, None);
-        fetch_subscription(&sub, &settings_with_hwid()).unwrap();
+        fetch_subscription_after_validation(&sub, &settings_with_hwid()).unwrap();
         let req = captured_request(rx);
         assert_eq!(
             req.get("user-agent").map(String::as_str),
@@ -918,7 +963,7 @@ mod tests {
         let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
         let (url, rx) = spawn_http_server("HTTP/1.1 200 OK", &[], sample_vless());
         let sub = sub_with(url, false, Some("provider-registered-device-id"));
-        fetch_subscription(&sub, &settings_with_hwid()).unwrap();
+        fetch_subscription_after_validation(&sub, &settings_with_hwid()).unwrap();
         let req = captured_request(rx);
         assert!(!req.contains_key("x-hwid"));
         assert!(!req.contains_key("x-device-os"));
@@ -930,7 +975,7 @@ mod tests {
         let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
         let (url, rx) = spawn_http_server("HTTP/1.1 200 OK", &[], sample_vless());
         let sub = sub_with(url, true, None);
-        fetch_subscription(&sub, &settings_with_hwid()).unwrap();
+        fetch_subscription_after_validation(&sub, &settings_with_hwid()).unwrap();
         let req = captured_request(rx);
         assert_eq!(
             req.get("x-hwid").map(String::as_str),
@@ -950,7 +995,7 @@ mod tests {
         let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
         let (url, rx) = spawn_http_server("HTTP/1.1 200 OK", &[], sample_vless());
         let sub = sub_with(url, true, Some("provider-registered-device-id"));
-        fetch_subscription(&sub, &settings_with_hwid()).unwrap();
+        fetch_subscription_after_validation(&sub, &settings_with_hwid()).unwrap();
         let req = captured_request(rx);
         assert_eq!(
             req.get("x-hwid").map(String::as_str),
@@ -966,7 +1011,7 @@ mod tests {
         // Subscription A carries a provider-registered HWID override...
         let (url_a, rx_a) = spawn_http_server("HTTP/1.1 200 OK", &[], sample_vless());
         let sub_a = sub_with(url_a, true, Some("provider-registered-device-id"));
-        fetch_subscription(&sub_a, &settings).unwrap();
+        fetch_subscription_after_validation(&sub_a, &settings).unwrap();
         assert_eq!(
             captured_request(rx_a).get("x-hwid").map(String::as_str),
             Some("provider-registered-device-id"),
@@ -976,7 +1021,7 @@ mod tests {
         // never to A's override.
         let (url_b, rx_b) = spawn_http_server("HTTP/1.1 200 OK", &[], sample_vless());
         let sub_b = sub_with(url_b, true, None);
-        fetch_subscription(&sub_b, &settings).unwrap();
+        fetch_subscription_after_validation(&sub_b, &settings).unwrap();
         assert_eq!(
             captured_request(rx_b).get("x-hwid").map(String::as_str),
             Some("lnx-installation-hwid"),
@@ -985,7 +1030,7 @@ mod tests {
         // ...and subscription C (send_hwid: false) sends no HWID at all.
         let (url_c, rx_c) = spawn_http_server("HTTP/1.1 200 OK", &[], sample_vless());
         let sub_c = sub_with(url_c, false, None);
-        fetch_subscription(&sub_c, &settings).unwrap();
+        fetch_subscription_after_validation(&sub_c, &settings).unwrap();
         assert!(!captured_request(rx_c).contains_key("x-hwid"));
     }
 
@@ -998,7 +1043,7 @@ mod tests {
             sample_vless(),
         );
         let sub = sub_with(url, false, None);
-        let err = fetch_subscription(&sub, &settings_with_hwid()).unwrap_err();
+        let err = fetch_subscription_after_validation(&sub, &settings_with_hwid()).unwrap_err();
         assert!(err.to_string().contains("enable 'send HWID'"), "got: {err}");
     }
 
@@ -1011,7 +1056,7 @@ mod tests {
             sample_vless(),
         );
         let sub = sub_with(url, true, None);
-        let err = fetch_subscription(&sub, &settings_with_hwid()).unwrap_err();
+        let err = fetch_subscription_after_validation(&sub, &settings_with_hwid()).unwrap_err();
         assert!(
             err.to_string().contains("device limit reached"),
             "got: {err}"
@@ -1027,7 +1072,7 @@ mod tests {
             "forbidden",
         );
         let sub = sub_with(url, false, None);
-        let err = fetch_subscription(&sub, &settings_with_hwid()).unwrap_err();
+        let err = fetch_subscription_after_validation(&sub, &settings_with_hwid()).unwrap_err();
         assert!(err.to_string().contains("enable 'send HWID'"), "got: {err}");
         assert!(err.to_string().contains("HTTP 403"), "got: {err}");
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -765,7 +765,8 @@ fn write_test_config(
     socks_port: u16,
 ) -> anyhow::Result<std::path::PathBuf> {
     let config = crate::singbox::config::generate_test_config(profile, socks_port)?;
-    let path = crate::paths::temp_test_config_path(&id);
+    crate::paths::ensure_runtime_dir()?;
+    let path = crate::paths::temp_test_config_path(&id)?;
     crate::atomic_write::write(&path, serde_json::to_string(&config)?.as_bytes())?;
     Ok(path)
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -622,6 +622,11 @@ fn execute_daemon_effect(
             if let Some(sub) = model.config.subscriptions.iter().find(|s| s.id == id) {
                 let sub = sub.clone();
                 let settings = model.config.settings.clone();
+                if let Some(message) =
+                    crate::config::subscription::deprecated_http_warning(&sub, &settings)
+                {
+                    crate::services::log_tailer::append_app_log("WARN", &message);
+                }
                 let tx = tx.clone();
                 thread::spawn(move || {
                     let result = crate::config::subscription::fetch_subscription(&sub, &settings)

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -686,13 +686,20 @@ fn execute_daemon_effect(
         }
         Effect::TestProfile { id } => {
             let profile = model.config.profiles.iter().find(|p| p.id == id).cloned();
+            let probe = model.config.settings.connectivity_probe.clone();
             let tx = tx.clone();
             thread::spawn(move || {
-                let latency_ms = profile.and_then(|p| match run_test(&p, id) {
-                    Ok(ms) => Some(ms),
-                    Err(e) => {
-                        tracing::warn!("profile test failed: {e:#}");
-                        None
+                let latency_ms = profile.and_then(|p| {
+                    if !probe.enabled {
+                        return None;
+                    }
+                    let probe_url = probe.url.as_deref()?;
+                    match run_test(&p, id, probe_url) {
+                        Ok(ms) => Some(ms),
+                        Err(e) => {
+                            tracing::warn!("profile test failed: {e:#}");
+                            None
+                        }
                     }
                 });
                 let _ = tx.send(Msg::TestResult { id, latency_ms });
@@ -706,10 +713,16 @@ fn execute_daemon_effect(
 ///
 /// Allocates a free loopback port, writes a minimal SOCKS5-inbound config,
 /// spawns sing-box, waits for the port to open, then performs a SOCKS5
-/// CONNECT to `connectivitycheck.gstatic.com:80` through the proxy and
-/// returns the round-trip latency in milliseconds.
-fn run_test(profile: &crate::config::profile::Profile, id: uuid::Uuid) -> anyhow::Result<u64> {
+/// CONNECT to the configured HTTP(S) endpoint through the proxy and returns
+/// the end-to-end request latency in milliseconds.
+fn run_test(
+    profile: &crate::config::profile::Profile,
+    id: uuid::Uuid,
+    probe_url: &str,
+) -> anyhow::Result<u64> {
     use std::process::{Command, Stdio};
+
+    let probe = crate::config::profile::parse_connectivity_probe_url(probe_url)?;
 
     // Find a free loopback port by binding to :0, recording the OS-assigned
     // port, then dropping the listener so sing-box can bind to it.
@@ -753,8 +766,7 @@ fn run_test(profile: &crate::config::profile::Profile, id: uuid::Uuid) -> anyhow
         anyhow::bail!("sing-box did not open SOCKS5 port within 3 s");
     }
 
-    // Perform SOCKS5 CONNECT to a well-known host and measure latency.
-    let result = socks5_connect_latency(&addr);
+    let result = socks5_connect_latency(&addr, &probe);
     cleanup(&mut child);
     result
 }
@@ -771,18 +783,24 @@ fn write_test_config(
     Ok(path)
 }
 
-/// Tunnel through the SOCKS5 proxy at `addr` to `connectivitycheck.gstatic.com:80`,
-/// send a minimal HTTP GET, and return the time from request-send to first
-/// response byte in milliseconds.
+/// Tunnel through the SOCKS5 proxy at `addr`, send a minimal HTTP(S) GET, and
+/// return the time from request/TLS start to the first response byte.
 ///
 /// sing-box replies to SOCKS5 CONNECT before the outbound tunnel is open, so
 /// measuring CONNECT RTT gives ~0 ms. The HTTP round-trip through the actual
 /// VPN tunnel is the meaningful latency number.
-fn socks5_connect_latency(addr: &str) -> anyhow::Result<u64> {
-    const HOST: &[u8] = b"connectivitycheck.gstatic.com";
-    const HOST_STR: &str = "connectivitycheck.gstatic.com";
-    const PORT: u16 = 80;
-
+fn socks5_connect_latency(addr: &str, probe: &url::Url) -> anyhow::Result<u64> {
+    let host = probe
+        .host_str()
+        .context("connectivity probe URL is missing a host")?;
+    let host_bytes = host.as_bytes();
+    anyhow::ensure!(
+        host_bytes.len() <= u8::MAX as usize,
+        "connectivity probe host is too long"
+    );
+    let port = probe
+        .port_or_known_default()
+        .context("connectivity probe URL has no port")?;
     let mut stream = TcpStream::connect(addr)?;
     stream.set_read_timeout(Some(Duration::from_secs(10)))?;
     stream.set_write_timeout(Some(Duration::from_secs(10)))?;
@@ -794,10 +812,10 @@ fn socks5_connect_latency(addr: &str) -> anyhow::Result<u64> {
     anyhow::ensure!(resp == [0x05, 0x00], "SOCKS5 auth negotiation failed");
 
     // SOCKS5 CONNECT to target host (domain ATYP 0x03).
-    let mut req = vec![0x05, 0x01, 0x00, 0x03, HOST.len() as u8];
-    req.extend_from_slice(HOST);
-    req.push((PORT >> 8) as u8);
-    req.push((PORT & 0xff) as u8);
+    let mut req = vec![0x05, 0x01, 0x00, 0x03, host_bytes.len() as u8];
+    req.extend_from_slice(host_bytes);
+    req.push((port >> 8) as u8);
+    req.push((port & 0xff) as u8);
     stream.write_all(&req)?;
 
     // Read and discard CONNECT reply — sing-box answers before the tunnel is
@@ -823,14 +841,43 @@ fn socks5_connect_latency(addr: &str) -> anyhow::Result<u64> {
         _ => anyhow::bail!("unknown SOCKS5 address type"),
     }
 
-    // Now the tunnel is open. Send an HTTP GET and time the first response byte
-    // — this is the real VPN round-trip latency.
-    let http_req =
-        format!("GET /generate_204 HTTP/1.1\r\nHost: {HOST_STR}\r\nConnection: close\r\n\r\n");
+    let request_target = match probe.query() {
+        Some(query) => format!("{}?{query}", probe.path()),
+        None => probe.path().to_string(),
+    };
+    let host_header = match probe.host().expect("validated probe host") {
+        url::Host::Ipv6(address) => format!("[{address}]"),
+        host => host.to_string(),
+    };
+    let host_header = probe
+        .port()
+        .map_or(host_header.clone(), |port| format!("{host_header}:{port}"));
+    let request = format!(
+        "GET {request_target} HTTP/1.1\r\nHost: {host_header}\r\nConnection: close\r\n\r\n"
+    );
+
+    // sing-box acknowledges SOCKS CONNECT before the outbound connection is
+    // ready. For HTTPS, starting here includes TLS setup in the user-visible
+    // end-to-end latency, matching ordinary web traffic more closely.
     let start = Instant::now();
-    stream.write_all(http_req.as_bytes())?;
     let mut buf = [0u8; 16];
-    stream.read_exact(&mut buf)?;
+    if probe.scheme() == "https" {
+        let roots =
+            rustls::RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+        let config = rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+        let server_name = rustls::pki_types::ServerName::try_from(host.to_owned())
+            .context("invalid connectivity probe TLS server name")?;
+        let connection = rustls::ClientConnection::new(std::sync::Arc::new(config), server_name)
+            .context("failed to initialize connectivity probe TLS")?;
+        let mut tls = rustls::StreamOwned::new(connection, stream);
+        tls.write_all(request.as_bytes())?;
+        tls.read_exact(&mut buf)?;
+    } else {
+        stream.write_all(request.as_bytes())?;
+        stream.read_exact(&mut buf)?;
+    }
     Ok(start.elapsed().as_millis() as u64)
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -718,9 +718,7 @@ fn run_test(profile: &crate::config::profile::Profile, id: uuid::Uuid) -> anyhow
         listener.local_addr()?.port()
     };
 
-    let config = crate::singbox::config::generate_test_config(profile, socks_port)?;
-    let config_path = crate::paths::temp_test_config_path(&id);
-    std::fs::write(&config_path, serde_json::to_string(&config)?)?;
+    let config_path = write_test_config(profile, id, socks_port)?;
 
     let singbox_bin = std::env::var("SING_BOX_PATH").unwrap_or_else(|_| "sing-box".to_string());
     let mut child = Command::new(&singbox_bin)
@@ -759,6 +757,17 @@ fn run_test(profile: &crate::config::profile::Profile, id: uuid::Uuid) -> anyhow
     let result = socks5_connect_latency(&addr);
     cleanup(&mut child);
     result
+}
+
+fn write_test_config(
+    profile: &crate::config::profile::Profile,
+    id: uuid::Uuid,
+    socks_port: u16,
+) -> anyhow::Result<std::path::PathBuf> {
+    let config = crate::singbox::config::generate_test_config(profile, socks_port)?;
+    let path = crate::paths::temp_test_config_path(&id);
+    crate::atomic_write::write(&path, serde_json::to_string(&config)?.as_bytes())?;
+    Ok(path)
 }
 
 /// Tunnel through the SOCKS5 proxy at `addr` to `connectivitycheck.gstatic.com:80`,
@@ -1213,13 +1222,33 @@ fn spawn_signal_handler(tx: Sender<Msg>) -> Result<()> {
 mod tests {
     use super::{
         ProcessSlot, ServiceRefreshResult, finalize_geo_result, handshake_protocols,
-        lock_process_slot, log_prune_due, poll_process_exit,
+        lock_process_slot, log_prune_due, poll_process_exit, write_test_config,
     };
     use crate::app::msg::{GeoResult, Msg};
     use crate::config::profile::Protocol;
     use crate::singbox::process_handle::ProcessHandle;
+    use std::os::unix::fs::PermissionsExt;
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn latency_test_config_is_private() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let runtime = tempfile::tempdir().unwrap();
+        let _runtime = crate::test_helpers::EnvVarGuard::set("XDG_RUNTIME_DIR", runtime.path());
+        let profile = crate::config::profile::Profile::new_vless(
+            "Test".into(),
+            "1.2.3.4".into(),
+            443,
+            "secret-uuid".into(),
+        );
+        let path = write_test_config(&profile, uuid::Uuid::new_v4(), 1080).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
 
     #[test]
     fn log_prune_is_due_initially_and_after_twenty_four_hours() {

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -10,7 +10,11 @@ use anyhow::Result;
 const MIN_SINGBOX_VERSION: (u64, u64, u64) = (1, 12, 0);
 const USER_UNIT: &str = "kvn-tui.service";
 const KILLSWITCH_HELPER: &str = "/usr/lib/kvn-tui/killswitch-helper.sh";
-const POLKIT_DNS_ACTION: &str = "org.freedesktop.resolve1.set-dns-servers";
+const POLKIT_DNS_ACTIONS: [&str; 3] = [
+    "org.freedesktop.resolve1.set-dns-servers",
+    "org.freedesktop.resolve1.set-domains",
+    "org.freedesktop.resolve1.set-default-route",
+];
 const OMAKVN_PLUGIN_ID: &str = "yarikov.omakvn";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -330,10 +334,45 @@ fn check_clipboard() -> Check {
 }
 
 fn check_killswitch() -> Check {
-    if Path::new(KILLSWITCH_HELPER).is_file() {
-        Check::pass("kill switch helper is installed")
-    } else {
-        Check::optional("kill switch is not installed (optional)")
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let path = Path::new(KILLSWITCH_HELPER);
+    if !path.is_file() {
+        return Check::optional("kill switch is not installed (optional)");
+    }
+    let Ok(metadata) = path.metadata() else {
+        return Check::warning(
+            "kill switch helper metadata could not be read",
+            "Reinstall it with `sudo kvn-tui setup --killswitch`.",
+        );
+    };
+    let mode = metadata.permissions().mode() & 0o777;
+    if metadata.uid() != 0 || mode & 0o022 != 0 {
+        return Check::warning(
+            format!(
+                "kill switch helper has unsafe ownership or mode (uid {}, {:03o})",
+                metadata.uid(),
+                mode
+            ),
+            "Reinstall it with `sudo kvn-tui setup --killswitch`.",
+        );
+    }
+
+    match Command::new("sudo")
+        .args(["-n", KILLSWITCH_HELPER, "check"])
+        .output()
+    {
+        Ok(output) if output.status.success() => {
+            Check::pass("kill switch helper and passwordless authorization are active")
+        }
+        Ok(_) => Check::warning(
+            "kill switch helper is installed but passwordless authorization is unavailable",
+            "Run `sudo kvn-tui setup --killswitch`, then log out and back in.",
+        ),
+        Err(_) => Check::warning(
+            "kill switch helper is installed but `sudo` could not be executed",
+            "Install sudo and run `sudo kvn-tui setup --killswitch`.",
+        ),
     }
 }
 
@@ -344,35 +383,40 @@ fn check_polkit() -> Check {
             "Run `kvn-tui doctor` again or inspect polkit with `sudo kvn-tui setup --polkit`.",
         );
     };
-    let output = Command::new("pkcheck")
-        .args(["--action-id", POLKIT_DNS_ACTION, "--process", &identity])
-        .output();
-    let Ok(output) = output else {
-        return Check::warning(
-            "`pkcheck` is unavailable, so polkit authorization could not be checked",
-            "Install the `polkit` package and run `kvn-tui doctor` again.",
-        );
-    };
+    for action in POLKIT_DNS_ACTIONS {
+        let output = Command::new("pkcheck")
+            .args(["--action-id", action, "--process", &identity])
+            .output();
+        let Ok(output) = output else {
+            return Check::warning(
+                "`pkcheck` is unavailable, so polkit authorization could not be checked",
+                "Install the `polkit` package and run `kvn-tui doctor` again.",
+            );
+        };
 
-    match output.status.code() {
-        Some(0) => Check::pass("polkit authorization for DNS changes is active"),
-        // 1 means denied. 2 means authorization would require interaction;
-        // doctor deliberately never opens an authentication prompt.
-        Some(1 | 2) => Check::warning(
-            "passwordless polkit authorization for DNS changes is not active (recommended)",
-            "Run `sudo kvn-tui setup --polkit`.",
-        ),
-        _ => {
-            let error = String::from_utf8_lossy(&output.stderr);
-            Check::warning(
-                format!(
-                    "polkit authorization could not be checked: {}",
-                    error.trim()
-                ),
-                "Verify that polkit is running, then run `kvn-tui doctor` again.",
-            )
+        match output.status.code() {
+            Some(0) => {}
+            // 1 means denied. 2 means authorization would require interaction;
+            // doctor deliberately never opens an authentication prompt.
+            Some(1 | 2) => {
+                return Check::warning(
+                    format!("passwordless polkit authorization is missing for {action}"),
+                    "Run `sudo kvn-tui setup --polkit`, then log out and back in.",
+                );
+            }
+            _ => {
+                let error = String::from_utf8_lossy(&output.stderr);
+                return Check::warning(
+                    format!(
+                        "polkit authorization for {action} could not be checked: {}",
+                        error.trim()
+                    ),
+                    "Verify that polkit is running, then run `kvn-tui doctor` again.",
+                );
+            }
         }
     }
+    Check::pass("all required polkit DNS authorizations are active")
 }
 
 /// Build the non-racy `PID,START_TIME,UID` identity recommended by pkcheck.
@@ -674,7 +718,7 @@ mod tests {
         assert_eq!(check.level, Level::Warning);
         assert_eq!(
             check.remedy.as_deref(),
-            Some("Run `sudo kvn-tui setup --polkit`.")
+            Some("Run `sudo kvn-tui setup --polkit`, then log out and back in.")
         );
         executable(dir.path(), "pkcheck", "echo unavailable >&2; exit 127");
         assert_eq!(check_polkit().level, Level::Warning);

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -275,16 +275,19 @@ fn check_daemon() -> Vec<Check> {
         )),
     }
 
-    if crate::ipc::is_daemon_running() {
-        checks.push(Check::pass(format!(
+    match crate::ipc::socket_path() {
+        Err(error) => checks.push(Check::failure(
+            format!("daemon IPC path is unavailable: {error}"),
+            "Run kvn-tui from a desktop user session with XDG_RUNTIME_DIR set.",
+        )),
+        Ok(path) if crate::ipc::is_daemon_running() => checks.push(Check::pass(format!(
             "daemon IPC socket is reachable: {}",
-            crate::ipc::socket_path().display()
-        )));
-    } else {
-        checks.push(Check::warning(
+            path.display()
+        ))),
+        Ok(_) => checks.push(Check::warning(
             "daemon IPC socket is not reachable",
             "Start it with `systemctl --user start kvn-tui.service`; kvn-tui can also start it on demand.",
-        ));
+        )),
     }
     checks
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -17,26 +17,23 @@ use crate::app::msg::{IpcCommand, Msg, StateSnapshot};
 const BROADCAST_WRITE_TIMEOUT: Duration = Duration::from_millis(200);
 
 /// Return the path to the Unix domain socket used for IPC.
-pub fn socket_path() -> std::path::PathBuf {
-    if let Some(dir) = std::env::var_os("XDG_RUNTIME_DIR") {
-        std::path::PathBuf::from(dir).join("kvn-tui.sock")
-    } else {
-        // getuid is async-signal-safe and has no preconditions; the unsafe is
-        // a libc-binding artefact, not a real invariant.
-        #[allow(unsafe_code)]
-        let uid = unsafe { libc::getuid() };
-        std::path::PathBuf::from("/tmp").join(format!("kvn-tui-{}.sock", uid))
-    }
+pub fn socket_path() -> anyhow::Result<std::path::PathBuf> {
+    let dir = dirs::runtime_dir().ok_or_else(|| {
+        anyhow::anyhow!("XDG_RUNTIME_DIR is not set; kvn-tui requires a desktop user session")
+    })?;
+    Ok(dir.join("kvn-tui.sock"))
 }
 
 /// Remove the socket file.
 pub fn cleanup_socket() {
-    let _ = std::fs::remove_file(socket_path());
+    if let Ok(path) = socket_path() {
+        let _ = std::fs::remove_file(path);
+    }
 }
 
 /// Check whether the daemon socket is accepting connections.
 pub fn is_daemon_running() -> bool {
-    UnixStream::connect(socket_path()).is_ok()
+    socket_path().is_ok_and(|path| UnixStream::connect(path).is_ok())
 }
 
 /// Poll for daemon readiness with exponential backoff (10ms → 320ms cap),
@@ -64,7 +61,7 @@ pub struct IpcServer {
 
 impl IpcServer {
     pub fn bind(tx: Sender<Msg>) -> anyhow::Result<Self> {
-        let path = socket_path();
+        let path = socket_path()?;
         if path.exists() {
             if UnixStream::connect(&path).is_ok() {
                 anyhow::bail!("kvn-tui daemon is already running at {}", path.display());
@@ -73,9 +70,7 @@ impl IpcServer {
                 .with_context(|| format!("Failed to remove stale socket {}", path.display()))?;
         }
         let listener = UnixListener::bind(&path)?;
-        // 0600: any local user knowing the socket path could otherwise send
-        // IpcCommand (Quit / Key / Paste). XDG_RUNTIME_DIR is typically 0700
-        // already, but the /tmp/kvn-tui-<uid>.sock fallback path is not.
+        // Defense in depth on top of the private 0700 runtime directory.
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
             .context("Failed to chmod IPC socket")?;
         let clients: Arc<Mutex<Vec<UnixStream>>> = Arc::new(Mutex::new(Vec::new()));
@@ -166,7 +161,7 @@ pub struct IpcClient {
 
 impl IpcClient {
     pub fn connect() -> anyhow::Result<Self> {
-        let stream = UnixStream::connect(socket_path())?;
+        let stream = UnixStream::connect(socket_path()?)?;
         stream.set_nonblocking(false)?;
         Ok(Self { stream })
     }
@@ -329,7 +324,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let prev = std::env::var_os("XDG_RUNTIME_DIR");
         unsafe { std::env::set_var("XDG_RUNTIME_DIR", tmp.path()) };
-        let p = socket_path();
+        let p = socket_path().unwrap();
         assert!(p.starts_with(tmp.path()));
         assert_eq!(p.file_name().unwrap(), "kvn-tui.sock");
         unsafe {
@@ -341,20 +336,15 @@ mod tests {
     }
 
     #[test]
-    fn socket_path_falls_back_to_tmp_with_uid_when_no_xdg() {
+    fn socket_path_requires_xdg_runtime_dir() {
         let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
-        let prev = std::env::var_os("XDG_RUNTIME_DIR");
-        unsafe { std::env::remove_var("XDG_RUNTIME_DIR") };
-        let p = socket_path();
-        assert!(p.starts_with("/tmp"));
-        let name = p.file_name().unwrap().to_string_lossy();
-        assert!(name.starts_with("kvn-tui-"));
-        assert!(name.ends_with(".sock"));
-        unsafe {
-            if let Some(v) = prev {
-                std::env::set_var("XDG_RUNTIME_DIR", v);
-            }
-        }
+        let _runtime = crate::test_helpers::EnvVarGuard::remove("XDG_RUNTIME_DIR");
+        let error = socket_path().unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("requires a desktop user session")
+        );
     }
 
     #[test]
@@ -366,7 +356,7 @@ mod tests {
 
         let (server_tx, _server_rx) = channel::<Msg>();
         let _server = IpcServer::bind(server_tx).expect("server bind");
-        let mode = std::fs::metadata(socket_path())
+        let mode = std::fs::metadata(socket_path().unwrap())
             .unwrap()
             .permissions()
             .mode()
@@ -393,7 +383,7 @@ mod tests {
         };
 
         assert!(err.to_string().contains("already running"));
-        assert!(UnixStream::connect(socket_path()).is_ok());
+        assert!(UnixStream::connect(socket_path().unwrap()).is_ok());
 
         cleanup_socket();
         unsafe { std::env::remove_var("XDG_RUNTIME_DIR") };
@@ -404,12 +394,13 @@ mod tests {
         let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir().unwrap();
         unsafe { std::env::set_var("XDG_RUNTIME_DIR", tmp.path()) };
-        std::fs::write(socket_path(), b"stale").unwrap();
+        crate::paths::ensure_runtime_dir().unwrap();
+        std::fs::write(socket_path().unwrap(), b"stale").unwrap();
 
         let (server_tx, _server_rx) = channel::<Msg>();
         let _server = IpcServer::bind(server_tx).expect("replace stale socket");
 
-        assert!(UnixStream::connect(socket_path()).is_ok());
+        assert!(UnixStream::connect(socket_path().unwrap()).is_ok());
 
         cleanup_socket();
         unsafe { std::env::remove_var("XDG_RUNTIME_DIR") };
@@ -458,7 +449,7 @@ mod tests {
         let (server_tx, server_rx) = channel::<Msg>();
         let _server = IpcServer::bind(server_tx).expect("server bind");
 
-        let mut stream = UnixStream::connect(socket_path()).expect("client connect");
+        let mut stream = UnixStream::connect(socket_path().unwrap()).expect("client connect");
         stream
             .write_all(b"this is not json\n")
             .expect("write garbage");

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod geo;
 mod ipc;
 mod omarchy;
 mod paths;
+mod redaction;
 mod services;
 mod singbox;
 mod tui_client;

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,5 +1,38 @@
 use std::path::PathBuf;
 
+/// Return the private directory used for secret runtime files.
+pub fn runtime_dir() -> anyhow::Result<PathBuf> {
+    let base = dirs::runtime_dir().ok_or_else(|| {
+        anyhow::anyhow!("XDG_RUNTIME_DIR is not set; kvn-tui requires a desktop user session")
+    })?;
+    Ok(base.join("kvn-tui"))
+}
+
+/// Create and validate the private runtime directory with owner-only access.
+pub fn ensure_runtime_dir() -> anyhow::Result<PathBuf> {
+    use anyhow::{Context, ensure};
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let dir = runtime_dir()?;
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("Failed to create runtime directory {:?}", dir))?;
+    let metadata = std::fs::symlink_metadata(&dir)
+        .with_context(|| format!("Failed to inspect runtime directory {:?}", dir))?;
+    ensure!(
+        metadata.file_type().is_dir(),
+        "Runtime path is not a directory"
+    );
+    #[allow(unsafe_code)]
+    let uid = unsafe { libc::getuid() };
+    ensure!(
+        metadata.uid() == uid,
+        "Runtime directory is not owned by the current user"
+    );
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))
+        .with_context(|| format!("Failed to protect runtime directory {:?}", dir))?;
+    Ok(dir)
+}
+
 /// Return the application configuration directory (`~/.config/kvn-tui`).
 ///
 /// When running under `sudo` the calling user's home directory is used
@@ -29,25 +62,15 @@ pub fn app_log_path() -> PathBuf {
 }
 
 /// Return the path to the temporary sing-box JSON configuration.
-pub fn temp_singbox_config_path() -> PathBuf {
-    if let Some(dir) = dirs::runtime_dir() {
-        dir.join("kvn-tui-singbox.json")
-    } else if let Some(dir) = dirs::cache_dir() {
-        dir.join("kvn-tui/singbox.json")
-    } else {
-        PathBuf::from("/tmp/kvn-tui-singbox.json")
-    }
+pub fn temp_singbox_config_path() -> anyhow::Result<PathBuf> {
+    Ok(runtime_dir()?.join("singbox.json"))
 }
 
 /// Return the path to a temporary sing-box config used for profile latency
 /// tests. Each test gets its own file keyed by profile UUID so concurrent
 /// tests don't collide.
-pub fn temp_test_config_path(id: &uuid::Uuid) -> PathBuf {
-    if let Some(dir) = dirs::runtime_dir() {
-        dir.join(format!("kvn-test-{id}.json"))
-    } else {
-        PathBuf::from(format!("/tmp/kvn-test-{id}.json"))
-    }
+pub fn temp_test_config_path(id: &uuid::Uuid) -> anyhow::Result<PathBuf> {
+    Ok(runtime_dir()?.join(format!("test-{id}.json")))
 }
 
 /// Return the directory for geo rule-set databases.
@@ -80,6 +103,7 @@ pub fn ensure_config_dirs() -> anyhow::Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::fs::PermissionsExt;
 
     #[test]
     fn singbox_log_path_is_not_empty() {
@@ -97,8 +121,52 @@ mod tests {
 
     #[test]
     fn temp_singbox_config_path_is_not_empty() {
-        let path = temp_singbox_config_path();
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let _runtime = crate::test_helpers::EnvVarGuard::set("XDG_RUNTIME_DIR", root.path());
+        let path = temp_singbox_config_path().unwrap();
         assert!(!path.as_os_str().is_empty());
+    }
+
+    #[test]
+    fn runtime_directory_requires_xdg_runtime_dir() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let _runtime = crate::test_helpers::EnvVarGuard::remove("XDG_RUNTIME_DIR");
+
+        let error = runtime_dir().unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("requires a desktop user session")
+        );
+    }
+
+    #[test]
+    fn runtime_directory_is_private() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let _runtime = crate::test_helpers::EnvVarGuard::set("XDG_RUNTIME_DIR", root.path());
+        let expected = root.path().join("kvn-tui");
+        std::fs::create_dir(&expected).unwrap();
+        std::fs::set_permissions(&expected, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let dir = ensure_runtime_dir().unwrap();
+
+        assert_eq!(dir, expected);
+        assert_eq!(
+            std::fs::metadata(dir).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+    }
+
+    #[test]
+    fn runtime_directory_rejects_symlink() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+        let _runtime = crate::test_helpers::EnvVarGuard::set("XDG_RUNTIME_DIR", root.path());
+        std::os::unix::fs::symlink(target.path(), root.path().join("kvn-tui")).unwrap();
+
+        assert!(ensure_runtime_dir().is_err());
     }
 
     #[test]

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -1,0 +1,90 @@
+/// Return a diagnostic representation of a URL or share link without
+/// credentials, path tokens, query parameters, or fragments.
+pub fn redact_url_for_log(input: &str) -> String {
+    let Ok(url) = url::Url::parse(input) else {
+        return "<redacted URL>".to_string();
+    };
+
+    let scheme = url.scheme();
+    if !matches!(scheme, "http" | "https") && url.username().is_empty() {
+        return format!("{scheme}://<redacted>");
+    }
+    let Some(host) = url.host() else {
+        return format!("{scheme}://<redacted>");
+    };
+    let host = match host {
+        url::Host::Ipv6(address) => format!("[{address}]"),
+        _ => host.to_string(),
+    };
+    let port = url
+        .port()
+        .map_or_else(String::new, |port| format!(":{port}"));
+
+    match scheme {
+        "http" | "https" => format!("{scheme}://{host}{port}/<redacted>"),
+        _ => format!("{scheme}://<redacted>@{host}{port}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_url_for_log;
+
+    #[test]
+    fn redacts_subscription_credentials_and_tokens() {
+        let inputs = [
+            "https://user:password@example.com/sub/secret-token?auth=query-secret#fragment",
+            "http://example.com/another-secret",
+        ];
+
+        for input in inputs {
+            let redacted = redact_url_for_log(input);
+            for secret in [
+                "user",
+                "password",
+                "secret-token",
+                "query-secret",
+                "fragment",
+                "another-secret",
+            ] {
+                assert!(!redacted.contains(secret), "{secret} leaked in {redacted}");
+            }
+        }
+    }
+
+    #[test]
+    fn redacts_supported_share_link_credentials() {
+        let inputs = [
+            "vless://secret-uuid@vpn.example:443?pbk=secret-key#name",
+            "trojan://secret-password@vpn.example:443#name",
+            "socks://user:secret-password@vpn.example:1080",
+            "ssh://user:secret-password@vpn.example:22",
+            "vmess://opaque-base64-secret",
+        ];
+
+        for input in inputs {
+            let redacted = redact_url_for_log(input);
+            for secret in [
+                "secret-uuid",
+                "secret-key",
+                "secret-password",
+                "opaque-base64-secret",
+            ] {
+                assert!(!redacted.contains(secret), "{secret} leaked in {redacted}");
+            }
+        }
+    }
+
+    #[test]
+    fn preserves_only_safe_endpoint_context() {
+        assert_eq!(
+            redact_url_for_log("https://example.com:8443/sub/token"),
+            "https://example.com:8443/<redacted>"
+        );
+        assert_eq!(
+            redact_url_for_log("vless://uuid@[2001:db8::1]:443?security=reality"),
+            "vless://<redacted>@[2001:db8::1]:443"
+        );
+        assert_eq!(redact_url_for_log("not a URL"), "<redacted URL>");
+    }
+}

--- a/src/services/killswitch.rs
+++ b/src/services/killswitch.rs
@@ -3,7 +3,7 @@
 //! (`kvn-tui-killswitch.service`) that runs a wrapped `nft -f` at boot. This
 //! module shells out to a helper script installed at
 //! `/usr/lib/kvn-tui/killswitch-helper.sh` (via `sudo -n`, NOPASSWD for the
-//! `network` group) to enable/disable the unit and to add/remove handshake
+//! dedicated `kvn-tui` group) to enable/disable the unit and add/remove handshake
 //! exceptions while sing-box is establishing the VPN tunnel.
 //!
 //! See `contrib/setup-killswitch.sh` for the one-time setup that the user

--- a/src/singbox/runner.rs
+++ b/src/singbox/runner.rs
@@ -33,7 +33,7 @@ fn write_config(profile: &Profile, settings: &Settings, geo: &GeoAvailability) -
         fs::create_dir_all(parent)?;
     }
 
-    fs::write(&path, serde_json::to_string_pretty(&config)?)
+    crate::atomic_write::write(&path, serde_json::to_string_pretty(&config)?.as_bytes())
         .with_context(|| format!("Failed to write config to {:?}", path))?;
 
     Ok(path)
@@ -159,6 +159,7 @@ fn spawn_stderr_drain(stderr: ChildStderr) {
 mod tests {
     use super::*;
     use crate::config::profile::Profile;
+    use std::os::unix::fs::PermissionsExt;
 
     #[test]
     fn singbox_binary_resolution() {
@@ -194,6 +195,10 @@ mod tests {
         let json: serde_json::Value = serde_json::from_str(&contents).unwrap();
         assert!(json.get("log").is_some());
         assert!(json.get("outbounds").is_some());
+        assert_eq!(
+            fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
 
         // Clean up
         let _ = fs::remove_file(&path);

--- a/src/singbox/runner.rs
+++ b/src/singbox/runner.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::io::{BufRead, BufReader, Read};
 use std::path::PathBuf;
 use std::process::{ChildStderr, Command, Stdio};
@@ -27,11 +26,8 @@ fn singbox_binary() -> &'static str {
 fn write_config(profile: &Profile, settings: &Settings, geo: &GeoAvailability) -> Result<PathBuf> {
     let config =
         generate_config(profile, settings, geo).context("Failed to generate sing-box config")?;
-    let path = crate::paths::temp_singbox_config_path();
-
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
+    crate::paths::ensure_runtime_dir()?;
+    let path = crate::paths::temp_singbox_config_path()?;
 
     crate::atomic_write::write(&path, serde_json::to_string_pretty(&config)?.as_bytes())
         .with_context(|| format!("Failed to write config to {:?}", path))?;
@@ -159,6 +155,7 @@ fn spawn_stderr_drain(stderr: ChildStderr) {
 mod tests {
     use super::*;
     use crate::config::profile::Profile;
+    use std::fs;
     use std::os::unix::fs::PermissionsExt;
 
     #[test]

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -44,6 +44,12 @@ impl EnvVarGuard {
         unsafe { std::env::set_var(key, value) };
         Self { key, previous }
     }
+
+    pub fn remove(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        unsafe { std::env::remove_var(key) };
+        Self { key, previous }
+    }
 }
 
 impl Drop for EnvVarGuard {


### PR DESCRIPTION
## Summary

Harden kvn-tui against local credential exposure, unsafe subscription responses, overly broad privileged access, and unintended external connectivity checks.

Sensitive runtime files now use private XDG paths and restrictive permissions. Subscription handling validates transport, redacts credentials, limits payload sizes, and preserves HTTP compatibility only for migrated users. Privileged system integrations now expose a narrower, validated command surface.

## Changes

- Write generated sing-box and latency-test configurations atomically with mode `0600`, and require an owner-validated `0700` XDG runtime directory.
- Remove shared temporary-directory fallbacks and protect the daemon IPC socket.
- Redact credentials, tokens, paths, query parameters, and fragments from URL errors.
- Limit downloaded, decoded, and parsed subscription payloads to 2 MiB.
- Require HTTPS subscriptions for new installations while preserving deprecated HTTP support through the v4-to-v5 migration and an explicit compatibility setting.
- Emit a warning for every permitted HTTP subscription update without logging its URL.
- Make the latency connectivity probe configurable and disableable, with certificate-verified HTTPS support.
- Restrict polkit access to the required systemd-resolved actions and use a dedicated `kvn-tui` group.
- Install a root-owned kill-switch helper with strict command and argument validation.
-  Add explicit cleanup commands for the optional polkit and kill-switch integrations, preserving the shared `kvn-tui` group while it is still needed and removing it after the final integration is removed.
- Extend doctor checks and update user-facing security and configuration documentation.
