### PR TITLE
feat(ui): add contextual command help

### DIFF
--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -15,13 +15,57 @@ use chrono::{DateTime, Local};
 pub enum Overlay {
     #[default]
     None,
-    Help,
+    Help(HelpState),
     ConfirmDelete,
     RoutingMode,
     GeoRegions,
     DnsSettings,
     ThemeSettings,
     ServiceRouting,
+}
+
+/// Screen that was active when contextual help was opened.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HelpContext {
+    #[default]
+    Sources,
+    Logs,
+    ConfirmDelete,
+    RoutingMode,
+    GeoRegions,
+    DnsSettings,
+    ThemeSettings,
+    ServiceRouting,
+}
+
+impl HelpContext {
+    pub fn restore_overlay(self) -> Overlay {
+        match self {
+            Self::Sources | Self::Logs => Overlay::None,
+            Self::ConfirmDelete => Overlay::ConfirmDelete,
+            Self::RoutingMode => Overlay::RoutingMode,
+            Self::GeoRegions => Overlay::GeoRegions,
+            Self::DnsSettings => Overlay::DnsSettings,
+            Self::ThemeSettings => Overlay::ThemeSettings,
+            Self::ServiceRouting => Overlay::ServiceRouting,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HelpMode {
+    #[default]
+    Context,
+    All,
+}
+
+/// Interactive state of the help popup.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HelpState {
+    pub context: HelpContext,
+    pub mode: HelpMode,
+    /// Selected help row; rendering keeps it inside the visible viewport.
+    pub selected: usize,
 }
 
 /// Main panel focused by the active daemon session. It is deliberately not

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -2204,10 +2204,13 @@ mod tests {
     }
 
     #[test]
-    fn help_mode_any_key_returns_to_normal() {
+    fn help_mode_only_closes_on_exit_keys() {
         let mut model = model_with_profiles(vec![]);
-        model.overlay = Overlay::Help;
-        let effects = handle_key(&mut model, key('x'));
+        model.overlay = Overlay::Help(crate::app::model::HelpState::default());
+        assert!(handle_key(&mut model, key('x')).is_empty());
+        assert!(matches!(model.overlay, Overlay::Help(_)));
+
+        let effects = handle_key(&mut model, key('q'));
         assert_eq!(model.overlay, Overlay::None);
         assert!(effects.is_empty());
     }
@@ -3045,7 +3048,7 @@ mod tests {
         model.overlay = Overlay::None;
         let effects = handle_key(&mut model, key('?'));
         assert!(effects.is_empty());
-        assert_eq!(model.overlay, Overlay::Help);
+        assert!(matches!(model.overlay, Overlay::Help(_)));
     }
 
     #[test]

--- a/src/app/update/key.rs
+++ b/src/app/update/key.rs
@@ -9,17 +9,23 @@
 use crossterm::event::KeyEvent;
 
 use crate::app::effect::Effect;
-use crate::app::model::{AppStatus, Model, Overlay};
+use crate::app::model::{
+    AppStatus, HelpContext, HelpMode, HelpState, MainPaneFocus, Model, Overlay,
+};
 
 use super::*;
 
 pub(super) fn handle_key(model: &mut Model, key: KeyEvent) -> Vec<Effect> {
+    if key.code == KeyCode::Char('?') && !matches!(model.overlay, Overlay::Help(_)) {
+        open_help(model);
+        return vec![];
+    }
     match model.overlay {
-        Overlay::None => handle_sources(model, key),
-        Overlay::Help => {
-            model.overlay = Overlay::None;
-            vec![]
+        Overlay::None if model.main_pane_focus == MainPaneFocus::Sources => {
+            handle_sources(model, key)
         }
+        Overlay::None => handle_logs(model, key),
+        Overlay::Help(state) => handle_help(model, state, key),
         Overlay::ConfirmDelete => handle_confirm_delete(model, key),
         Overlay::RoutingMode => handle_routing_mode(model, key),
         Overlay::GeoRegions => handle_geo_region(model, key),
@@ -27,6 +33,69 @@ pub(super) fn handle_key(model: &mut Model, key: KeyEvent) -> Vec<Effect> {
         Overlay::ThemeSettings => handle_theme_picker(model, key),
         Overlay::ServiceRouting => handle_service_routing(model, key),
     }
+}
+
+fn handle_logs(model: &mut Model, key: KeyEvent) -> Vec<Effect> {
+    match key.code {
+        KeyCode::Char('m')
+        | KeyCode::Char('o')
+        | KeyCode::Char('D')
+        | KeyCode::Char('S')
+        | KeyCode::Char('C')
+        | KeyCode::Char('a')
+        | KeyCode::Char('K')
+        | KeyCode::Char('r')
+        | KeyCode::Char('s')
+        | KeyCode::Char('I') => handle_sources(model, key),
+        _ => vec![],
+    }
+}
+
+fn open_help(model: &mut Model) {
+    let context = match model.overlay {
+        Overlay::None => match model.main_pane_focus {
+            MainPaneFocus::Sources => HelpContext::Sources,
+            MainPaneFocus::Logs => HelpContext::Logs,
+        },
+        Overlay::ConfirmDelete => HelpContext::ConfirmDelete,
+        Overlay::RoutingMode => HelpContext::RoutingMode,
+        Overlay::GeoRegions => HelpContext::GeoRegions,
+        Overlay::DnsSettings => HelpContext::DnsSettings,
+        Overlay::ThemeSettings => HelpContext::ThemeSettings,
+        Overlay::ServiceRouting => HelpContext::ServiceRouting,
+        Overlay::Help(_) => return,
+    };
+    model.overlay = Overlay::Help(HelpState {
+        context,
+        mode: HelpMode::Context,
+        selected: 0,
+    });
+}
+
+fn handle_help(model: &mut Model, mut state: HelpState, key: KeyEvent) -> Vec<Effect> {
+    let can_cancel_geo = model.config.settings.geo_routing.current_region.is_some();
+    let row_count = crate::ui::help::rows(state, can_cancel_geo).len();
+    match key.code {
+        KeyCode::Tab => {
+            state.mode = match state.mode {
+                HelpMode::Context => HelpMode::All,
+                HelpMode::All => HelpMode::Context,
+            };
+            state.selected = 0;
+        }
+        KeyCode::Char('j') | KeyCode::Down => {
+            crate::ui::nav::select_next(&mut state.selected, row_count);
+        }
+        KeyCode::Char('k') | KeyCode::Up => crate::ui::nav::select_prev(&mut state.selected),
+        KeyCode::Char('G') => crate::ui::nav::select_last(&mut state.selected, row_count),
+        KeyCode::Char('q') | KeyCode::Esc | KeyCode::Char('?') => {
+            model.overlay = state.context.restore_overlay();
+            return vec![];
+        }
+        _ => {}
+    }
+    model.overlay = Overlay::Help(state);
+    vec![]
 }
 
 /// Build the picker list. First entry is the Auto-follow-Omarchy slot
@@ -262,9 +331,6 @@ pub(super) fn handle_sources(model: &mut Model, key: KeyEvent) -> Vec<Effect> {
             model.theme_draft = None;
             model.overlay = Overlay::ThemeSettings;
         }
-
-        // Help
-        KeyCode::Char('?') => model.overlay = Overlay::Help,
 
         _ => {}
     }
@@ -582,7 +648,11 @@ fn handle_go_first(model: &mut Model) -> Vec<Effect> {
         Overlay::ServiceRouting => {
             crate::ui::nav::select_first(&mut model.service_routing_selected);
         }
-        Overlay::Help | Overlay::ConfirmDelete => {}
+        Overlay::Help(mut state) => {
+            state.selected = 0;
+            model.overlay = Overlay::Help(state);
+        }
+        Overlay::ConfirmDelete => {}
     }
     vec![]
 }
@@ -598,6 +668,8 @@ pub(super) fn rebuild_key_event(
         "Esc" => KeyCode::Esc,
         "Up" => KeyCode::Up,
         "Down" => KeyCode::Down,
+        "Left" => KeyCode::Left,
+        "Right" => KeyCode::Right,
         "Tab" => KeyCode::Tab,
         "BackTab" => KeyCode::BackTab,
         "Char" => KeyCode::Char(ch.unwrap_or(' ')),
@@ -1778,6 +1850,14 @@ mod tests {
             rebuild_key_event("Down", None, false).unwrap().code,
             KeyCode::Down
         );
+        assert_eq!(
+            rebuild_key_event("Left", None, false).unwrap().code,
+            KeyCode::Left
+        );
+        assert_eq!(
+            rebuild_key_event("Right", None, false).unwrap().code,
+            KeyCode::Right
+        );
         let ctrl_c = rebuild_key_event("Char", Some('c'), true).unwrap();
         assert_eq!(ctrl_c.code, KeyCode::Char('c'));
         assert_eq!(ctrl_c.modifiers, KeyModifiers::CONTROL);
@@ -1933,7 +2013,10 @@ mod tests {
     fn ipc_go_first_is_noop_for_non_selectable_overlays() {
         let mut model = model_with_profiles(vec![]);
         model.routing_selected = 2;
-        for overlay in [Overlay::Help, Overlay::ConfirmDelete] {
+        for overlay in [
+            Overlay::Help(crate::app::model::HelpState::default()),
+            Overlay::ConfirmDelete,
+        ] {
             model.overlay = overlay;
             handle_ipc_command(&mut model, crate::app::msg::IpcCommand::GoFirst);
             assert_eq!(model.overlay, overlay);
@@ -2183,5 +2266,81 @@ mod tests {
         );
         assert_eq!(model.connection, ConnectionState::Connected);
         assert_eq!(model.connecting_profile_id, None);
+    }
+
+    #[test]
+    fn help_uses_pane_context_and_blocks_source_actions_in_logs() {
+        let profile = Profile::new_vless("A".into(), "a".into(), 1, "u".into());
+        let profile_id = profile.id;
+        let mut model = model_with_profiles(vec![profile]);
+        model.main_pane_focus = MainPaneFocus::Logs;
+
+        assert!(handle_key(&mut model, enter()).is_empty());
+        assert_eq!(model.connection, ConnectionState::Idle);
+
+        handle_key(&mut model, key('D'));
+        assert_eq!(model.overlay, Overlay::DnsSettings);
+        model.overlay = Overlay::None;
+
+        let effects = handle_key(&mut model, key('a'));
+        assert!(model.config.settings.auto_connect);
+        assert!(effects.contains(&Effect::SaveConfig));
+
+        let effects = handle_key(&mut model, key('K'));
+        assert_eq!(model.kill_switch_pending, Some(true));
+        assert!(effects.contains(&Effect::ApplyKillSwitch { enabled: true }));
+
+        let previous_schedule = model.config.settings.geo_routing.auto_update;
+        let effects = handle_key(&mut model, key('I'));
+        assert_ne!(
+            model.config.settings.geo_routing.auto_update,
+            previous_schedule
+        );
+        assert!(effects.contains(&Effect::SaveConfig));
+
+        model.connection = ConnectionState::Connected;
+        model.active_profile_id = Some(profile_id);
+        handle_key(&mut model, key('r'));
+        assert_eq!(model.connection, ConnectionState::Connecting);
+        assert_eq!(model.connecting_profile_id, Some(profile_id));
+
+        model.connection = ConnectionState::Connected;
+        let effects = handle_key(&mut model, key('s'));
+        assert_eq!(effects, vec![Effect::Disconnect]);
+
+        handle_key(&mut model, key('?'));
+        assert!(matches!(
+            model.overlay,
+            Overlay::Help(HelpState {
+                context: HelpContext::Logs,
+                mode: HelpMode::Context,
+                selected: 0,
+            })
+        ));
+    }
+
+    #[test]
+    fn help_switches_modes_scrolls_and_restores_overlay_draft() {
+        let mut model = model_with_profiles(vec![]);
+        model.overlay = Overlay::DnsSettings;
+        model.dns_selected = 4;
+        model.dns_strategy_draft = Some(DnsStrategy::PreferIpv6);
+
+        handle_key(&mut model, key('?'));
+        handle_key(&mut model, KeyEvent::from(KeyCode::Tab));
+        handle_key(&mut model, key('j'));
+        assert!(matches!(
+            model.overlay,
+            Overlay::Help(HelpState {
+                context: HelpContext::DnsSettings,
+                mode: HelpMode::All,
+                selected: 1,
+            })
+        ));
+
+        handle_key(&mut model, key('?'));
+        assert_eq!(model.overlay, Overlay::DnsSettings);
+        assert_eq!(model.dns_selected, 4);
+        assert_eq!(model.dns_strategy_draft, Some(DnsStrategy::PreferIpv6));
     }
 }

--- a/src/tui_client.rs
+++ b/src/tui_client.rs
@@ -393,14 +393,18 @@ fn run_loop(
                         std::thread::sleep(Duration::from_millis(300));
                         break;
                     }
-                    KeyCode::Char('h') if model.overlay == crate::app::model::Overlay::None => {
+                    KeyCode::Char('h') | KeyCode::Left
+                        if model.overlay == crate::app::model::Overlay::None =>
+                    {
                         pane_focus = MainPaneFocus::Sources;
                         client.send(&IpcCommand::SetMainPaneFocus {
                             focus: MainPaneFocus::Sources,
                         })?;
                         needs_redraw = true;
                     }
-                    KeyCode::Char('l') if model.overlay == crate::app::model::Overlay::None => {
+                    KeyCode::Char('l') | KeyCode::Right
+                        if model.overlay == crate::app::model::Overlay::None =>
+                    {
                         pane_focus = MainPaneFocus::Logs;
                         client.send(&IpcCommand::SetMainPaneFocus {
                             focus: MainPaneFocus::Logs,
@@ -492,7 +496,10 @@ fn run_loop(
                         }
                         needs_redraw = true;
                     }
-                    KeyCode::Char('p') => {
+                    KeyCode::Char('p')
+                        if model.overlay == crate::app::model::Overlay::None
+                            && pane_focus == MainPaneFocus::Sources =>
+                    {
                         if let Ok(text) = self::clipboard::read_clipboard_text() {
                             client.send(&IpcCommand::Paste { text })?;
                         }
@@ -519,7 +526,10 @@ fn run_loop(
                             })?;
                         }
                     }
-                    KeyCode::Char('e') => {
+                    KeyCode::Char('e')
+                        if model.overlay == crate::app::model::Overlay::None
+                            && pane_focus == MainPaneFocus::Sources =>
+                    {
                         log_selection = None;
                         log_dragging = false;
                         anyhow::ensure!(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,3 +1,4 @@
+pub(crate) mod help;
 pub mod layout;
 pub mod nav;
 pub mod palette;

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -1,0 +1,386 @@
+use crate::app::model::{HelpContext, HelpMode, HelpState};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct HelpRow {
+    pub context: &'static str,
+    pub key: &'static str,
+    pub action: &'static str,
+}
+
+const GLOBAL: &[(&str, &str)] = &[("?", "Show help"), ("Ctrl+C", "Quit daemon")];
+
+const SOURCES: &[(&str, &str)] = &[
+    ("Enter", "Connect to selected profile"),
+    ("p", "Paste from clipboard"),
+    ("y", "Yank selected source"),
+    ("d", "Delete selected source"),
+    ("u", "Update subscription or geo"),
+    ("i", "Cycle subscription auto-update"),
+    ("e", "Open profiles.json in $EDITOR"),
+    ("t", "Test selected profile latency"),
+    ("T", "Test all profiles"),
+    ("r", "Reconnect"),
+    ("s", "Disconnect"),
+    ("a", "Toggle auto-connect"),
+    ("K", "Toggle kill switch"),
+    ("m", "Routing mode"),
+    ("o", "Geo region"),
+    ("D", "DNS settings"),
+    ("S", "Service routing"),
+    ("C", "Theme picker"),
+    ("I", "Cycle geo auto-update"),
+    ("h/l / Left/Right", "Focus Sources / Logs"),
+    ("j / Down", "Move down"),
+    ("k / Up", "Move up"),
+    ("gg", "Go to first"),
+    ("G", "Go to last"),
+    ("q / Esc", "Detach TUI"),
+];
+
+const LOGS: &[(&str, &str)] = &[
+    ("Shift+V", "Select multiple logs"),
+    ("y", "Yank selected log(s)"),
+    ("Esc", "Cancel log selection"),
+    ("r", "Reconnect"),
+    ("s", "Disconnect"),
+    ("a", "Toggle auto-connect"),
+    ("K", "Toggle kill switch"),
+    ("m", "Routing mode"),
+    ("o", "Geo region"),
+    ("D", "DNS settings"),
+    ("S", "Service routing"),
+    ("C", "Theme picker"),
+    ("I", "Cycle geo auto-update"),
+    ("h/l / Left/Right", "Focus Sources / Logs"),
+    ("j / Down", "Move down"),
+    ("k / Up", "Move up"),
+    ("gg", "Go to buffer top"),
+    ("G", "Go to buffer bottom"),
+    ("q / Esc", "Detach TUI"),
+];
+
+const CONFIRM_DELETE: &[(&str, &str)] = &[("y / Enter", "Confirm deletion"), ("q / Esc", "Cancel")];
+
+const PICKER: &[(&str, &str)] = &[
+    ("Enter", "Confirm"),
+    ("j / Down", "Move down"),
+    ("k / Up", "Move up"),
+    ("gg", "Go to first"),
+    ("G", "Go to last"),
+    ("q / Esc", "Cancel"),
+];
+
+const DNS: &[(&str, &str)] = &[
+    ("h/l / Left/Right", "Change selected value"),
+    ("Enter", "Confirm"),
+    ("j / Down", "Move down"),
+    ("k / Up", "Move up"),
+    ("gg", "Go to first"),
+    ("G", "Go to last"),
+    ("q / Esc", "Cancel"),
+];
+
+const SERVICES: &[(&str, &str)] = &[
+    ("h/l / Left/Right", "Change selected route"),
+    ("Enter", "Confirm all changes"),
+    ("j / Down", "Move down"),
+    ("k / Up", "Move up"),
+    ("gg", "Go to first"),
+    ("G", "Go to last"),
+    ("q / Esc", "Cancel"),
+];
+
+/// Compact, purpose-grouped catalog for the All view. This is intentionally
+/// curated separately from the contextual lists: repeating j/k and the main
+/// pane shortcuts under every overlay makes the complete reference noisy.
+const ALL_ROWS: &[HelpRow] = &[
+    HelpRow {
+        context: "Sources",
+        key: "Enter",
+        action: "Connect to selected profile",
+    },
+    HelpRow {
+        context: "Sources",
+        key: "p",
+        action: "Paste from clipboard",
+    },
+    HelpRow {
+        context: "Sources",
+        key: "y",
+        action: "Yank selected source",
+    },
+    HelpRow {
+        context: "Sources",
+        key: "d",
+        action: "Delete selected source",
+    },
+    HelpRow {
+        context: "Sources",
+        key: "u",
+        action: "Update subscription or geo",
+    },
+    HelpRow {
+        context: "Sources",
+        key: "i",
+        action: "Cycle subscription auto-update",
+    },
+    HelpRow {
+        context: "Sources",
+        key: "e",
+        action: "Open profiles.json in $EDITOR",
+    },
+    HelpRow {
+        context: "Sources",
+        key: "t / T",
+        action: "Test selected / all profiles",
+    },
+    HelpRow {
+        context: "Logs",
+        key: "Shift+V",
+        action: "Select multiple logs",
+    },
+    HelpRow {
+        context: "Logs",
+        key: "y",
+        action: "Yank selected log(s)",
+    },
+    HelpRow {
+        context: "DNS / Services",
+        key: "h/l / Left/Right",
+        action: "Change selected value",
+    },
+    HelpRow {
+        context: "Confirm Delete",
+        key: "y / Enter",
+        action: "Confirm deletion",
+    },
+    HelpRow {
+        context: "Overlays",
+        key: "Enter",
+        action: "Confirm selection or changes",
+    },
+    HelpRow {
+        context: "Main panes",
+        key: "r",
+        action: "Reconnect",
+    },
+    HelpRow {
+        context: "Main panes",
+        key: "s",
+        action: "Disconnect",
+    },
+    HelpRow {
+        context: "Main panes",
+        key: "a",
+        action: "Toggle auto-connect",
+    },
+    HelpRow {
+        context: "Main panes",
+        key: "K",
+        action: "Toggle kill switch",
+    },
+    HelpRow {
+        context: "Main panes",
+        key: "m",
+        action: "Routing mode",
+    },
+    HelpRow {
+        context: "Main panes",
+        key: "o",
+        action: "Geo region",
+    },
+    HelpRow {
+        context: "Main panes",
+        key: "D",
+        action: "DNS settings",
+    },
+    HelpRow {
+        context: "Main panes",
+        key: "S",
+        action: "Service routing",
+    },
+    HelpRow {
+        context: "Main panes",
+        key: "C",
+        action: "Theme picker",
+    },
+    HelpRow {
+        context: "Main panes",
+        key: "I",
+        action: "Cycle geo auto-update",
+    },
+    HelpRow {
+        context: "Main panes",
+        key: "h/l / Left/Right",
+        action: "Focus Sources / Logs",
+    },
+    HelpRow {
+        context: "Lists / pickers",
+        key: "j/k / Up/Down",
+        action: "Navigate",
+    },
+    HelpRow {
+        context: "Lists / pickers",
+        key: "gg/G",
+        action: "Jump to list/buffer edges",
+    },
+    HelpRow {
+        context: "Main panes",
+        key: "q / Esc",
+        action: "Detach; Esc cancels visual",
+    },
+    HelpRow {
+        context: "Overlays",
+        key: "q / Esc",
+        action: "Cancel",
+    },
+    HelpRow {
+        context: "Global",
+        key: "?",
+        action: "Show help",
+    },
+    HelpRow {
+        context: "Global",
+        key: "Ctrl+C",
+        action: "Quit daemon",
+    },
+];
+
+fn label(context: HelpContext) -> &'static str {
+    match context {
+        HelpContext::Sources => "Sources",
+        HelpContext::Logs => "Logs",
+        HelpContext::ConfirmDelete => "Confirm Delete",
+        HelpContext::RoutingMode => "Routing Mode",
+        HelpContext::GeoRegions => "Geo Region",
+        HelpContext::DnsSettings => "DNS",
+        HelpContext::ThemeSettings => "Theme",
+        HelpContext::ServiceRouting => "Service Routing",
+    }
+}
+
+fn commands(context: HelpContext) -> &'static [(&'static str, &'static str)] {
+    match context {
+        HelpContext::Sources => SOURCES,
+        HelpContext::Logs => LOGS,
+        HelpContext::ConfirmDelete => CONFIRM_DELETE,
+        HelpContext::RoutingMode | HelpContext::GeoRegions | HelpContext::ThemeSettings => PICKER,
+        HelpContext::DnsSettings => DNS,
+        HelpContext::ServiceRouting => SERVICES,
+    }
+}
+
+fn append(
+    rows: &mut Vec<HelpRow>,
+    context: &'static str,
+    commands: &[(&'static str, &'static str)],
+) {
+    rows.extend(commands.iter().map(|&(key, action)| HelpRow {
+        context,
+        key,
+        action,
+    }));
+}
+
+pub(crate) fn rows(state: HelpState, can_cancel_geo: bool) -> Vec<HelpRow> {
+    let mut rows = Vec::new();
+    match state.mode {
+        HelpMode::Context => {
+            append(&mut rows, label(state.context), commands(state.context));
+            if state.context == HelpContext::GeoRegions && !can_cancel_geo {
+                rows.retain(|row| row.key != "q / Esc");
+            }
+            append(&mut rows, "Global", GLOBAL);
+        }
+        HelpMode::All => {
+            rows.extend_from_slice(ALL_ROWS);
+        }
+    }
+    rows
+}
+
+pub(crate) fn title(context: HelpContext) -> &'static str {
+    label(context)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state(context: HelpContext, mode: HelpMode) -> HelpState {
+        HelpState {
+            context,
+            mode,
+            selected: 0,
+        }
+    }
+
+    #[test]
+    fn contextual_rows_only_include_active_context_and_global_commands() {
+        let sources = rows(state(HelpContext::Sources, HelpMode::Context), true);
+        assert_eq!(sources.first().map(|row| row.key), Some("Enter"));
+        assert!(sources.iter().any(|row| row.key == "p"));
+        assert!(!sources.iter().any(|row| row.key == "Shift+V"));
+
+        let logs = rows(state(HelpContext::Logs, HelpMode::Context), true);
+        assert_eq!(logs.first().map(|row| row.key), Some("Shift+V"));
+        assert!(logs.iter().any(|row| row.key == "Shift+V"));
+        assert!(logs.iter().any(|row| row.key == "D"));
+        assert!(logs.iter().any(|row| row.key == "a"));
+        assert!(logs.iter().any(|row| row.key == "K"));
+        assert!(logs.iter().any(|row| row.key == "r"));
+        assert!(logs.iter().any(|row| row.key == "s"));
+        assert!(logs.iter().any(|row| row.key == "I"));
+        assert!(!logs.iter().any(|row| row.key == "p"));
+        assert!(logs.iter().any(|row| row.context == "Global"));
+
+        let dns = rows(state(HelpContext::DnsSettings, HelpMode::Context), true);
+        assert_eq!(dns.first().map(|row| row.key), Some("h/l / Left/Right"));
+        let picker = rows(state(HelpContext::ThemeSettings, HelpMode::Context), true);
+        assert_eq!(picker.first().map(|row| row.key), Some("Enter"));
+    }
+
+    #[test]
+    fn all_rows_are_compact_and_cover_command_categories() {
+        use std::collections::HashSet;
+
+        let all = rows(state(HelpContext::Sources, HelpMode::All), true);
+        assert_eq!(all.first().map(|row| row.context), Some("Sources"));
+        assert_eq!(all.first().map(|row| row.key), Some("Enter"));
+        assert_eq!(all.last().map(|row| row.key), Some("Ctrl+C"));
+        for context in [
+            "Global",
+            "Lists / pickers",
+            "Main panes",
+            "Sources",
+            "Logs",
+            "Confirm Delete",
+            "Overlays",
+            "DNS / Services",
+        ] {
+            assert!(all.iter().any(|row| row.context == context), "{context}");
+        }
+        assert_eq!(all.iter().filter(|row| row.key == "m").count(), 1);
+        assert_eq!(
+            all.iter().filter(|row| row.key == "j/k / Up/Down").count(),
+            1
+        );
+        assert!(all.len() < SOURCES.len() + LOGS.len());
+        let index = |context| all.iter().position(|row| row.context == context).unwrap();
+        assert!(index("Sources") < index("Logs"));
+        assert!(index("Logs") < index("Main panes"));
+        assert!(index("Main panes") < index("Lists / pickers"));
+        assert!(index("Lists / pickers") < index("Global"));
+        let mut unique = HashSet::new();
+        assert!(all.iter().all(|row| unique.insert((row.key, row.action))));
+    }
+
+    #[test]
+    fn required_geo_selection_omits_cancel_in_context_mode() {
+        let required = rows(state(HelpContext::GeoRegions, HelpMode::Context), false);
+        assert!(!required.iter().any(|row| row.key == "q / Esc"));
+
+        let optional = rows(state(HelpContext::GeoRegions, HelpMode::Context), true);
+        assert!(optional.iter().any(|row| row.key == "q / Esc"));
+    }
+}

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -2,11 +2,11 @@ use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, Paragraph, Row, Table, Wrap};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Row, Table, TableState, Wrap};
 use std::time::{Duration, Instant};
 use unicode_width::UnicodeWidthChar;
 
-use crate::app::model::{MainPaneFocus, Model, Overlay, SourceRow};
+use crate::app::model::{HelpMode, MainPaneFocus, Model, Overlay, SourceRow};
 use crate::ui::styles::Theme;
 use crate::ui::widgets::{
     StatusBar, format_bps_field, format_bytes_field, format_connections_field,
@@ -572,9 +572,8 @@ pub(crate) fn draw_with_interaction(
     );
     draw_status_bar(frame, model, status_area);
 
-    let theme = &model.theme;
     match model.overlay {
-        Overlay::Help => draw_help(frame, theme, area),
+        Overlay::Help(state) => draw_help(frame, model, state, area),
         Overlay::ConfirmDelete => draw_confirm_delete(frame, model, area),
         Overlay::RoutingMode => draw_routing_mode(frame, model, area),
         Overlay::GeoRegions => draw_geo_region(frame, model, area),
@@ -681,48 +680,39 @@ fn draw_status_bar(frame: &mut Frame, model: &Model, area: Rect) {
 }
 
 /// Draw the help popup overlay.
-fn draw_help(frame: &mut Frame, theme: &Theme, area: Rect) {
-    let header = Row::new(vec!["Key", "Action"]).style(theme.accent().add_modifier(Modifier::BOLD));
-
-    let rows: Vec<Row> = vec![
-        Row::new(vec!["h / l", "Focus Sources / Logs"]),
-        Row::new(vec!["j / Down", "Move down"]),
-        Row::new(vec!["k / Up", "Move up"]),
-        Row::new(vec!["gg", "Go to first / buffer top"]),
-        Row::new(vec!["G", "Go to last / buffer bottom"]),
-        Row::new(vec!["Enter", "Connect to selected profile"]),
-        Row::new(vec!["p", "Paste from clipboard"]),
-        Row::new(vec!["y", "Yank selected source / log"]),
-        Row::new(vec!["Shift+V", "Select multiple logs"]),
-        Row::new(vec!["d", "Delete selected source"]),
-        Row::new(vec!["m", "Routing mode (popup list)"]),
-        Row::new(vec!["o", "Geo region"]),
-        Row::new(vec!["u", "Update subscription or geo"]),
-        Row::new(vec!["i", "Cycle subscription auto-update"]),
-        Row::new(vec!["I", "Cycle geo auto-update"]),
-        Row::new(vec!["e", "Open profiles.json in $EDITOR"]),
-        Row::new(vec!["a", "Toggle auto-connect"]),
-        Row::new(vec!["K", "Toggle kill switch"]),
-        Row::new(vec!["D", "DNS settings"]),
-        Row::new(vec!["S", "Service routing"]),
-        Row::new(vec!["C", "Theme picker"]),
-        Row::new(vec!["t", "Test selected profile latency"]),
-        Row::new(vec!["T", "Test all profiles (batch)"]),
-        Row::new(vec!["r", "Reconnect"]),
-        Row::new(vec!["s", "Stop / disconnect"]),
-        Row::new(vec!["q / Esc", "Detach TUI"]),
-        Row::new(vec!["Ctrl+C", "Quit"]),
-        Row::new(vec!["?", "Show this help"]),
-    ];
-
-    let needed = rows.len() as u16 + 1 + 2 + 1; // data rows + header + borders + padding
-    let percent = ((needed * 100) / area.height).clamp(50, 90);
-    let popup_area = centered_rect(POPUP_WIDTH_PERCENT, percent, area);
+fn draw_help(
+    frame: &mut Frame,
+    model: &Model,
+    help_state: crate::app::model::HelpState,
+    area: Rect,
+) {
+    let theme = &model.theme;
+    let help_rows = crate::ui::help::rows(
+        help_state,
+        model.config.settings.geo_routing.current_region.is_some(),
+    );
+    let needed = help_rows.len() as u16 + 1 + 2 + 2;
+    let percent = needed
+        .saturating_mul(100)
+        .checked_div(area.height)
+        .unwrap_or(90)
+        .clamp(50, 90);
+    let width_percent = match help_state.mode {
+        HelpMode::Context => 70,
+        HelpMode::All => 80,
+    };
+    let popup_area = centered_rect(width_percent, percent, area);
 
     frame.render_widget(Clear, popup_area);
 
     let block = Block::default()
-        .title(" Help ")
+        .title(format!(
+            " Help — {} ",
+            match help_state.mode {
+                HelpMode::Context => crate::ui::help::title(help_state.context),
+                HelpMode::All => "All",
+            }
+        ))
         .borders(Borders::ALL)
         .border_style(theme.accent())
         .style(theme.popup_bg());
@@ -730,9 +720,61 @@ fn draw_help(frame: &mut Frame, theme: &Theme, area: Rect) {
     let inner = block.inner(popup_area);
     frame.render_widget(block, popup_area);
 
-    let table = Table::new(rows, [Constraint::Length(12), Constraint::Min(1)]).header(header);
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(2)])
+        .split(inner);
+    let visible_count = chunks[0].height.saturating_sub(1) as usize;
+    let selected = help_state.selected.min(help_rows.len().saturating_sub(1));
+    let window_start = if help_rows.len() > visible_count {
+        selected
+            .saturating_sub(visible_count / 2)
+            .min(help_rows.len() - visible_count)
+    } else {
+        0
+    };
+    let window_end = (window_start + visible_count).min(help_rows.len());
+    let all_mode = help_state.mode == HelpMode::All;
+    let header = if all_mode {
+        Row::new(vec!["Context", "Key", "Action"])
+    } else {
+        Row::new(vec!["Key", "Action"])
+    }
+    .style(theme.accent().add_modifier(Modifier::BOLD));
+    let rows = help_rows[window_start..window_end].iter().map(|row| {
+        if all_mode {
+            Row::new(vec![row.context, row.key, row.action])
+        } else {
+            Row::new(vec![row.key, row.action])
+        }
+    });
+    let widths = if all_mode {
+        vec![
+            Constraint::Length(16),
+            Constraint::Length(18),
+            Constraint::Min(1),
+        ]
+    } else {
+        vec![Constraint::Length(18), Constraint::Min(1)]
+    };
+    let table = Table::new(rows, widths)
+        .header(header)
+        .row_highlight_style(theme.selected())
+        .highlight_symbol("> ");
+    let mut table_state = TableState::default().with_selected(Some(selected - window_start));
+    frame.render_stateful_widget(table, chunks[0], &mut table_state);
 
-    frame.render_widget(table, inner);
+    let mode_hint = match help_state.mode {
+        HelpMode::Context => "Tab: show all commands",
+        HelpMode::All => "Tab: show contextual commands",
+    };
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from(mode_hint).centered(),
+            Line::from("j/k scroll · gg/G edges · q/Esc/? back").centered(),
+        ]),
+        chunks[1],
+    );
 }
 
 /// Draw the delete confirmation dialog.
@@ -751,7 +793,7 @@ fn draw_confirm_delete(frame: &mut Frame, model: &Model, area: Rect) {
         vec![
             Line::from(Span::styled(message, theme.error())),
             Line::from(""),
-            Line::from("Press y/Enter to confirm, q/Esc to cancel"),
+            Line::from("y/Enter confirm, q/Esc cancel, ? help"),
         ],
         POPUP_HEIGHT_PERCENT,
     );
@@ -809,7 +851,7 @@ fn draw_routing_mode(frame: &mut Frame, model: &Model, area: Rect) {
         model.routing_selected,
         active,
         POPUP_HEIGHT_PERCENT,
-        &["j/k navigate, Enter confirm, q/Esc cancel"],
+        &["j/k navigate, Enter confirm", "q/Esc cancel, ? help"],
     );
 }
 
@@ -842,9 +884,9 @@ fn draw_geo_region(frame: &mut Frame, model: &Model, area: Rect) {
         active,
         POPUP_HEIGHT_PERCENT,
         if model.config.settings.geo_routing.current_region.is_some() {
-            &["j/k navigate, Enter confirm, q/Esc cancel"]
+            &["j/k navigate, Enter confirm", "q/Esc cancel, ? help"]
         } else {
-            &["j/k navigate, Enter confirm"]
+            &["j/k navigate, Enter confirm, ? help"]
         },
     );
 }
@@ -892,7 +934,10 @@ fn draw_dns_settings(frame: &mut Frame, model: &Model, area: Rect) {
         model.dns_selected,
         current_dns_preset_index(dns),
         POPUP_HEIGHT_PERCENT,
-        &["j/k navigate, h/l change", "Enter confirm, q/Esc cancel"],
+        &[
+            "j/k navigate, h/l change",
+            "Enter confirm, q/Esc cancel, ? help",
+        ],
     );
 }
 
@@ -955,7 +1000,7 @@ fn draw_service_routing(frame: &mut Frame, model: &Model, area: Rect) {
 
     lines.push(Line::from(""));
     lines.push(Line::from("j/k navigate, h/l change").centered());
-    lines.push(Line::from("Enter confirm, q/Esc cancel").centered());
+    lines.push(Line::from("Enter confirm, q/Esc cancel, ? help").centered());
 
     frame.render_widget(Paragraph::new(lines), inner);
 }
@@ -979,7 +1024,7 @@ fn draw_theme_settings(frame: &mut Frame, model: &Model, area: Rect) {
         model.theme_selected,
         active,
         POPUP_HEIGHT_PERCENT_TALL,
-        &["j/k navigate, Enter confirm, q/Esc cancel"],
+        &["j/k navigate, Enter confirm", "q/Esc cancel, ? help"],
     );
 }
 
@@ -1427,7 +1472,7 @@ mod tests {
         assert_eq!(source_hit_test(&model, area, 0, 5), None); // border
         assert_eq!(source_hit_test(&model, area, 50, 5), None); // Logs
         assert_eq!(source_hit_test(&model, Rect::new(0, 0, 80, 5), 2, 4), None);
-        model.overlay = Overlay::Help;
+        model.overlay = Overlay::Help(crate::app::model::HelpState::default());
         assert_eq!(source_hit_test(&model, area, 2, 5), None);
     }
 
@@ -1440,7 +1485,7 @@ mod tests {
         assert!(viewport.contains(41, 4));
         assert!(!viewport.contains(40, 4));
         assert!(!viewport.contains(41, 3));
-        model.overlay = Overlay::Help;
+        model.overlay = Overlay::Help(crate::app::model::HelpState::default());
         assert!(log_viewport(&model, area).is_none());
     }
 
@@ -1780,36 +1825,37 @@ mod tests {
 
         let backend = TestBackend::new(80, 40);
         let mut terminal = Terminal::new(backend).unwrap();
+        let model = model_with_profiles(vec![]);
+        let state = crate::app::model::HelpState::default();
         let frame = terminal
             .draw(|frame| {
                 let area = frame.area();
-                draw_help(frame, &Theme::legacy(), area);
+                draw_help(frame, &model, state, area);
             })
             .unwrap();
 
         let content: String = frame.buffer.content.iter().map(|c| c.symbol()).collect();
         let expected = [
-            ("h / l", "Focus Sources / Logs"),
+            ("h/l / Left/Right", "Focus Sources / Logs"),
             ("j / Down", "Move down"),
             ("k / Up", "Move up"),
-            ("gg", "Go to first / buffer top"),
-            ("G", "Go to last / buffer bottom"),
+            ("gg", "Go to first"),
+            ("G", "Go to last"),
             ("Enter", "Connect to selected profile"),
             ("p", "Paste from clipboard"),
-            ("Shift+V", "Select multiple logs"),
             ("d", "Delete selected source"),
-            ("m", "Routing mode (popup list)"),
+            ("m", "Routing mode"),
             ("u", "Update subscription or geo"),
             ("i", "Cycle subscription auto-update"),
             ("e", "Open profiles.json in $EDITOR"),
             ("C", "Theme picker"),
             ("t", "Test selected profile latency"),
-            ("T", "Test all profiles (batch)"),
+            ("T", "Test all profiles"),
             ("r", "Reconnect"),
-            ("s", "Stop / disconnect"),
+            ("s", "Disconnect"),
             ("q / Esc", "Detach TUI"),
             ("Ctrl+C", "Quit"),
-            ("?", "Show this help"),
+            ("?", "Show help"),
         ];
         for (key, action) in expected {
             assert!(content.contains(key), "help should contain key: {}", key);
@@ -1904,10 +1950,22 @@ mod tests {
         use ratatui::backend::TestBackend;
         use ratatui::style::Color;
 
-        for (overlay, height_percent) in [
-            (Overlay::ConfirmDelete, POPUP_HEIGHT_PERCENT),
-            (Overlay::Help, 90),
-            (Overlay::ServiceRouting, POPUP_HEIGHT_PERCENT),
+        for (overlay, width_percent, height_percent) in [
+            (
+                Overlay::ConfirmDelete,
+                POPUP_WIDTH_PERCENT,
+                POPUP_HEIGHT_PERCENT,
+            ),
+            (
+                Overlay::Help(crate::app::model::HelpState::default()),
+                70,
+                90,
+            ),
+            (
+                Overlay::ServiceRouting,
+                POPUP_WIDTH_PERCENT,
+                POPUP_HEIGHT_PERCENT,
+            ),
         ] {
             let mut model = mouse_model();
             model.overlay = overlay;
@@ -1918,7 +1976,7 @@ mod tests {
                 })
                 .unwrap();
 
-            let popup = centered_rect(POPUP_WIDTH_PERCENT, height_percent, Rect::new(0, 0, 80, 20));
+            let popup = centered_rect(width_percent, height_percent, Rect::new(0, 0, 80, 20));
             let corner =
                 &terminal.backend().buffer().content[popup.y as usize * 80 + popup.x as usize];
             assert_eq!(corner.style().fg, Some(Color::Cyan), "overlay: {overlay:?}");
@@ -1966,8 +2024,19 @@ mod tests {
     fn draw_help_overlay_snapshot() {
         let mut model = model_with_profiles(vec![]);
         model.geo_last_updated = Some("2026-05-31 13:41".to_string());
-        model.overlay = Overlay::Help;
+        model.overlay = Overlay::Help(crate::app::model::HelpState::default());
         insta::assert_snapshot!(snapshot_terminal(&model, 80, 40));
+    }
+
+    #[test]
+    fn draw_all_help_overlay_snapshot() {
+        let mut model = model_with_profiles(vec![]);
+        model.overlay = Overlay::Help(crate::app::model::HelpState {
+            context: crate::app::model::HelpContext::Logs,
+            mode: HelpMode::All,
+            selected: 12,
+        });
+        insta::assert_snapshot!(snapshot_terminal(&model, 100, 24));
     }
 
     #[test]
@@ -2021,7 +2090,8 @@ mod tests {
             .geo_routing
             .set_region(crate::config::profile::GeoRegion::Ru);
         let optional = snapshot_terminal(&model, 80, 20);
-        assert!(optional.contains("j/k navigate, Enter confirm, q/Esc cancel"));
+        assert!(optional.contains("j/k navigate, Enter confirm"));
+        assert!(optional.contains("q/Esc cancel, ? help"));
     }
 
     #[test]
@@ -2128,7 +2198,8 @@ mod tests {
 
         let rendered = snapshot_terminal(&model, 80, 24);
         assert!(rendered.contains("> white"));
-        assert!(rendered.contains("j/k navigate, Enter confirm, q/Esc cancel"));
+        assert!(rendered.contains("j/k navigate, Enter confirm"));
+        assert!(rendered.contains("q/Esc cancel, ? help"));
         assert!(!rendered.contains("catppuccin-latte"));
     }
 

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -851,7 +851,7 @@ fn draw_routing_mode(frame: &mut Frame, model: &Model, area: Rect) {
         model.routing_selected,
         active,
         POPUP_HEIGHT_PERCENT,
-        &["j/k navigate, Enter confirm", "q/Esc cancel, ? help"],
+        &["Enter confirm, q/Esc cancel, ? help"],
     );
 }
 
@@ -884,9 +884,9 @@ fn draw_geo_region(frame: &mut Frame, model: &Model, area: Rect) {
         active,
         POPUP_HEIGHT_PERCENT,
         if model.config.settings.geo_routing.current_region.is_some() {
-            &["j/k navigate, Enter confirm", "q/Esc cancel, ? help"]
+            &["Enter confirm, q/Esc cancel, ? help"]
         } else {
-            &["j/k navigate, Enter confirm, ? help"]
+            &["Enter confirm, ? help"]
         },
     );
 }
@@ -934,10 +934,7 @@ fn draw_dns_settings(frame: &mut Frame, model: &Model, area: Rect) {
         model.dns_selected,
         current_dns_preset_index(dns),
         POPUP_HEIGHT_PERCENT,
-        &[
-            "j/k navigate, h/l change",
-            "Enter confirm, q/Esc cancel, ? help",
-        ],
+        &["Enter confirm, q/Esc cancel, ? help"],
     );
 }
 
@@ -999,7 +996,6 @@ fn draw_service_routing(frame: &mut Frame, model: &Model, area: Rect) {
     }
 
     lines.push(Line::from(""));
-    lines.push(Line::from("j/k navigate, h/l change").centered());
     lines.push(Line::from("Enter confirm, q/Esc cancel, ? help").centered());
 
     frame.render_widget(Paragraph::new(lines), inner);
@@ -1024,7 +1020,7 @@ fn draw_theme_settings(frame: &mut Frame, model: &Model, area: Rect) {
         model.theme_selected,
         active,
         POPUP_HEIGHT_PERCENT_TALL,
-        &["j/k navigate, Enter confirm", "q/Esc cancel, ? help"],
+        &["Enter confirm, q/Esc cancel, ? help"],
     );
 }
 
@@ -2081,8 +2077,9 @@ mod tests {
         model.overlay = Overlay::GeoRegions;
 
         let required = snapshot_terminal(&model, 80, 20);
-        assert!(required.contains("j/k navigate, Enter confirm"));
+        assert!(required.contains("Enter confirm, ? help"));
         assert!(!required.contains("q/Esc cancel"));
+        assert!(!required.contains("j/k navigate"));
 
         model
             .config
@@ -2090,8 +2087,8 @@ mod tests {
             .geo_routing
             .set_region(crate::config::profile::GeoRegion::Ru);
         let optional = snapshot_terminal(&model, 80, 20);
-        assert!(optional.contains("j/k navigate, Enter confirm"));
-        assert!(optional.contains("q/Esc cancel, ? help"));
+        assert!(optional.contains("Enter confirm, q/Esc cancel, ? help"));
+        assert!(!optional.contains("j/k navigate"));
     }
 
     #[test]
@@ -2198,8 +2195,8 @@ mod tests {
 
         let rendered = snapshot_terminal(&model, 80, 24);
         assert!(rendered.contains("> white"));
-        assert!(rendered.contains("j/k navigate, Enter confirm"));
-        assert!(rendered.contains("q/Esc cancel, ? help"));
+        assert!(rendered.contains("Enter confirm, q/Esc cancel, ? help"));
+        assert!(!rendered.contains("j/k navigate"));
         assert!(!rendered.contains("catppuccin-latte"));
     }
 

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_all_help_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_all_help_overlay_snapshot.snap
@@ -1,0 +1,28 @@
+---
+source: src/ui/layout.rs
+expression: "snapshot_terminal(&model, 100, 24)"
+---
+┌ Traffic ─────────────────────────────────────────────────────────────────────────────────────────┐
+│↑ 0.0 KB/┌ Help — All ──────────────────────────────────────────────────────────────────┐         │
+└─────────│  Context          Key                Action                                  │─────────┘
+┌ Sources │  Sources          u                  Update subscription or geo              │─────────┐
+│No source│  Sources          i                  Cycle subscription auto-update          │         │
+│subscript│  Sources          e                  Open profiles.json in $EDITOR           │         │
+│         │  Sources          t / T              Test selected / all profiles            │         │
+│         │  Logs             Shift+V            Select multiple logs                    │         │
+│         │  Logs             y                  Yank selected log(s)                    │         │
+│         │  DNS / Services   h/l / Left/Right   Change selected value                   │         │
+│         │  Confirm Delete   y / Enter          Confirm deletion                        │         │
+│         │> Overlays         Enter              Confirm selection or changes            │         │
+│         │  Main panes       r                  Reconnect                               │         │
+│         │  Main panes       s                  Disconnect                              │         │
+│         │  Main panes       a                  Toggle auto-connect                     │         │
+│         │  Main panes       K                  Toggle kill switch                      │         │
+│         │  Main panes       m                  Routing mode                            │         │
+│         │  Main panes       o                  Geo region                              │         │
+│         │  Main panes       D                  DNS settings                            │         │
+│         │  Main panes       S                  Service routing                         │         │
+│         │                         Tab: show contextual commands                        │         │
+│         │                    j/k scroll · gg/G edges · q/Esc/? back                    │         │
+└─────────└──────────────────────────────────────────────────────────────────────────────┘─────────┘
+[DISCONNECTED] [DNS: DoH] [Global] [Geo: never]

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_confirm_delete_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_confirm_delete_overlay_snapshot.snap
@@ -10,7 +10,7 @@ expression: "snapshot_terminal(&model, 80, 20)"
 │└ Alpha        ┌ Confirm ─────────────────────────────────────┐               │
 │               │           Delete selected profile?           │               │
 │               │                                              │               │
-│               │   Press y/Enter to confirm, q/Esc to cancel  │               │
+│               │     y/Enter confirm, q/Esc cancel, ? help    │               │
 │               │                                              │               │
 │               │                                              │               │
 │               │                                              │               │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_dns_settings_overlay_fakeip_on_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_dns_settings_overlay_fakeip_on_snapshot.snap
@@ -18,7 +18,7 @@ expression: "snapshot_terminal(&model, 80, 24)"
 │               │               > Fake-IP: ‹ on ›              │               │
 │               │                                              │               │
 │               │           j/k navigate, h/l change           │               │
-│               │          Enter confirm, q/Esc cancel         │               │
+│               │      Enter confirm, q/Esc cancel, ? help     │               │
 │               └──────────────────────────────────────────────┘               │
 │                                      ││                                      │
 │                                      ││                                      │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_dns_settings_overlay_fakeip_on_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_dns_settings_overlay_fakeip_on_snapshot.snap
@@ -11,13 +11,13 @@ expression: "snapshot_terminal(&model, 80, 24)"
 │               ┌ DNS ─────────────────────────────────────────┐               │
 │               │                 DNS settings                 │               │
 │               │                                              │               │
+│               │       Preset: Cloudflare DoH (1.1.1.1)       │               │
 │               │         Preset: Google DoT (8.8.8.8)         │               │
 │               │          Preset: Quad9 DoH (9.9.9.9)         │               │
 │               │        Preset: System resolver (local)       │               │
 │               │           Strategy: ‹ prefer_ipv4 ›          │               │
 │               │               > Fake-IP: ‹ on ›              │               │
 │               │                                              │               │
-│               │           j/k navigate, h/l change           │               │
 │               │      Enter confirm, q/Esc cancel, ? help     │               │
 │               └──────────────────────────────────────────────┘               │
 │                                      ││                                      │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_dns_settings_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_dns_settings_overlay_snapshot.snap
@@ -18,7 +18,7 @@ expression: "snapshot_terminal(&model, 80, 24)"
 │               │               Fake-IP: ‹ off ›               │               │
 │               │                                              │               │
 │               │           j/k navigate, h/l change           │               │
-│               │          Enter confirm, q/Esc cancel         │               │
+│               │      Enter confirm, q/Esc cancel, ? help     │               │
 │               └──────────────────────────────────────────────┘               │
 │                                      ││                                      │
 │                                      ││                                      │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_dns_settings_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_dns_settings_overlay_snapshot.snap
@@ -11,13 +11,13 @@ expression: "snapshot_terminal(&model, 80, 24)"
 │               ┌ DNS ─────────────────────────────────────────┐               │
 │               │                 DNS settings                 │               │
 │               │                                              │               │
+│               │       Preset: Cloudflare DoH (1.1.1.1)       │               │
 │               │         Preset: Google DoT (8.8.8.8)         │               │
 │               │          Preset: Quad9 DoH (9.9.9.9)         │               │
 │               │        Preset: System resolver (local)       │               │
 │               │          > Strategy: ‹ prefer_ipv4 ›         │               │
 │               │               Fake-IP: ‹ off ›               │               │
 │               │                                              │               │
-│               │           j/k navigate, h/l change           │               │
 │               │      Enter confirm, q/Esc cancel, ? help     │               │
 │               └──────────────────────────────────────────────┘               │
 │                                      ││                                      │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_geo_region_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_geo_region_overlay_snapshot.snap
@@ -15,7 +15,7 @@ expression: "snapshot_terminal(&model, 80, 20)"
 │               │                    🇮🇷  Iran                   │               │
 │               │           🌍  Global (no geo rules)           │               │
 │               │                                              │               │
-│               │          j/k navigate, Enter confirm         │               │
+│               │      j/k navigate, Enter confirm, ? help     │               │
 │               └──────────────────────────────────────────────┘               │
 │                                      ││                                      │
 │                                      ││                                      │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_geo_region_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_geo_region_overlay_snapshot.snap
@@ -15,7 +15,7 @@ expression: "snapshot_terminal(&model, 80, 20)"
 │               │                    🇮🇷  Iran                   │               │
 │               │           🌍  Global (no geo rules)           │               │
 │               │                                              │               │
-│               │      j/k navigate, Enter confirm, ? help     │               │
+│               │             Enter confirm, ? help            │               │
 │               └──────────────────────────────────────────────┘               │
 │                                      ││                                      │
 │                                      ││                                      │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_help_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_help_overlay_snapshot.snap
@@ -6,38 +6,38 @@ expression: "snapshot_terminal(&model, 80, 40)"
 │↑ 0.0 KB/s  ↓ 0.0 KB/s    Total: ↑ 0.0 KB  ↓ 0.0 KB    0 connections          │
 └──────────────────────────────────────────────────────────────────────────────┘
 ┌ Sources ─────────────────────────────┐┌ Logs ────────────────────────────────┐
-│No sources. Pre┌ Help ────────────────────────────────────────┐               │
-│or subscription│Key          Action                           │               │
-│               │h / l        Focus Sources / Logs             │               │
-│               │j / Down     Move down                        │               │
-│               │k / Up       Move up                          │               │
-│               │gg           Go to first / buffer top         │               │
-│               │G            Go to last / buffer bottom       │               │
-│               │Enter        Connect to selected profile      │               │
-│               │p            Paste from clipboard             │               │
-│               │y            Yank selected source / log       │               │
-│               │Shift+V      Select multiple logs             │               │
-│               │d            Delete selected source           │               │
-│               │m            Routing mode (popup list)        │               │
-│               │o            Geo region                       │               │
-│               │u            Update subscription or geo       │               │
-│               │i            Cycle subscription auto-update   │               │
-│               │I            Cycle geo auto-update            │               │
-│               │e            Open profiles.json in $EDITOR    │               │
-│               │a            Toggle auto-connect              │               │
-│               │K            Toggle kill switch               │               │
-│               │D            DNS settings                     │               │
-│               │S            Service routing                  │               │
-│               │C            Theme picker                     │               │
-│               │t            Test selected profile latency    │               │
-│               │T            Test all profiles (batch)        │               │
-│               │r            Reconnect                        │               │
-│               │s            Stop / disconnect                │               │
-│               │q / Esc      Detach TUI                       │               │
-│               │Ctrl+C       Quit                             │               │
-│               │?            Show this help                   │               │
-│               │                                              │               │
-│               └──────────────────────────────────────────────┘               │
+│No sources.┌ Help — Sources ──────────────────────────────────────┐           │
+│or subscrip│  Key                Action                           │           │
+│           │> Enter              Connect to selected profile      │           │
+│           │  p                  Paste from clipboard             │           │
+│           │  y                  Yank selected source             │           │
+│           │  d                  Delete selected source           │           │
+│           │  u                  Update subscription or geo       │           │
+│           │  i                  Cycle subscription auto-update   │           │
+│           │  e                  Open profiles.json in $EDITOR    │           │
+│           │  t                  Test selected profile latency    │           │
+│           │  T                  Test all profiles                │           │
+│           │  r                  Reconnect                        │           │
+│           │  s                  Disconnect                       │           │
+│           │  a                  Toggle auto-connect              │           │
+│           │  K                  Toggle kill switch               │           │
+│           │  m                  Routing mode                     │           │
+│           │  o                  Geo region                       │           │
+│           │  D                  DNS settings                     │           │
+│           │  S                  Service routing                  │           │
+│           │  C                  Theme picker                     │           │
+│           │  I                  Cycle geo auto-update            │           │
+│           │  h/l / Left/Right   Focus Sources / Logs             │           │
+│           │  j / Down           Move down                        │           │
+│           │  k / Up             Move up                          │           │
+│           │  gg                 Go to first                      │           │
+│           │  G                  Go to last                       │           │
+│           │  q / Esc            Detach TUI                       │           │
+│           │  ?                  Show help                        │           │
+│           │  Ctrl+C             Quit daemon                      │           │
+│           │                Tab: show all commands                │           │
+│           │        j/k scroll · gg/G edges · q/Esc/? back        │           │
+│           └──────────────────────────────────────────────────────┘           │
 │                                      ││                                      │
 │                                      ││                                      │
 └──────────────────────────────────────┘└──────────────────────────────────────┘

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_routing_mode_overlay_global_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_routing_mode_overlay_global_snapshot.snap
@@ -12,8 +12,8 @@ expression: "snapshot_terminal(&model, 80, 20)"
 │               │                                              │               │
 │               │                   > Global                   │               │
 │               │                                              │               │
-│               │          j/k navigate, Enter confirm         │               │
-│               │             q/Esc cancel, ? help             │               │
+│               │      Enter confirm, q/Esc cancel, ? help     │               │
+│               │                                              │               │
 │               │                                              │               │
 │               │                                              │               │
 │               └──────────────────────────────────────────────┘               │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_routing_mode_overlay_global_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_routing_mode_overlay_global_snapshot.snap
@@ -12,8 +12,8 @@ expression: "snapshot_terminal(&model, 80, 20)"
 │               │                                              │               │
 │               │                   > Global                   │               │
 │               │                                              │               │
-│               │   j/k navigate, Enter confirm, q/Esc cancel  │               │
-│               │                                              │               │
+│               │          j/k navigate, Enter confirm         │               │
+│               │             q/Esc cancel, ? help             │               │
 │               │                                              │               │
 │               │                                              │               │
 │               └──────────────────────────────────────────────┘               │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_routing_mode_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_routing_mode_overlay_snapshot.snap
@@ -14,8 +14,8 @@ expression: "snapshot_terminal(&model, 80, 20)"
 │               │                   Bypass RU                  │               │
 │               │                   > Only RU                  │               │
 │               │                                              │               │
-│               │   j/k navigate, Enter confirm, q/Esc cancel  │               │
-│               │                                              │               │
+│               │          j/k navigate, Enter confirm         │               │
+│               │             q/Esc cancel, ? help             │               │
 │               └──────────────────────────────────────────────┘               │
 │                                      ││                                      │
 │                                      ││                                      │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_routing_mode_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_routing_mode_overlay_snapshot.snap
@@ -14,8 +14,8 @@ expression: "snapshot_terminal(&model, 80, 20)"
 │               │                   Bypass RU                  │               │
 │               │                   > Only RU                  │               │
 │               │                                              │               │
-│               │          j/k navigate, Enter confirm         │               │
-│               │             q/Esc cancel, ? help             │               │
+│               │      Enter confirm, q/Esc cancel, ? help     │               │
+│               │                                              │               │
 │               └──────────────────────────────────────────────┘               │
 │                                      ││                                      │
 │                                      ││                                      │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_service_routing_overlay_no_edits_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_service_routing_overlay_no_edits_snapshot.snap
@@ -15,7 +15,7 @@ expression: "snapshot_terminal(&model, 80, 24)"
 │               │            Telegram  ‹ Disabled ›            │               │
 │               │                                              │               │
 │               │           j/k navigate, h/l change           │               │
-│               │          Enter confirm, q/Esc cancel         │               │
+│               │      Enter confirm, q/Esc cancel, ? help     │               │
 │               │                                              │               │
 │               │                                              │               │
 │               │                                              │               │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_service_routing_overlay_no_edits_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_service_routing_overlay_no_edits_snapshot.snap
@@ -14,8 +14,8 @@ expression: "snapshot_terminal(&model, 80, 24)"
 │               │          > Steam     ‹ Disabled ›            │               │
 │               │            Telegram  ‹ Disabled ›            │               │
 │               │                                              │               │
-│               │           j/k navigate, h/l change           │               │
 │               │      Enter confirm, q/Esc cancel, ? help     │               │
+│               │                                              │               │
 │               │                                              │               │
 │               │                                              │               │
 │               │                                              │               │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_service_routing_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_service_routing_overlay_snapshot.snap
@@ -15,7 +15,7 @@ expression: "snapshot_terminal(&model, 80, 24)"
 │               │          > Telegram  ‹  Proxy   › *          │               │
 │               │                                              │               │
 │               │           j/k navigate, h/l change           │               │
-│               │          Enter confirm, q/Esc cancel         │               │
+│               │      Enter confirm, q/Esc cancel, ? help     │               │
 │               │                                              │               │
 │               │                                              │               │
 │               │                                              │               │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_service_routing_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_service_routing_overlay_snapshot.snap
@@ -14,8 +14,8 @@ expression: "snapshot_terminal(&model, 80, 24)"
 │               │            Steam     ‹  Direct  ›            │               │
 │               │          > Telegram  ‹  Proxy   › *          │               │
 │               │                                              │               │
-│               │           j/k navigate, h/l change           │               │
 │               │      Enter confirm, q/Esc cancel, ? help     │               │
+│               │                                              │               │
 │               │                                              │               │
 │               │                                              │               │
 │               │                                              │               │

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_theme_settings_overlay_light_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_theme_settings_overlay_light_snapshot.snap
@@ -28,9 +28,9 @@ expression: "snapshot_terminal(&model, 80, 32)"
 │               │                   solitude                   │               │
 │               │                  tokyo-night                 │               │
 │               │                  vantablack                  │               │
+│               │                     white                    │               │
 │               │                                              │               │
-│               │          j/k navigate, Enter confirm         │               │
-│               │             q/Esc cancel, ? help             │               │
+│               │      Enter confirm, q/Esc cancel, ? help     │               │
 │               └──────────────────────────────────────────────┘               │
 └──────────────────────────────────────┘└──────────────────────────────────────┘
 [DISCONNECTED] [DNS: DoH] [Global] [Geo: 2026-05-31 13:41]

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_theme_settings_overlay_light_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_theme_settings_overlay_light_snapshot.snap
@@ -28,9 +28,9 @@ expression: "snapshot_terminal(&model, 80, 32)"
 │               │                   solitude                   │               │
 │               │                  tokyo-night                 │               │
 │               │                  vantablack                  │               │
-│               │                     white                    │               │
 │               │                                              │               │
-│               │   j/k navigate, Enter confirm, q/Esc cancel  │               │
+│               │          j/k navigate, Enter confirm         │               │
+│               │             q/Esc cancel, ? help             │               │
 │               └──────────────────────────────────────────────┘               │
 └──────────────────────────────────────┘└──────────────────────────────────────┘
 [DISCONNECTED] [DNS: DoH] [Global] [Geo: 2026-05-31 13:41]

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_theme_settings_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_theme_settings_overlay_snapshot.snap
@@ -28,9 +28,9 @@ expression: "snapshot_terminal(&model, 80, 32)"
 │               │                   solitude                   │               │
 │               │                  tokyo-night                 │               │
 │               │                  vantablack                  │               │
+│               │                     white                    │               │
 │               │                                              │               │
-│               │          j/k navigate, Enter confirm         │               │
-│               │             q/Esc cancel, ? help             │               │
+│               │      Enter confirm, q/Esc cancel, ? help     │               │
 │               └──────────────────────────────────────────────┘               │
 └──────────────────────────────────────┘└──────────────────────────────────────┘
 [DISCONNECTED] [DNS: DoH] [Global] [Geo: 2026-05-31 13:41]

--- a/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_theme_settings_overlay_snapshot.snap
+++ b/src/ui/snapshots/kvn_tui__ui__layout__tests__draw_theme_settings_overlay_snapshot.snap
@@ -28,9 +28,9 @@ expression: "snapshot_terminal(&model, 80, 32)"
 │               │                   solitude                   │               │
 │               │                  tokyo-night                 │               │
 │               │                  vantablack                  │               │
-│               │                     white                    │               │
 │               │                                              │               │
-│               │   j/k navigate, Enter confirm, q/Esc cancel  │               │
+│               │          j/k navigate, Enter confirm         │               │
+│               │             q/Esc cancel, ? help             │               │
 │               └──────────────────────────────────────────────┘               │
 └──────────────────────────────────────┘└──────────────────────────────────────┘
 [DISCONNECTED] [DNS: DoH] [Global] [Geo: 2026-05-31 13:41]


### PR DESCRIPTION
## Summary

Replace the static help popup with context-aware command help that reflects the active pane or overlay while retaining access to a compact complete command reference.

## Changes

- Show commands relevant to Sources, Logs, or the currently open overlay.
- Preserve and restore the originating overlay, including draft values and selection state.
- Add a scrollable All mode with deduplicated commands ordered by context specificity.
- Keep connection, settings, and overlay shortcuts available from the Logs pane while blocking source-only actions.
- Support Left/Right pane focus switching alongside h/l.
- Add help hints to overlays and update UI snapshots.
- Simplified overlay footers to show only confirm, cancel, and help actions.
