### PR TITLE
chore(config): use kvn0 as the TUN interface name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,7 +214,7 @@ The **TUI client** (`tui_client.rs`) additionally spawns:
 - `services/suspend.rs` runs a blocking zbus listener in a dedicated thread. On resume (`PrepareForSleep` with `false`), it sends `Msg::SystemResumed` through the `mpsc` channel so `update.rs` can schedule a reconnect effect.
 
 ### Kill Switch
-- Uses **nftables** + a systemd unit (`kvn-tui-killswitch.service`) that loads `/etc/kvn-tui/killswitch.nft`. The ruleset drops all outbound traffic except localhost, `tun*` interfaces, and packets marked `0x29a` by sing-box.
+- Uses **nftables** + a systemd unit (`kvn-tui-killswitch.service`) that loads `/etc/kvn-tui/killswitch.nft`. The ruleset drops all outbound traffic except localhost, `tun*`/`kvn*` interfaces, and packets marked `0x29a` by sing-box.
 - Privilege escalation via **sudoers NOPASSWD** (not polkit) — grants the `network` group passwordless access to `/usr/lib/kvn-tui/killswitch-helper.sh`. Installed with `sudo kvn-tui setup --killswitch`.
 - **Toggle flow**: `K` keybinding → `Effect::ApplyKillSwitch { enabled }` → daemon spawns thread calling `services::killswitch::apply(enabled)` → sends `Msg::KillSwitchApplied { enabled, error }` back. On success the boolean is flipped and config is saved; on error the boolean is unchanged and the error is shown.
 - **Reconciliation on startup**: daemon queries systemd to check whether the unit is actually active and aligns `settings.kill_switch` with the real state, preventing drift if the unit was manually disabled or the helper was uninstalled.

--- a/contrib/setup-killswitch.sh
+++ b/contrib/setup-killswitch.sh
@@ -57,6 +57,7 @@ table inet kvn_tui_killswitch {
         type filter hook input priority -10; policy drop;
         iifname "lo" accept
         iifname "tun*" accept
+        iifname "kvn*" accept
         ct state established,related accept
         meta l4proto { icmp, icmpv6 } accept
         ip saddr { 192.168.0.0/16, 10.0.0.0/8, 172.16.0.0/12 } accept
@@ -69,6 +70,7 @@ table inet kvn_tui_killswitch {
         type filter hook output priority -10; policy drop;
         oifname "lo" accept
         oifname "tun*" accept
+        oifname "kvn*" accept
         # Packets marked by sing-box (route.default_mark = 666 / 0x29a). This
         # allows the `direct` outbound used by Bypass/Only routing modes to
         # reach the physical interface; everything else still drops.
@@ -86,6 +88,7 @@ table inet kvn_tui_killswitch {
     chain forward {
         type filter hook forward priority -10; policy drop;
         oifname "tun*" accept
+        oifname "kvn*" accept
         ct state established,related accept
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,7 @@ A subscription contains `id`, `name`, `url`, `auto_update`, and an optional
 | Field | Default | Description |
 |-------|---------|-------------|
 | `default_profile` | `null` | UUID of the selected default profile |
-| `tun_interface` | `tun0` | Name of the sing-box TUN interface |
+| `tun_interface` | `kvn0` | Name of the sing-box TUN interface |
 | `dns` | Cloudflare DoH | DNS servers, rules, strategy, and fake-IP state |
 | `geo_routing` | no region | Country modes, rule-set updates, and service overrides |
 | `auto_connect` | `false` | Connect to `last_connected_profile` at startup |
@@ -207,6 +207,7 @@ Older files are migrated automatically:
 
 - v0 → v1 moves the legacy `dns_strategy` value into `dns.strategy`.
 - v1 → v2 moves the legacy VLESS `fingerprint` into the shared TLS settings.
+- v4 → v5 sets the TUN interface name to `kvn0`, replacing any previous name.
 
 A file with a schema version newer than the running kvn-tui build is rejected;
 upgrade kvn-tui instead of downgrading the version manually.

--- a/docs/system-integration.md
+++ b/docs/system-integration.md
@@ -108,7 +108,7 @@ accepts only:
 - `allow <ip> <tcp|udp> <port>`
 
 The nftables policy drops other input, output, and forwarded traffic while
-allowing loopback, `tun*`, established connections, private LAN ranges,
+allowing loopback, `tun*`/`kvn*`, established connections, private LAN ranges,
 DHCP, ICMP, and packets marked by sing-box. Temporary IPv4/IPv6 exceptions are
 added for VPN and DNS handshakes, then revoked on disconnect.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -120,7 +120,7 @@ mod tests {
         let path = PathBuf::from("/nonexistent/path/profiles.json");
         let config = load_config_at(&path).unwrap();
         assert!(config.profiles.is_empty());
-        assert_eq!(config.settings.tun_interface, "tun0");
+        assert_eq!(config.settings.tun_interface, "kvn0");
         assert_eq!(
             config.settings.dns_strategy,
             profile::DnsStrategy::PreferIpv4

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -1435,7 +1435,7 @@ fn validate_host(address: &str) -> anyhow::Result<()> {
 }
 
 fn default_tun_interface() -> String {
-    "tun0".to_string()
+    "kvn0".to_string()
 }
 
 fn default_dns_strategy() -> DnsStrategy {
@@ -1803,10 +1803,12 @@ impl Config {
     }
 
     /// v4 → v5: preserve the historical always-on latency probe and HTTP
-    /// subscription support while making both behaviors configurable.
+    /// subscription support while making both behaviors configurable, and
+    /// reset the TUN interface name to the app-specific one.
     fn migrate_v4_to_v5(&mut self) {
         self.settings.connectivity_probe = ConnectivityProbeConfig::default();
         self.settings.allow_insecure_http_subscriptions = true;
+        self.settings.tun_interface = default_tun_interface();
     }
 }
 
@@ -2109,7 +2111,7 @@ mod tests {
     #[test]
     fn settings_default() {
         let s = Settings::default();
-        assert_eq!(s.tun_interface, "tun0");
+        assert_eq!(s.tun_interface, "kvn0");
         assert_eq!(s.dns_strategy, DnsStrategy::PreferIpv4);
         assert!(s.default_profile.is_none());
         assert!(!s.auto_connect);
@@ -2228,7 +2230,7 @@ mod tests {
     fn config_default() {
         let c = Config::default();
         assert!(c.profiles.is_empty());
-        assert_eq!(c.settings.tun_interface, "tun0");
+        assert_eq!(c.settings.tun_interface, "kvn0");
     }
 
     #[test]
@@ -2442,7 +2444,7 @@ mod tests {
         let json = r#"{}"#;
         let c: Config = serde_json::from_str(json).unwrap();
         assert!(c.profiles.is_empty());
-        assert_eq!(c.settings.tun_interface, "tun0");
+        assert_eq!(c.settings.tun_interface, "kvn0");
     }
 
     #[test]
@@ -3910,6 +3912,7 @@ mod tests {
             schema_version: 4,
             ..Config::default()
         };
+        cfg.settings.tun_interface = "tun0".into();
         cfg.settings.connectivity_probe = ConnectivityProbeConfig {
             enabled: false,
             url: None,
@@ -3925,6 +3928,20 @@ mod tests {
             Some("https://connectivitycheck.gstatic.com/generate_204")
         );
         assert!(cfg.settings.allow_insecure_http_subscriptions);
+        assert_eq!(cfg.settings.tun_interface, "kvn0");
+    }
+
+    #[test]
+    fn migrate_v4_to_v5_replaces_custom_tun_interface() {
+        let mut cfg = Config {
+            schema_version: 4,
+            ..Config::default()
+        };
+        cfg.settings.tun_interface = "work-vpn".into();
+
+        cfg.migrate().unwrap();
+
+        assert_eq!(cfg.settings.tun_interface, "kvn0");
     }
 
     #[test]

--- a/src/tui_client.rs
+++ b/src/tui_client.rs
@@ -323,7 +323,7 @@ pub fn run_docs_preview(theme_slug: &str) -> Result<()> {
     for line in [
         "[app] Starting connection to 🇺🇸 United States",
         "[sb] 17:43:01 INFO network: updated default interface wlp1s0, index 2",
-        "[sb] 17:43:01 INFO inbound/tun[tun-in]: started at tun0",
+        "[sb] 17:43:01 INFO inbound/tun[tun-in]: started at kvn0",
         "[sb] 17:43:02 INFO outbound/trojan[proxy]: connected to us.demo.example:443",
         "[app] Connection established; traffic statistics are live",
         "[sb] 17:43:03 INFO inbound/tun[tun-in]: inbound packet connection to 10.222.0.2:53",


### PR DESCRIPTION
## Summary

Use the application-specific `kvn0` name for the sing-box TUN interface instead of the generic `tun0`.

## Changes

- set `kvn0` as the default TUN interface name
- update the v4 → v5 migration to replace the previous interface name with `kvn0`
- allow `kvn*` interfaces through the kill switch while retaining compatibility with `tun*`
- update configuration and system integration documentation
