### PR TITLE
fix(cli): enforce integration privilege boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ the kill switch can also be installed together:
 sudo kvn-tui setup --polkit --killswitch
 ```
 
+System setup and cleanup must be run through `sudo` from a non-root user.
+Unprivileged invocations and commands run directly from a root shell are
+rejected.
+
 Remove either system integration with:
 
 ```bash
@@ -176,6 +180,10 @@ integration with:
 ```bash
 kvn-tui setup --omarchy
 ```
+
+Run Omarchy setup and cleanup without `sudo`, because they modify the current
+user's configuration. `--omarchy` cannot be combined with `--polkit` or
+`--killswitch`; run the user and system commands separately.
 
 On **Omarchy 4 (Quattro)** this installs the standalone
 [omakvn](https://github.com/yarikov/omakvn) Quickshell bar plugin (`yarikov.omakvn`):

--- a/contrib/clean-killswitch.sh
+++ b/contrib/clean-killswitch.sh
@@ -30,6 +30,12 @@ if [[ $EUID -ne 0 ]]; then
     exit 1
 fi
 
+USER_NAME="${SUDO_USER:-}"
+if [[ -z "$USER_NAME" || "$USER_NAME" == "root" ]] || ! id "$USER_NAME" >/dev/null 2>&1; then
+    echo "Could not identify a non-root invoking user; run this command via sudo." >&2
+    exit 1
+fi
+
 if systemctl is-active --quiet "$UNIT"; then
     systemctl disable --now "$UNIT"
     if systemctl is-active --quiet "$UNIT"; then

--- a/contrib/clean-polkit.sh
+++ b/contrib/clean-polkit.sh
@@ -26,6 +26,12 @@ if [[ $EUID -ne 0 ]]; then
     exit 1
 fi
 
+USER_NAME="${SUDO_USER:-}"
+if [[ -z "$USER_NAME" || "$USER_NAME" == "root" ]] || ! id "$USER_NAME" >/dev/null 2>&1; then
+    echo "Could not identify a non-root invoking user; run this command via sudo." >&2
+    exit 1
+fi
+
 if [[ -e "$RULE_FILE" ]]; then
     rm -- "$RULE_FILE"
     echo "Removed $RULE_FILE"

--- a/contrib/setup-killswitch.sh
+++ b/contrib/setup-killswitch.sh
@@ -14,7 +14,7 @@ if [[ $EUID -ne 0 ]]; then
     exit 1
 fi
 
-USER_NAME="${SUDO_USER:-${USER:-}}"
+USER_NAME="${SUDO_USER:-}"
 if [[ -z "$USER_NAME" || "$USER_NAME" == "root" ]] || ! id "$USER_NAME" >/dev/null 2>&1; then
     echo "Could not identify a non-root invoking user; run this command via sudo." >&2
     exit 1

--- a/docs/system-integration.md
+++ b/docs/system-integration.md
@@ -47,6 +47,11 @@ Do not revoke them while another TUN client relies on the same sing-box binary.
 sudo kvn-tui setup --polkit
 ```
 
+System integration setup and cleanup must be run through `sudo` from a
+non-root user. Unprivileged invocations and commands run directly from a root
+shell are rejected. Polkit and the kill switch may be handled together with
+`--polkit --killswitch`.
+
 The command:
 
 - creates the dedicated system group `kvn-tui` and adds the invoking user if
@@ -134,8 +139,11 @@ persisted state is reconciled.
 kvn-tui setup --omarchy
 ```
 
-This command runs without sudo and changes only the current user's files. Both
-Omarchy generations install this executable launcher:
+This command runs without sudo and changes only the current user's files.
+Running it as root is rejected to prevent changes under `/root`. `--omarchy`
+cannot be combined with `--polkit` or `--killswitch`; run user-level and
+system-level commands separately. Both Omarchy generations install this
+executable launcher:
 
 ```text
 ~/.local/bin/omarchy-launch-kvn-tui

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,7 +72,7 @@ enum Command {
     ))]
     Setup {
         /// Set up Omarchy Shell/Waybar, launcher, and Hyprland integration.
-        #[arg(long)]
+        #[arg(long, conflicts_with_all = ["polkit", "killswitch"])]
         omarchy: bool,
 
         /// Set up polkit access for passwordless DNS management.
@@ -172,6 +172,53 @@ fn clean_killswitch() -> Result<()> {
         "clean-killswitch.sh",
         include_str!("../contrib/clean-killswitch.sh"),
         &[],
+    )
+}
+
+fn validate_integration_privileges(
+    omarchy: bool,
+    system: bool,
+    effective_uid: u32,
+    sudo_user: Option<&str>,
+    action: &str,
+) -> Result<()> {
+    if omarchy && effective_uid == 0 {
+        anyhow::bail!(
+            "Omarchy integration changes user files; run `kvn-tui {action} --omarchy` without sudo"
+        );
+    }
+
+    if system {
+        if effective_uid != 0 {
+            anyhow::bail!(
+                "system integration requires root privileges; run `sudo kvn-tui {action} --polkit` and/or `sudo kvn-tui {action} --killswitch`"
+            );
+        }
+        if !matches!(sudo_user, Some(user) if !user.is_empty() && user != "root") {
+            anyhow::bail!(
+                "could not identify a non-root invoking user; run this command via sudo from a non-root account"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_current_integration_privileges(
+    omarchy: bool,
+    polkit: bool,
+    killswitch: bool,
+    action: &str,
+) -> Result<()> {
+    #[allow(unsafe_code)]
+    let effective_uid = unsafe { libc::geteuid() };
+    let sudo_user = std::env::var("SUDO_USER").ok();
+    validate_integration_privileges(
+        omarchy,
+        polkit || killswitch,
+        effective_uid,
+        sudo_user.as_deref(),
+        action,
     )
 }
 
@@ -381,6 +428,7 @@ pub fn try_run_from_parsed(cli: &Cli) -> Option<Result<()>> {
             killswitch,
         }) => {
             let result = (|| {
+                validate_current_integration_privileges(*omarchy, *polkit, *killswitch, "setup")?;
                 if *omarchy {
                     install_omarchy()?;
                 }
@@ -400,6 +448,7 @@ pub fn try_run_from_parsed(cli: &Cli) -> Option<Result<()>> {
             killswitch,
         }) => {
             let result = (|| {
+                validate_current_integration_privileges(*omarchy, *polkit, *killswitch, "clean")?;
                 if *omarchy {
                     clean_omarchy()?;
                 }
@@ -617,16 +666,22 @@ esac
     }
 
     #[test]
-    fn setup_options_can_be_combined() {
-        let cli = Cli::parse_from(["kvn-tui", "setup", "--omarchy", "--polkit", "--killswitch"]);
+    fn setup_system_options_can_be_combined() {
+        let cli = Cli::parse_from(["kvn-tui", "setup", "--polkit", "--killswitch"]);
         assert!(matches!(
             cli.command,
             Some(Command::Setup {
-                omarchy: true,
+                omarchy: false,
                 polkit: true,
                 killswitch: true,
             })
         ));
+    }
+
+    #[test]
+    fn setup_omarchy_conflicts_with_system_integrations() {
+        assert!(Cli::try_parse_from(["kvn-tui", "setup", "--omarchy", "--polkit"]).is_err());
+        assert!(Cli::try_parse_from(["kvn-tui", "setup", "--omarchy", "--killswitch"]).is_err());
     }
 
     #[test]
@@ -672,6 +727,33 @@ esac
     }
 
     #[test]
+    fn integration_privileges_separate_user_and_system_actions() {
+        assert!(validate_integration_privileges(true, false, 1000, None, "setup").is_ok());
+        assert!(validate_integration_privileges(false, true, 0, Some("alice"), "setup").is_ok());
+
+        let omarchy_as_root =
+            validate_integration_privileges(true, false, 0, Some("alice"), "setup")
+                .unwrap_err()
+                .to_string();
+        assert!(omarchy_as_root.contains("without sudo"));
+
+        let system_as_user = validate_integration_privileges(false, true, 1000, None, "clean")
+            .unwrap_err()
+            .to_string();
+        assert!(system_as_user.contains("sudo kvn-tui clean"));
+    }
+
+    #[test]
+    fn system_integrations_require_non_root_sudo_user() {
+        for sudo_user in [None, Some(""), Some("root")] {
+            let error = validate_integration_privileges(false, true, 0, sudo_user, "setup")
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("non-root invoking user"));
+        }
+    }
+
+    #[test]
     fn embedded_system_scripts_have_valid_bash_syntax() {
         let _lock = crate::test_helpers::ENV_LOCK.lock().unwrap();
         for (name, script) in [
@@ -707,6 +789,20 @@ esac
         let killswitch = include_str!("../contrib/clean-killswitch.sh");
         assert!(killswitch.contains("/etc/polkit-1/rules.d/49-kvn-tui.rules"));
         assert!(killswitch.contains("groupdel \"$GROUP_NAME\""));
+    }
+
+    #[test]
+    fn system_scripts_require_sudo_user() {
+        for script in [
+            include_str!("../contrib/setup-polkit.sh"),
+            include_str!("../contrib/setup-killswitch.sh"),
+            include_str!("../contrib/clean-polkit.sh"),
+            include_str!("../contrib/clean-killswitch.sh"),
+        ] {
+            assert!(script.contains("SUDO_USER"));
+            assert!(script.contains("non-root invoking user"));
+        }
+        assert!(!include_str!("../contrib/setup-killswitch.sh").contains("${USER:-}"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Prevent integration setup and cleanup from running under the wrong user context. Omarchy actions now stay user-scoped, while polkit and kill-switch actions require sudo from a non-root account.

## Changes

- reject root execution for Omarchy setup and cleanup
- require a valid non-root `SUDO_USER` for system integration setup and cleanup
- prevent combining Omarchy flags with polkit or kill-switch flags
- align installer safeguards and document the required invocation modes
