### PR TITLE
ci(release): generate categorized release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,20 @@ env:
   INSTA_UPDATE: no
 
 jobs:
+  release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: orhun/git-cliff-action@v4.8.0
+        with:
+          version: v2.13.1
+          config: cliff.toml
+          args: --unreleased --strip header --offline
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+
   fmt:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
 
       - name: Debug tag info
         run: |
@@ -68,6 +69,17 @@ jobs:
         with:
           name: release-assets
 
+      - name: Generate categorized release notes
+        uses: orhun/git-cliff-action@v4.8.0
+        with:
+          version: v2.13.1
+          config: cliff.toml
+          args: --latest --strip header
+          github_token: ${{ github.token }}
+        env:
+          OUTPUT: release-notes.md
+          GITHUB_REPO: ${{ github.repository }}
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
@@ -76,4 +88,4 @@ jobs:
           files: |
             kvn-tui-*-x86_64-linux.tar.gz
             checksums.txt
-          generate_release_notes: true
+          body_path: release-notes.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,9 +60,15 @@ must use the same Conventional Commits format as a commit message:
 fix(subscription): support per-source request headers
 ```
 
-GitHub uses merged pull request titles to generate release notes. Write the
-title as a concise, user-facing changelog entry. A title such as `update code`
-will become an unhelpful public release note.
+`git-cliff` uses commit subjects to generate release notes. Since pull requests
+are squash-merged, their titles become those subjects. Write the title as a
+concise, user-facing changelog entry; `update code` would produce an unhelpful
+public release note.
+
+Release notes remove the Conventional Commit prefix and group pull requests as
+follows: `feat` becomes **New Features**; `fix` becomes **Bug Fixes**;
+`perf`, `refactor`, `docs`, and dependency chores become **Improvements**; and
+the remaining types become **Other**. `chore(release)` version bumps are omitted.
 
 The description must explain:
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -14,7 +14,7 @@ body = """\
 {% endfor -%}\
 {% set new_contributors = github.contributors | filter(attribute="is_first_time", value=true) %}\
 {% if new_contributors | length != 0 %}
-## New Contributors
+### New Contributors
 
 {% for contributor in new_contributors -%}
 * @{{ contributor.username }} made their first contribution\

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,44 @@
+[changelog]
+header = ""
+body = """\
+{% for group, commits in commits | group_by(attribute="group") -%}
+### {{ group | striptags | trim }}
+
+{% for commit in commits -%}
+* {{ commit.message }}\
+{% if commit.remote.username %} by @{{ commit.remote.username }}{%- endif %}\
+{% if commit.remote.pr_number %} in #{{ commit.remote.pr_number }}\
+{% else %} in [`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/commit/{{ commit.id }})\
+{% endif %}
+{% endfor %}
+{% endfor -%}\
+{% set new_contributors = github.contributors | filter(attribute="is_first_time", value=true) %}\
+{% if new_contributors | length != 0 %}
+## New Contributors
+
+{% for contributor in new_contributors -%}
+* @{{ contributor.username }} made their first contribution\
+{% if contributor.pr_number %} in #{{ contributor.pr_number }}{%- endif %}
+{% endfor -%}
+{% endif %}\
+{% if previous.version and version %}
+**Full Changelog**: https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/compare/{{ previous.version }}...{{ version }}
+{% endif %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+protect_breaking_commits = false
+filter_commits = false
+commit_parsers = [
+  { message = '^chore\(release\)', skip = true },
+  { message = '^feat', group = '<!-- 0 -->New Features' },
+  { message = '^chore\((dep|deps|dependencies)\)', group = '<!-- 1 -->Improvements' },
+  { message = '^(perf|refactor|docs)', group = '<!-- 1 -->Improvements' },
+  { message = '^fix', group = '<!-- 2 -->Bug Fixes' },
+  { message = '.*', group = '<!-- 3 -->Other' },
+]
+tag_pattern = 'v[0-9].*'
+sort_commits = "newest"


### PR DESCRIPTION
## Summary

Replace flat GitHub-generated release notes with categorized changelogs produced by git-cliff.

## Changes

- group release entries into New Features, Improvements, Bug Fixes, and Other
- omit release bump commits and remove Conventional Commit prefixes
- enrich entries with GitHub authors and PR numbers, falling back to commit links
- preserve new contributor and full changelog metadata
- validate the git-cliff configuration in CI
- document how commit types map to release note categories
