### PR TITLE
feat(config): add conflict-safe persistence

### DIFF
--- a/src/app/effect.rs
+++ b/src/app/effect.rs
@@ -1,4 +1,4 @@
-use crate::config::profile::{Profile, Settings};
+use crate::config::profile::{Config, Profile, Settings};
 use uuid::Uuid;
 
 #[derive(Debug, PartialEq)]
@@ -29,6 +29,14 @@ pub enum Effect {
     ResetGeoUpdateSchedules,
     WriteState,
     SaveConfig,
+    SaveConfigConflict {
+        edited: Box<Config>,
+        conflicts: Vec<String>,
+    },
+    CommitEditedConfig {
+        base: Box<Config>,
+        edited: Box<Config>,
+    },
     UpdateSubscription {
         id: Uuid,
     },

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -3,10 +3,10 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::Instant;
 use uuid::Uuid;
 
+use crate::config::load_config;
 use crate::config::profile::{
     Config, DnsStrategy, GeoRegion, Profile, RoutedService, ServiceRoute,
 };
-use crate::config::{load_config, save_config};
 use crate::ui::styles::Theme;
 use chrono::{DateTime, Local};
 
@@ -200,6 +200,9 @@ pub struct Model {
     pub main_pane_focus: MainPaneFocus,
     pub connection: ConnectionState,
     pub config: Config,
+    /// Prevents a fallback config from overwriting an unreadable persisted
+    /// config. Cleared only after a successful reload from disk.
+    pub config_persistence_blocked: bool,
     pub selected: usize,
     pub status: AppStatus,
     pub singbox_pid: Option<u32>,
@@ -322,6 +325,7 @@ impl Model {
     /// (see the `startup_error` block near the end of this function).
     pub fn new() -> anyhow::Result<Self> {
         let mut startup_error: Option<String> = None;
+        let mut config_persistence_blocked = false;
         let config = match load_config() {
             Ok(cfg) => match cfg.validate() {
                 Ok(()) => cfg,
@@ -329,6 +333,7 @@ impl Model {
                     let msg = format!("Config invalid, using defaults: {e:#}");
                     tracing::error!("{msg}");
                     startup_error = Some(msg);
+                    config_persistence_blocked = true;
                     Config::default()
                 }
             },
@@ -336,6 +341,7 @@ impl Model {
                 let msg = format!("Failed to load config, using defaults: {e:#}");
                 tracing::error!("{msg}");
                 startup_error = Some(msg);
+                config_persistence_blocked = true;
                 Config::default()
             }
         };
@@ -418,6 +424,7 @@ impl Model {
             main_pane_focus: MainPaneFocus::Sources,
             connection,
             config,
+            config_persistence_blocked,
             selected,
             status: AppStatus::Info(String::new()),
             singbox_pid: None,
@@ -522,6 +529,7 @@ impl Model {
             main_pane_focus: MainPaneFocus::Sources,
             connection: ConnectionState::Idle,
             config,
+            config_persistence_blocked: false,
             selected,
             status: AppStatus::Info(String::new()),
             singbox_pid: None,
@@ -601,11 +609,6 @@ impl Model {
             default_selected,
             AppStatus::Info("Press ? for help".to_string()),
         )
-    }
-
-    /// Save current configuration to disk.
-    pub fn save(&self) -> anyhow::Result<()> {
-        save_config(&self.config)
     }
 
     /// Build the flat list of selectable rows for the current config.
@@ -751,6 +754,7 @@ impl Model {
             main_pane_focus: MainPaneFocus::Sources,
             connection: ConnectionState::Idle,
             config,
+            config_persistence_blocked: false,
             selected,
             status: AppStatus::Info(String::new()),
             singbox_pid: None,
@@ -1076,23 +1080,8 @@ mod tests {
             "logs: {:?}",
             model.logs,
         );
-    }
-
-    #[test]
-    fn model_save_roundtrip() {
-        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
-        let dir = tempfile::tempdir().unwrap();
-        unsafe { std::env::set_var("XDG_CONFIG_HOME", dir.path()) };
-
-        let model = model_with_profiles(vec![Profile::new_vless(
-            "Alpha".to_string(),
-            "1.1.1.1".to_string(),
-            443,
-            crate::test_helpers::TEST_UUID.to_string(),
-        )]);
-        // Save should not panic and must write into the temp directory.
-        let _ = model.save();
-        assert!(crate::paths::profiles_path().unwrap().exists());
+        assert!(model.config_persistence_blocked);
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "not json at all");
     }
 
     #[test]

--- a/src/app/msg.rs
+++ b/src/app/msg.rs
@@ -252,6 +252,10 @@ pub enum IpcCommand {
         count: usize,
     },
     ReloadConfig,
+    ApplyEditedConfig {
+        base: Box<crate::config::profile::Config>,
+        edited: Box<crate::config::profile::Config>,
+    },
     Quit,
     /// Client-side failure the daemon owns none of — e.g. the external editor
     /// path rejecting an edit. The daemon writes it into its model's status
@@ -330,6 +334,10 @@ mod tests {
                 count: 2,
             },
             IpcCommand::ReloadConfig,
+            IpcCommand::ApplyEditedConfig {
+                base: Box::new(crate::config::profile::Config::default()),
+                edited: Box::new(crate::config::profile::Config::default()),
+            },
             IpcCommand::Quit,
         ];
         for cmd in cmds {

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -465,7 +465,7 @@ fn append_download_hint(effects: &mut Vec<Effect>, model: &Model, kind: Download
     });
 }
 
-fn handle_config_reloaded(
+pub(crate) fn handle_config_reloaded(
     model: &mut Model,
     result: Result<crate::config::profile::Config, crate::app::msg::IpcError>,
 ) -> Vec<Effect> {
@@ -501,6 +501,7 @@ fn handle_config_reloaded(
             let region_changed = model.config.settings.geo_routing.current_region
                 != config.settings.geo_routing.current_region;
             model.replace_config_preserving_selection(config);
+            model.config_persistence_blocked = false;
             let mut effects = vec![Effect::BroadcastState];
             if active_missing || connecting_missing {
                 effects.push(Effect::Disconnect);
@@ -1613,6 +1614,51 @@ mod tests {
         assert_eq!(effects, vec![Effect::ReloadConfig, Effect::BroadcastState]);
     }
 
+    #[test]
+    fn ipc_apply_edited_config_merges_concurrent_setting_change() {
+        let mut model = model_with_profiles(vec![]);
+        let base = model.config.clone();
+        model.config.settings.auto_connect = true;
+        let mut edited = base.clone();
+        edited.settings.theme = "nord".into();
+
+        let effects = handle_ipc_command(
+            &mut model,
+            crate::app::msg::IpcCommand::ApplyEditedConfig {
+                base: Box::new(base),
+                edited: Box::new(edited),
+            },
+        );
+
+        assert!(model.config.settings.auto_connect);
+        assert_eq!(model.config.settings.theme, "tokyo-night");
+        assert!(matches!(
+            &effects[0],
+            Effect::CommitEditedConfig { base: effect_base, edited: effect_edited }
+                if effect_base.settings.theme == "tokyo-night" && effect_edited.settings.theme == "nord"
+        ));
+    }
+
+    #[test]
+    fn ipc_apply_edited_config_preserves_current_on_conflict() {
+        let mut model = model_with_profiles(vec![]);
+        let base = model.config.clone();
+        model.config.settings.theme = "nord".into();
+        let mut edited = base.clone();
+        edited.settings.theme = "catppuccin".into();
+
+        let effects = handle_ipc_command(
+            &mut model,
+            crate::app::msg::IpcCommand::ApplyEditedConfig {
+                base: Box::new(base),
+                edited: Box::new(edited),
+            },
+        );
+
+        assert_eq!(model.config.settings.theme, "nord");
+        assert!(matches!(effects[0], Effect::CommitEditedConfig { .. }));
+    }
+
     // ---- semantic IPC commands (bar widget / CLI clients) ----
 
     fn connected_model() -> (Model, Uuid) {
@@ -1869,7 +1915,9 @@ mod tests {
         )]);
         model.config.settings.geo_routing.set_region(GeoRegion::Ru);
         let config = model.config.clone();
+        model.config_persistence_blocked = true;
         let effects = update(&mut model, Msg::ConfigReloaded(Box::new(Ok(config))));
+        assert!(!model.config_persistence_blocked);
         assert_eq!(
             effects,
             vec![Effect::BroadcastState, app_log_info("Profiles reloaded")]

--- a/src/app/update/key.rs
+++ b/src/app/update/key.rs
@@ -522,7 +522,7 @@ pub(super) fn handle_ipc_command(
     cmd: crate::app::msg::IpcCommand,
 ) -> Vec<Effect> {
     use crate::app::msg::IpcCommand;
-    let mut effects = match cmd {
+    let effects = match cmd {
         IpcCommand::Attach => vec![],
         IpcCommand::Detach => vec![],
         IpcCommand::Key { code, char, ctrl } => {
@@ -624,6 +624,24 @@ pub(super) fn handle_ipc_command(
         IpcCommand::ReloadConfig => {
             vec![Effect::ReloadConfig]
         }
+        IpcCommand::ApplyEditedConfig { base, edited } => {
+            if model.config_persistence_blocked {
+                let conflicts = vec!["persisted config failed to load".to_string()];
+                let mut result = vec![Effect::SaveConfigConflict {
+                    edited,
+                    conflicts: conflicts.clone(),
+                }];
+                push_status(
+                    &mut result,
+                    model,
+                    AppStatus::Error(
+                        "Cannot apply an edit over an unreadable profiles.json".into(),
+                    ),
+                );
+                return finish_ipc_effects(result);
+            }
+            vec![Effect::CommitEditedConfig { base, edited }]
+        }
         IpcCommand::Quit => vec![Effect::Quit],
         IpcCommand::ClientError { message } => {
             let mut inner = Vec::new();
@@ -631,6 +649,10 @@ pub(super) fn handle_ipc_command(
             inner
         }
     };
+    finish_ipc_effects(effects)
+}
+
+fn finish_ipc_effects(mut effects: Vec<Effect>) -> Vec<Effect> {
     effects.push(Effect::BroadcastState);
     effects
 }

--- a/src/atomic_write.rs
+++ b/src/atomic_write.rs
@@ -13,6 +13,17 @@ use anyhow::{Context, Result};
 /// metadata can be lost after a power cut even though the file contents are
 /// persisted — leaving the user with an empty or stale `dest`.
 pub fn write(dest: &Path, data: &[u8]) -> Result<()> {
+    write_inner(dest, data, None)
+}
+
+/// Atomically write `data` only while the destination still has the bytes the
+/// caller previously read. The comparison happens after the temporary file is
+/// durable and immediately before rename.
+pub fn write_if_unchanged(dest: &Path, data: &[u8], expected: Option<&[u8]>) -> Result<()> {
+    write_inner(dest, data, Some(expected))
+}
+
+fn write_inner(dest: &Path, data: &[u8], expected: Option<Option<&[u8]>>) -> Result<()> {
     let dir = dest
         .parent()
         .with_context(|| format!("Atomic write: dest {:?} has no parent", dest))?;
@@ -38,6 +49,21 @@ pub fn write(dest: &Path, data: &[u8]) -> Result<()> {
             .with_context(|| format!("Failed to write temp file {:?}", temp))?;
         file.sync_all()
             .with_context(|| format!("Failed to fsync temp file {:?}", temp))?;
+    }
+
+    if let Some(expected) = expected {
+        let actual = match fs::read(dest) {
+            Ok(bytes) => Some(bytes),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => {
+                let _ = fs::remove_file(&temp);
+                return Err(error).context("Failed to verify destination revision");
+            }
+        };
+        if actual.as_deref() != expected {
+            let _ = fs::remove_file(&temp);
+            anyhow::bail!("destination changed since it was read");
+        }
     }
 
     fs::rename(&temp, dest)
@@ -117,5 +143,24 @@ mod tests {
         write(&path, b"new").unwrap();
         let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600, "expected 0600, got {:o}", mode);
+    }
+
+    #[test]
+    fn conditional_write_rejects_changed_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("profiles.json");
+        fs::write(&path, b"newer").unwrap();
+        assert!(write_if_unchanged(&path, b"ours", Some(b"older")).is_err());
+        assert_eq!(fs::read(&path).unwrap(), b"newer");
+        assert!(!dir.path().join("profiles.json.tmp").exists());
+    }
+
+    #[test]
+    fn conditional_write_accepts_matching_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("profiles.json");
+        fs::write(&path, b"old").unwrap();
+        write_if_unchanged(&path, b"new", Some(b"old")).unwrap();
+        assert_eq!(fs::read(&path).unwrap(), b"new");
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,7 @@
 use anyhow::{Context, Result};
 use clap::{ArgGroup, Parser, Subcommand};
+use std::io::{BufRead, Write};
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -63,6 +65,12 @@ enum Command {
     /// Connect the last-used profile, or disconnect when connected.
     Toggle,
 
+    /// Recover or reset profiles.json while the daemon is stopped.
+    Config {
+        #[command(subcommand)]
+        command: ConfigCommand,
+    },
+
     /// Set up one or more optional kvn-tui integrations.
     #[command(group(
         ArgGroup::new("targets")
@@ -104,6 +112,114 @@ enum Command {
         #[arg(long)]
         killswitch: bool,
     },
+}
+
+#[derive(Debug, Subcommand)]
+enum ConfigCommand {
+    /// Archive the current file and create a default configuration.
+    Reset {
+        /// Confirm the reset (the old file is preserved, not deleted).
+        #[arg(long)]
+        yes: bool,
+    },
+    /// Validate a saved configuration and install it as profiles.json.
+    Recover {
+        /// Configuration or conflict file to restore.
+        file: PathBuf,
+    },
+}
+
+fn recovery_archive_path(path: &Path) -> PathBuf {
+    path.with_file_name(format!(
+        "profiles.json.invalid-{}-{}",
+        chrono::Local::now().format("%Y%m%dT%H%M%S"),
+        Uuid::new_v4()
+    ))
+}
+
+fn require_daemon_stopped() -> Result<()> {
+    anyhow::ensure!(
+        !crate::ipc::is_daemon_running(),
+        "stop the kvn-tui daemon before changing profiles.json"
+    );
+    Ok(())
+}
+
+fn archive_current(path: &Path) -> Result<Option<PathBuf>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let archive = recovery_archive_path(path);
+    let contents = std::fs::read(path).context("failed to read profiles.json before archiving")?;
+    crate::atomic_write::write(&archive, &contents)
+        .with_context(|| format!("failed to archive profiles.json to {}", archive.display()))?;
+    Ok(Some(archive))
+}
+
+fn confirm_config_reset<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> Result<bool> {
+    write!(
+        output,
+        "Archive the current configuration and create a default one? [y/N] "
+    )?;
+    output.flush()?;
+    let mut answer = String::new();
+    input.read_line(&mut answer)?;
+    Ok(matches!(
+        answer.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}
+
+fn run_config_reset(yes: bool) -> Result<()> {
+    require_daemon_stopped()?;
+    if !yes {
+        let stdin = std::io::stdin();
+        let stdout = std::io::stdout();
+        if !confirm_config_reset(&mut stdin.lock(), &mut stdout.lock())? {
+            println!("Config reset cancelled");
+            return Ok(());
+        }
+    }
+    let path = crate::paths::profiles_path().context("Failed to determine profiles path")?;
+    let archived = archive_current(&path)?;
+    crate::config::save_config_at(&path, &crate::config::profile::Config::default())
+        .context("failed to create default config")?;
+    match archived {
+        Some(path) => println!(
+            "Created default config; previous file archived at {}",
+            path.display()
+        ),
+        None => println!("Created default config at {}", path.display()),
+    }
+    Ok(())
+}
+
+fn run_config_recover(file: &Path) -> Result<()> {
+    require_daemon_stopped()?;
+    anyhow::ensure!(
+        file.is_file(),
+        "recovery file does not exist or is not a regular file"
+    );
+    let path = crate::paths::profiles_path().context("Failed to determine profiles path")?;
+    if path.exists() && file.exists() {
+        let source = std::fs::canonicalize(file)?;
+        let destination = std::fs::canonicalize(&path)?;
+        anyhow::ensure!(
+            source != destination,
+            "recovery file is already profiles.json"
+        );
+    }
+    let recovered = crate::config::load_config_at_read_only(file)
+        .with_context(|| format!("failed to load recovery file {}", file.display()))?;
+    recovered.validate().context("recovery config is invalid")?;
+    let archived = archive_current(&path)?;
+    crate::config::save_config_at(&path, &recovered)
+        .context("failed to install recovery config")?;
+    println!("Recovered config from {}", file.display());
+    if let Some(path) = archived {
+        println!("Previous file archived at {}", path.display());
+    }
+    Ok(())
 }
 
 /// Run a trusted, compile-time embedded shell script without materializing it
@@ -422,6 +538,12 @@ pub fn try_run_from_parsed(cli: &Cli) -> Option<Result<()>> {
         Some(Command::Disconnect) => return Some(run_disconnect()),
         Some(Command::Reconnect) => return Some(run_reconnect()),
         Some(Command::Toggle) => return Some(run_toggle()),
+        Some(Command::Config { command }) => {
+            return Some(match command {
+                ConfigCommand::Reset { yes } => run_config_reset(*yes),
+                ConfigCommand::Recover { file } => run_config_recover(file),
+            });
+        }
         Some(Command::Setup {
             omarchy,
             polkit,
@@ -572,6 +694,43 @@ esac
             .env("PATH", path)
             .output()
             .unwrap()
+    }
+
+    #[test]
+    fn parses_config_recovery_commands() {
+        assert!(matches!(
+            Cli::parse_from(["kvn-tui", "config", "reset", "--yes"]).command,
+            Some(Command::Config {
+                command: ConfigCommand::Reset { yes: true }
+            })
+        ));
+        assert!(matches!(
+            Cli::parse_from(["kvn-tui", "config", "recover", "saved.json"]).command,
+            Some(Command::Config { command: ConfigCommand::Recover { file } })
+                if file == Path::new("saved.json")
+        ));
+    }
+
+    #[test]
+    fn config_reset_confirmation_accepts_only_explicit_yes() {
+        for answer in ["y\n", "Y\n", "yes\n", " YES \n"] {
+            let mut output = Vec::new();
+            assert!(confirm_config_reset(&mut answer.as_bytes(), &mut output).unwrap());
+            assert!(String::from_utf8(output).unwrap().ends_with("[y/N] "));
+        }
+        for answer in ["\n", "n\n", "no\n", "anything\n", ""] {
+            assert!(!confirm_config_reset(&mut answer.as_bytes(), &mut Vec::new()).unwrap());
+        }
+    }
+
+    #[test]
+    fn recovery_archive_keeps_live_file_in_place() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("profiles.json");
+        fs::write(&path, b"secret config").unwrap();
+        let archive = archive_current(&path).unwrap().unwrap();
+        assert_eq!(fs::read(&path).unwrap(), b"secret config");
+        assert_eq!(fs::read(archive).unwrap(), b"secret config");
     }
 
     fn backup_files(path: &Path) -> Vec<PathBuf> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
+pub(crate) mod merge;
 pub mod profile;
 pub mod subscription;
 
@@ -17,17 +18,40 @@ pub fn load_config_at(path: &Path) -> Result<Config> {
     let contents =
         fs::read_to_string(path).with_context(|| format!("Failed to read {:?}", path))?;
 
-    let mut config: Config =
-        serde_json::from_str(&contents).with_context(|| format!("Failed to parse {:?}", path))?;
+    let mut config = parse_config(&contents, path)?;
     let loaded_schema_version = config.schema_version;
     config
         .migrate()
         .with_context(|| format!("Failed to migrate {:?}", path))?;
     if config.schema_version != loaded_schema_version && config.validate().is_ok() {
-        save_config_at(path, &config)
+        save_config_at_revision(path, &config, Some(contents.as_bytes()))
             .with_context(|| format!("Failed to persist migration for {:?}", path))?;
     }
 
+    Ok(config)
+}
+
+fn parse_config(contents: &str, path: &Path) -> Result<Config> {
+    serde_json::from_str(contents).with_context(|| format!("Failed to parse {:?}", path))
+}
+
+/// Load and migrate a configuration without modifying the source file.
+pub(crate) fn load_config_at_read_only(path: &Path) -> Result<Config> {
+    if !path.exists() {
+        return Ok(Config::default());
+    }
+    let contents =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {:?}", path))?;
+    load_config_bytes_read_only(contents.as_bytes(), path)
+}
+
+pub(crate) fn load_config_bytes_read_only(contents: &[u8], path: &Path) -> Result<Config> {
+    let contents = std::str::from_utf8(contents)
+        .with_context(|| format!("Config {:?} is not valid UTF-8", path))?;
+    let mut config = parse_config(contents, path)?;
+    config
+        .migrate()
+        .with_context(|| format!("Failed to migrate {:?}", path))?;
     Ok(config)
 }
 
@@ -36,22 +60,36 @@ pub fn load_config_at(path: &Path) -> Result<Config> {
 /// Fail-close on invalid input: [`Config::validate`] runs before the file is
 /// touched, so a broken in-memory state cannot overwrite a good `profiles.json`.
 pub fn save_config_at(path: &Path, config: &Config) -> Result<()> {
+    let dir = path.parent().context("Invalid config path")?;
+    fs::create_dir_all(dir)?;
+    let json = serialized_config(config)?;
+    crate::atomic_write::write(path, json.as_bytes())?;
+    Ok(())
+}
+
+fn serialized_config(config: &Config) -> Result<String> {
     config
         .validate()
         .context("Refusing to save invalid config")?;
-
-    let dir = path.parent().context("Invalid config path")?;
-    fs::create_dir_all(dir)?;
 
     // Mirror `dns.strategy` into the legacy `dns_strategy` field so configs
     // remain readable by older kvn-tui builds during the deprecation window.
     let mut serializable = config.clone();
     serializable.settings.dns_strategy = serializable.settings.dns.strategy.clone();
 
-    let json = serde_json::to_string_pretty(&serializable)?;
-    crate::atomic_write::write(path, json.as_bytes())?;
+    Ok(serde_json::to_string_pretty(&serializable)?)
+}
 
-    Ok(())
+/// Save only if `profiles.json` has not changed since `expected` was read.
+pub(crate) fn save_config_at_revision(
+    path: &Path,
+    config: &Config,
+    expected: Option<&[u8]>,
+) -> Result<()> {
+    let dir = path.parent().context("Invalid config path")?;
+    fs::create_dir_all(dir)?;
+    let json = serialized_config(config)?;
+    crate::atomic_write::write_if_unchanged(path, json.as_bytes(), expected)
 }
 
 /// Load configuration from disk, or return default if not present.
@@ -97,9 +135,21 @@ fn ensure_hwid(config: &mut Config, path: &Path) -> Result<()> {
 }
 
 /// Save configuration to disk atomically.
+#[cfg(test)]
 pub fn save_config(config: &Config) -> Result<()> {
     let path = crate::paths::profiles_path().context("Failed to determine profiles path")?;
     save_config_at(&path, config)
+}
+
+pub(crate) fn save_conflict_config(config: &Config) -> Result<std::path::PathBuf> {
+    let original = crate::paths::profiles_path().context("Failed to determine profiles path")?;
+    let path = original.with_file_name(format!(
+        "profiles.json.conflict-{}-{}",
+        chrono::Local::now().format("%Y%m%dT%H%M%S"),
+        uuid::Uuid::new_v4()
+    ));
+    save_config_at(&path, config)?;
+    Ok(path)
 }
 
 #[cfg(test)]
@@ -378,5 +428,16 @@ mod tests {
         let loaded = load_config().unwrap();
         assert_eq!(loaded.profiles.len(), 1);
         assert_eq!(loaded.profiles[0].name, "PathTest");
+    }
+
+    #[test]
+    fn read_only_load_migrates_without_rewriting_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("recovery.json");
+        let original = r#"{"schema_version":4,"profiles":[],"settings":{}}"#;
+        std::fs::write(&path, original).unwrap();
+        let loaded = load_config_at_read_only(&path).unwrap();
+        assert_eq!(loaded.schema_version, profile::CURRENT_SCHEMA_VERSION);
+        assert_eq!(std::fs::read_to_string(path).unwrap(), original);
     }
 }

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -1,0 +1,335 @@
+use std::collections::{BTreeSet, HashMap};
+
+use anyhow::Context;
+use serde_json::Value;
+
+use super::profile::Config;
+
+pub(crate) fn merge_configs(
+    base: &Config,
+    current: &Config,
+    edited: &Config,
+) -> Result<Config, Vec<String>> {
+    for (label, config) in [("base", base), ("current", current), ("edited", edited)] {
+        if let Err(error) = config.validate() {
+            return Err(vec![format!("{label} config is invalid: {error}")]);
+        }
+    }
+    let base = serde_json::to_value(base).expect("Config serialization cannot fail");
+    let current = serde_json::to_value(current).expect("Config serialization cannot fail");
+    let edited = serde_json::to_value(edited).expect("Config serialization cannot fail");
+    let mut conflicts = Vec::new();
+    let merged = merge_value(
+        Some(&base),
+        Some(&current),
+        Some(&edited),
+        "",
+        &mut conflicts,
+    );
+    if !conflicts.is_empty() {
+        return Err(conflicts);
+    }
+    let config: Config = serde_json::from_value(merged.expect("root config cannot be deleted"))
+        .context("merged config is invalid")
+        .map_err(|error| vec![error.to_string()])?;
+    let mut config = config;
+    if config
+        .settings
+        .last_connected_profile
+        .is_some_and(|id| !config.profiles.iter().any(|profile| profile.id == id))
+    {
+        config.settings.last_connected_profile = None;
+    }
+    config
+        .validate()
+        .context("merged config failed validation")
+        .map_err(|error| vec![error.to_string()])?;
+    Ok(config)
+}
+
+fn merge_value(
+    base: Option<&Value>,
+    current: Option<&Value>,
+    edited: Option<&Value>,
+    path: &str,
+    conflicts: &mut Vec<String>,
+) -> Option<Value> {
+    if edited == base {
+        return current.cloned();
+    }
+    if current == base {
+        return edited.cloned();
+    }
+    if current == edited {
+        return current.cloned();
+    }
+
+    match (base, current, edited) {
+        (Some(Value::Object(b)), Some(Value::Object(c)), Some(Value::Object(e))) => {
+            let keys: BTreeSet<_> = b.keys().chain(c.keys()).chain(e.keys()).collect();
+            let mut out = serde_json::Map::new();
+            for key in keys {
+                let child_path = if path.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{path}.{key}")
+                };
+                if let Some(value) =
+                    merge_value(b.get(key), c.get(key), e.get(key), &child_path, conflicts)
+                {
+                    out.insert(key.clone(), value);
+                }
+            }
+            Some(Value::Object(out))
+        }
+        (Some(Value::Array(b)), Some(Value::Array(c)), Some(Value::Array(e)))
+            if path == "profiles" || path == "subscriptions" =>
+        {
+            merge_uuid_array(b, c, e, path, conflicts)
+        }
+        _ => {
+            conflicts.push(if path.is_empty() {
+                "configuration".into()
+            } else {
+                path.into()
+            });
+            current.cloned()
+        }
+    }
+}
+
+fn merge_uuid_array(
+    base: &[Value],
+    current: &[Value],
+    edited: &[Value],
+    path: &str,
+    conflicts: &mut Vec<String>,
+) -> Option<Value> {
+    fn index(values: &[Value]) -> HashMap<String, &Value> {
+        values
+            .iter()
+            .filter_map(|value| {
+                value
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .map(|id| (id.to_owned(), value))
+            })
+            .collect()
+    }
+    let b = index(base);
+    let c = index(current);
+    let e = index(edited);
+    let id_order = |values: &[Value]| {
+        values
+            .iter()
+            .filter_map(|value| value.get("id").and_then(Value::as_str).map(str::to_owned))
+            .collect::<Vec<_>>()
+    };
+    let base_order = id_order(base);
+    let current_order = id_order(current);
+    let edited_order = id_order(edited);
+    let current_reordered = common_order_changed(&base_order, &current_order);
+    let edited_reordered = common_order_changed(&base_order, &edited_order);
+    if current_reordered && edited_reordered && current_order != edited_order {
+        conflicts.push(format!("{path} order"));
+    }
+    let mut ids = Vec::new();
+    let first = if edited_reordered { edited } else { current };
+    let second = if edited_reordered { current } else { edited };
+    for value in first.iter().chain(second) {
+        if let Some(id) = value.get("id").and_then(Value::as_str)
+            && !ids.iter().any(|known| known == id)
+        {
+            ids.push(id.to_owned());
+        }
+    }
+    let mut out = Vec::new();
+    for id in ids {
+        if let Some(value) = merge_value(
+            b.get(&id).copied(),
+            c.get(&id).copied(),
+            e.get(&id).copied(),
+            &format!("{path}[{id}]"),
+            conflicts,
+        ) {
+            out.push(value);
+        }
+    }
+    Some(Value::Array(out))
+}
+
+fn common_order_changed(base: &[String], side: &[String]) -> bool {
+    let common: Vec<_> = base.iter().filter(|id| side.contains(id)).collect();
+    let side_common: Vec<_> = side.iter().filter(|id| base.contains(id)).collect();
+    common != side_common
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::profile::Profile;
+
+    #[test]
+    fn merges_disjoint_profile_and_setting_changes() {
+        let mut base = Config::default();
+        base.profiles.push(Profile::new_vless(
+            "A".into(),
+            "1.1.1.1".into(),
+            443,
+            uuid::Uuid::new_v4().to_string(),
+        ));
+        let mut current = base.clone();
+        current.settings.auto_connect = true;
+        let mut edited = base.clone();
+        edited.profiles[0].name = "Edited".into();
+        let merged = merge_configs(&base, &current, &edited).unwrap();
+        assert!(merged.settings.auto_connect);
+        assert_eq!(merged.profiles[0].name, "Edited");
+    }
+
+    #[test]
+    fn reports_same_field_conflict() {
+        let base = Config::default();
+        let mut current = base.clone();
+        current.settings.theme = "nord".into();
+        let mut edited = base.clone();
+        edited.settings.theme = "catppuccin".into();
+        assert_eq!(
+            merge_configs(&base, &current, &edited).unwrap_err(),
+            vec!["settings.theme"]
+        );
+    }
+
+    #[test]
+    fn merges_independent_additions_and_deletions_by_uuid() {
+        let mut base = Config::default();
+        let removed = Profile::new_vless(
+            "Removed".into(),
+            "1.1.1.1".into(),
+            443,
+            uuid::Uuid::new_v4().to_string(),
+        );
+        base.profiles.push(removed);
+        let mut current = base.clone();
+        current.profiles.push(Profile::new_vless(
+            "Daemon".into(),
+            "2.2.2.2".into(),
+            443,
+            uuid::Uuid::new_v4().to_string(),
+        ));
+        let mut edited = base.clone();
+        edited.profiles.clear();
+        edited.profiles.push(Profile::new_vless(
+            "Editor".into(),
+            "3.3.3.3".into(),
+            443,
+            uuid::Uuid::new_v4().to_string(),
+        ));
+
+        let merged = merge_configs(&base, &current, &edited).unwrap();
+        let names: Vec<_> = merged
+            .profiles
+            .iter()
+            .map(|profile| profile.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["Daemon", "Editor"]);
+    }
+
+    #[test]
+    fn modification_conflicts_with_concurrent_deletion() {
+        let mut base = Config::default();
+        base.profiles.push(Profile::new_vless(
+            "A".into(),
+            "1.1.1.1".into(),
+            443,
+            uuid::Uuid::new_v4().to_string(),
+        ));
+        let mut current = base.clone();
+        current.profiles.clear();
+        let mut edited = base.clone();
+        edited.profiles[0].name = "Edited".into();
+
+        let conflicts = merge_configs(&base, &current, &edited).unwrap_err();
+        assert!(conflicts[0].starts_with("profiles["));
+    }
+
+    #[test]
+    fn rejects_duplicate_ids_before_indexing() {
+        let mut base = Config::default();
+        let profile = Profile::new_vless(
+            "A".into(),
+            "1.1.1.1".into(),
+            443,
+            uuid::Uuid::new_v4().to_string(),
+        );
+        base.profiles = vec![profile.clone(), profile];
+
+        let errors = merge_configs(&base, &Config::default(), &Config::default()).unwrap_err();
+        assert!(errors[0].contains("base config is invalid"));
+        assert!(errors[0].contains("duplicate id"));
+    }
+
+    #[test]
+    fn preserves_editor_reorder_during_concurrent_field_change() {
+        let mut base = Config::default();
+        let a = Profile::new_vless(
+            "A".into(),
+            "1.1.1.1".into(),
+            443,
+            uuid::Uuid::new_v4().to_string(),
+        );
+        let b = Profile::new_vless(
+            "B".into(),
+            "2.2.2.2".into(),
+            443,
+            uuid::Uuid::new_v4().to_string(),
+        );
+        base.profiles = vec![a, b];
+        let mut current = base.clone();
+        current.settings.auto_connect = true;
+        let mut edited = base.clone();
+        edited.profiles.reverse();
+        let merged = merge_configs(&base, &current, &edited).unwrap();
+        assert_eq!(merged.profiles[0].name, "B");
+        assert!(merged.settings.auto_connect);
+    }
+
+    #[test]
+    fn conflicting_reorders_are_reported() {
+        let mut base = Config::default();
+        for name in ["A", "B", "C"] {
+            base.profiles.push(Profile::new_vless(
+                name.into(),
+                "1.1.1.1".into(),
+                443,
+                uuid::Uuid::new_v4().to_string(),
+            ));
+        }
+        let mut current = base.clone();
+        current.profiles.swap(0, 1);
+        let mut edited = base.clone();
+        edited.profiles.swap(1, 2);
+        assert!(
+            merge_configs(&base, &current, &edited)
+                .unwrap_err()
+                .contains(&"profiles order".to_string())
+        );
+    }
+
+    #[test]
+    fn clears_dangling_last_connected_profile_after_merge() {
+        let mut base = Config::default();
+        let profile = Profile::new_vless(
+            "A".into(),
+            "1.1.1.1".into(),
+            443,
+            uuid::Uuid::new_v4().to_string(),
+        );
+        base.settings.last_connected_profile = Some(profile.id);
+        base.profiles.push(profile);
+        let mut edited = base.clone();
+        edited.profiles.clear();
+        let merged = merge_configs(&base, &base, &edited).unwrap();
+        assert_eq!(merged.settings.last_connected_profile, None);
+    }
+}

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::Result;
 use chrono::{DateTime, Datelike, Local, NaiveDate, Timelike};
@@ -1657,14 +1657,20 @@ impl Config {
     /// Validate semantic constraints that serde cannot enforce.
     ///
     /// Checks:
+    /// - Profile and subscription IDs are unique.
+    /// - Subscription-owned profiles reference an existing subscription.
     /// - Each profile has non-empty `name`, `address`, and `uuid`.
     /// - `settings.default_profile` references an existing profile if set.
     /// - DNS server tags are non-empty and unique; `dns.final_server` and every
     ///   `dns.rules[*].server` reference an existing tag; when `fakeip_enabled`
     ///   at least one server is of type `fakeip`.
     pub fn validate(&self) -> anyhow::Result<()> {
+        let mut profile_ids = HashSet::with_capacity(self.profiles.len());
         for (idx, profile) in self.profiles.iter().enumerate() {
             let num = idx + 1;
+            if !profile_ids.insert(profile.id) {
+                anyhow::bail!("Profile {num}: duplicate id {}", profile.id);
+            }
             if profile.name.trim().is_empty() {
                 anyhow::bail!("Profile {num}: name must not be empty");
             }
@@ -1679,7 +1685,11 @@ impl Config {
             }
         }
 
+        let mut subscription_ids = HashSet::with_capacity(self.subscriptions.len());
         for (idx, subscription) in self.subscriptions.iter().enumerate() {
+            if !subscription_ids.insert(subscription.id) {
+                anyhow::bail!("Subscription {}: duplicate id {}", idx + 1, subscription.id);
+            }
             if !subscription.send_hwid {
                 continue;
             }
@@ -1692,6 +1702,17 @@ impl Config {
                     "Subscription {} ({:?}): invalid HWID: {error}",
                     idx + 1,
                     subscription.name
+                );
+            }
+        }
+
+        for (idx, profile) in self.profiles.iter().enumerate() {
+            if let Some(id) = profile.subscription_id
+                && !subscription_ids.contains(&id)
+            {
+                anyhow::bail!(
+                    "Profile {}: subscription_id ({id}) references a non-existent subscription",
+                    idx + 1
                 );
             }
         }
@@ -2647,6 +2668,67 @@ mod tests {
         let err = crate::config::save_config_at(file.path(), &config).unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("Refusing to save"), "Error was: {}", msg);
+    }
+
+    #[test]
+    fn config_validate_rejects_duplicate_profile_ids() {
+        let profile = Profile::new_vless(
+            "A".into(),
+            "1.2.3.4".into(),
+            443,
+            crate::test_helpers::TEST_UUID.into(),
+        );
+        let config = Config {
+            profiles: vec![profile.clone(), profile],
+            ..Config::default()
+        };
+
+        assert!(
+            config
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("duplicate id")
+        );
+    }
+
+    #[test]
+    fn config_validate_rejects_duplicate_subscription_ids() {
+        let subscription = subscription_with_hwid(false, None);
+        let config = Config {
+            subscriptions: vec![subscription.clone(), subscription],
+            ..Config::default()
+        };
+
+        assert!(
+            config
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("duplicate id")
+        );
+    }
+
+    #[test]
+    fn config_validate_rejects_dangling_profile_subscription() {
+        let mut profile = Profile::new_vless(
+            "A".into(),
+            "1.2.3.4".into(),
+            443,
+            crate::test_helpers::TEST_UUID.into(),
+        );
+        profile.subscription_id = Some(Uuid::new_v4());
+        let config = Config {
+            profiles: vec![profile],
+            ..Config::default()
+        };
+        assert!(
+            config
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("subscription_id")
+        );
     }
 
     // ---- Settings::validate ----

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -119,7 +119,43 @@ fn run_loop(
 ) -> Result<()> {
     loop {
         let msg = rx.recv()?;
-        let effects = update(model, msg);
+        let config_before = model.config.clone();
+        let mut effects = update(model, msg);
+        if effects
+            .iter()
+            .any(|effect| matches!(effect, Effect::SaveConfig))
+        {
+            let edited = model.config.clone();
+            match commit_config_change(model, &config_before, &edited) {
+                Ok(config) => {
+                    model.replace_config_preserving_selection(config);
+                    effects.retain(|effect| !matches!(effect, Effect::SaveConfig));
+                }
+                Err(error) => {
+                    model.replace_config_preserving_selection(config_before);
+                    let message = match crate::config::save_conflict_config(&edited) {
+                        Ok(path) => format!(
+                            "Failed to save config: {error:#}; unsaved version preserved at {}",
+                            path.display()
+                        ),
+                        Err(save_error) => format!(
+                            "Failed to save config: {error:#}; failed to preserve unsaved version: {save_error:#}"
+                        ),
+                    };
+                    model.set_status(AppStatus::Error(message.clone()));
+                    crate::services::log_tailer::append_app_log("ERROR", &message);
+                    effects.retain(|effect| {
+                        matches!(effect, Effect::BroadcastState | Effect::AppendAppLog { .. })
+                    });
+                    if !effects
+                        .iter()
+                        .any(|effect| matches!(effect, Effect::BroadcastState))
+                    {
+                        effects.push(Effect::BroadcastState);
+                    }
+                }
+            }
+        }
         // `queue_connect` advances the generation before the next Tick emits
         // `Effect::Connect`. Publish that invalidation immediately so an old
         // worker cannot install its process during the intervening 250 ms.
@@ -136,6 +172,7 @@ fn run_loop(
                     | Effect::ResetGeoUpdateSchedules
                     | Effect::WriteState
                     | Effect::SaveConfig
+                    | Effect::CommitEditedConfig { .. }
                     | Effect::UpdateSubscription { .. }
                     | Effect::BroadcastState
                     | Effect::ApplyKillSwitch { .. }
@@ -157,6 +194,32 @@ fn run_loop(
         }
     }
     Ok(())
+}
+
+fn commit_config_change(
+    model: &Model,
+    base: &crate::config::profile::Config,
+    edited: &crate::config::profile::Config,
+) -> anyhow::Result<crate::config::profile::Config> {
+    anyhow::ensure!(
+        !model.config_persistence_blocked,
+        "persisted config previously failed to load"
+    );
+    let path = crate::paths::profiles_path().context("Failed to determine profiles path")?;
+    let expected = match std::fs::read(&path) {
+        Ok(bytes) => Some(bytes),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error).context("Failed to read config revision"),
+    };
+    let current = match expected.as_deref() {
+        Some(bytes) => crate::config::load_config_bytes_read_only(bytes, &path)?,
+        None => crate::config::profile::Config::default(),
+    };
+    let mut merged = crate::config::merge::merge_configs(base, &current, edited)
+        .map_err(|conflicts| anyhow::anyhow!("config conflicts at {}", conflicts.join(", ")))?;
+    merged.settings.kill_switch = edited.settings.kill_switch;
+    crate::config::save_config_at_revision(&path, &merged, expected.as_deref())?;
+    Ok(merged)
 }
 
 fn execute_daemon_effect(
@@ -614,8 +677,49 @@ fn execute_daemon_effect(
             crate::services::waybar::write_state(model);
         }
         Effect::SaveConfig => {
-            if let Err(e) = model.save() {
-                model.set_status(AppStatus::Error(format!("Failed to save config: {}", e)));
+            // The main loop must consume this marker through
+            // `commit_config_change` before executing effects. Never fall
+            // back to an unconditional write here.
+            model.set_status(AppStatus::Error(
+                "Internal error: uncommitted SaveConfig effect".into(),
+            ));
+        }
+        Effect::SaveConfigConflict { edited, conflicts } => {
+            match crate::config::save_conflict_config(&edited) {
+                Ok(path) => model.set_status(AppStatus::Error(format!(
+                    "Edit conflicts at {}; edited version saved to {}",
+                    conflicts.join(", "),
+                    path.display()
+                ))),
+                Err(error) => model.set_status(AppStatus::Error(format!(
+                    "Edit conflicts at {}; failed to save edited version: {error:#}",
+                    conflicts.join(", ")
+                ))),
+            }
+        }
+        Effect::CommitEditedConfig { base, edited } => {
+            let mut edited_for_commit = (*edited).clone();
+            edited_for_commit.settings.kill_switch = model.config.settings.kill_switch;
+            let result = commit_config_change(model, &base, &edited_for_commit);
+            match result {
+                Ok(config) => {
+                    for nested in crate::app::update::handle_config_reloaded(model, Ok(config)) {
+                        execute_daemon_effect(nested, tx, model, shared)?;
+                    }
+                }
+                Err(error) => {
+                    let message = match crate::config::save_conflict_config(&edited) {
+                        Ok(path) => format!(
+                            "Failed to apply edited config: {error:#}; edited version saved to {}",
+                            path.display()
+                        ),
+                        Err(save_error) => format!(
+                            "Failed to apply edited config: {error:#}; failed to preserve edited version: {save_error:#}"
+                        ),
+                    };
+                    model.set_status(AppStatus::Error(message.clone()));
+                    crate::services::log_tailer::append_app_log("ERROR", &message);
+                }
             }
         }
         Effect::UpdateSubscription { id } => {
@@ -1045,9 +1149,14 @@ fn reconcile_kill_switch_state(model: &mut Model) {
             model.config.settings.kill_switch,
             active
         );
-        model.config.settings.kill_switch = active;
-        if let Err(e) = model.save() {
-            tracing::warn!("Failed to persist reconciled kill switch state: {}", e);
+        let base = model.config.clone();
+        let mut edited = base.clone();
+        edited.settings.kill_switch = active;
+        match commit_config_change(model, &base, &edited) {
+            Ok(config) => model.replace_config_preserving_selection(config),
+            Err(e) => {
+                tracing::warn!("Failed to persist reconciled kill switch state: {}", e);
+            }
         }
     }
 }
@@ -1274,8 +1383,9 @@ fn spawn_signal_handler(tx: Sender<Msg>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        ProcessSlot, ServiceRefreshResult, finalize_geo_result, handshake_protocols,
-        lock_process_slot, log_prune_due, poll_process_exit, write_test_config,
+        ProcessSlot, ServiceRefreshResult, commit_config_change, finalize_geo_result,
+        handshake_protocols, lock_process_slot, log_prune_due, poll_process_exit,
+        write_test_config,
     };
     use crate::app::msg::{GeoResult, Msg};
     use crate::config::profile::Protocol;
@@ -1283,6 +1393,30 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn config_commit_merges_external_and_model_changes() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let _config_home = crate::test_helpers::EnvVarGuard::set("XDG_CONFIG_HOME", dir.path());
+        let base = crate::config::profile::Config::default();
+        crate::config::save_config(&base).unwrap();
+        let mut external = base.clone();
+        external.settings.theme = "nord".into();
+        crate::config::save_config(&external).unwrap();
+        let mut edited = base.clone();
+        edited.settings.auto_connect = true;
+        let model = crate::app::model::Model::test_new(edited.clone());
+
+        let merged = commit_config_change(&model, &base, &edited).unwrap();
+        assert_eq!(merged.settings.theme, "nord");
+        assert!(merged.settings.auto_connect);
+        assert_eq!(
+            crate::config::load_config_at_read_only(&crate::paths::profiles_path().unwrap())
+                .unwrap(),
+            merged
+        );
+    }
 
     #[test]
     fn latency_test_config_is_private() {

--- a/src/tui_client.rs
+++ b/src/tui_client.rs
@@ -781,7 +781,8 @@ fn run_loop(
                         disable_raw_mode()?;
                         terminal.backend_mut().execute(LeaveAlternateScreen)?;
                         let target = model.selected_row().map(self::editor::EditorTarget::from);
-                        let result = self::editor::open_profiles_editor(target);
+                        let result =
+                            self::editor::open_profiles_editor(target, model.config.clone());
                         enable_raw_mode()?;
                         terminal.backend_mut().execute(EnterAlternateScreen)?;
                         input::enable_keyboard_protocol(terminal.backend_mut())?;
@@ -792,21 +793,17 @@ fn run_loop(
                         event_reader_control.resume();
                         update_pointer_shape(terminal, model, mouse_position, &mut pointer_shape)?;
                         match result {
-                            Ok(_) => {
-                                if let Ok(config) = crate::config::load_config() {
-                                    model.replace_config_preserving_selection(config);
-                                }
-                                client.send(&IpcCommand::ReloadConfig)?;
+                            Ok(edit) => {
+                                client.send(&IpcCommand::ApplyEditedConfig {
+                                    base: Box::new(edit.base),
+                                    edited: Box::new(edit.edited),
+                                })?;
                             }
                             Err(e) => {
-                                // ConfigBackup restored the original file, so
-                                // profiles.json is intact — but the user's
-                                // edits are gone. Route the message through
-                                // the daemon: it updates its own model's
-                                // status (surviving apply_snapshot on the
-                                // client) and appends to app.log, which the
-                                // client's LogTailer picks up on the next
-                                // tick and shows in the log panel.
+                                // The live config was never opened by the
+                                // editor. Route the snapshot error through
+                                // the daemon so it survives the next state
+                                // broadcast and appears in app.log.
                                 let message = format!("Edit rejected: {e:#}");
                                 client.send(&IpcCommand::ClientError { message })?;
                             }

--- a/src/tui_client/editor.rs
+++ b/src/tui_client/editor.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 use anyhow::{Context, Result};
@@ -55,57 +55,6 @@ fn split_editor(editor: &str) -> (String, Vec<String>) {
     let mut parts = editor.split_whitespace().map(String::from);
     let program = parts.next().unwrap_or_else(|| "vi".to_string());
     (program, parts.collect())
-}
-
-/// RAII guard for a config file backup.
-///
-/// On creation: copies `original` to a `.bak` sibling.
-/// On drop: restores `original` from the backup unless [`ConfigBackup::commit`] was called.
-struct ConfigBackup {
-    original: PathBuf,
-    backup: PathBuf,
-    committed: bool,
-}
-
-impl ConfigBackup {
-    fn create(original: &Path) -> Result<Self> {
-        let backup = original.with_extension("json.bak");
-        fs::copy(original, &backup)
-            .with_context(|| format!("Failed to create backup at {:?}", backup))?;
-        Ok(Self {
-            original: original.to_path_buf(),
-            backup,
-            committed: false,
-        })
-    }
-
-    /// Mark the backup as committed — the original file is valid and the
-    /// backup can be safely removed on drop.
-    fn commit(&mut self) {
-        self.committed = true;
-        let _ = fs::remove_file(&self.backup)
-            .inspect_err(|e| tracing::warn!("Failed to remove backup file: {}", e));
-    }
-}
-
-impl Drop for ConfigBackup {
-    fn drop(&mut self) {
-        if self.committed || !self.backup.exists() {
-            return;
-        }
-        let _ = fs::rename(&self.backup, &self.original)
-            .inspect_err(|e| tracing::warn!("Failed to restore config backup: {}", e));
-    }
-}
-
-/// Ensure that `profiles.json` exists on disk, creating a default one if necessary.
-fn ensure_profiles_file(path: &Path) -> Result<()> {
-    if path.exists() {
-        return Ok(());
-    }
-    let default_config = Config::default();
-    crate::config::save_config_at(path, &default_config)
-        .context("Failed to create default profiles.json")
 }
 
 /// Determine the 1-based line number of an object in a top-level JSON array.
@@ -200,22 +149,19 @@ fn editor_args(editor: &str, path: &Path, line: usize) -> Vec<String> {
     }
 }
 
-/// Open `profiles.json` in the user's preferred external editor.
-///
-/// If `target` is present and within bounds, the editor will be asked to jump
-/// to the line where that object starts. The caller must restore the terminal
-/// before invoking this function. A backup is created before editing; if
-/// the edited file contains invalid JSON, the backup is restored automatically
-/// and an error is returned. On success the parsed [`Config`] is returned so
-/// the application can reload.
-pub fn open_profiles_editor(target: Option<EditorTarget>) -> Result<Config> {
+pub(super) struct EditedConfig {
+    pub base: Config,
+    pub edited: Config,
+}
+
+/// Edit an isolated snapshot. The live `profiles.json` remains daemon-owned.
+pub fn open_profiles_editor(target: Option<EditorTarget>, base: Config) -> Result<EditedConfig> {
     let editor = detect_editor();
     let (program, base_args) = split_editor(&editor);
-    let path = profiles_path().context("Failed to determine profiles path")?;
-
-    ensure_profiles_file(&path)?;
-
-    let mut backup = ConfigBackup::create(&path)?;
+    let live_path = profiles_path().context("Failed to determine profiles path")?;
+    let path =
+        live_path.with_file_name(format!(".profiles.json.edit-{}.json", uuid::Uuid::new_v4()));
+    crate::config::save_config_at(&path, &base).context("Failed to create editor snapshot")?;
 
     let args = if let Some(line) = target.and_then(|target| find_target_line(&path, target)) {
         editor_args(&program, &path, line)
@@ -227,82 +173,66 @@ pub fn open_profiles_editor(target: Option<EditorTarget>) -> Result<Config> {
         .args(&base_args)
         .args(&args)
         .status()
-        .with_context(|| format!("Failed to launch editor: {}", editor))?;
+        .with_context(|| format!("Failed to launch editor: {}", editor));
 
-    if !status.success() {
-        anyhow::bail!("Editor exited with non-zero status");
-    }
-
-    let config = match crate::config::load_config_at(&path) {
-        Ok(cfg) => cfg,
-        Err(e) => {
-            return Err(e).with_context(|| {
-                format!(
-                    "Invalid JSON in {:?}. Original config restored from backup.",
-                    path
-                )
-            });
-            // ConfigBackup::drop restores the original automatically.
+    let status = match status {
+        Ok(status) => status,
+        Err(error) => {
+            let _ = fs::remove_file(&path);
+            return Err(error);
         }
     };
 
-    if let Err(e) = config.validate() {
-        return Err(e).with_context(|| {
-            format!(
-                "Validation failed for {:?}. Original config restored from backup.",
-                path
-            )
-        });
-        // ConfigBackup::drop restores the original automatically.
+    if !status.success() {
+        let _ = fs::remove_file(&path);
+        anyhow::bail!("Editor exited with non-zero status");
     }
 
-    backup.commit();
-    Ok(config)
+    let edited = match crate::config::load_config_at(&path) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            let conflict = live_path.with_file_name(format!(
+                "profiles.json.conflict-invalid-{}-{}",
+                chrono::Local::now().format("%Y%m%dT%H%M%S"),
+                uuid::Uuid::new_v4()
+            ));
+            fs::rename(&path, &conflict).with_context(|| {
+                format!("Failed to preserve invalid edit at {}", conflict.display())
+            })?;
+            return Err(e).with_context(|| {
+                format!(
+                    "Invalid JSON; live config was not changed. Edited version saved to {}.",
+                    conflict.display()
+                )
+            });
+        }
+    };
+
+    if let Err(e) = edited.validate() {
+        let conflict = live_path.with_file_name(format!(
+            "profiles.json.conflict-invalid-{}-{}",
+            chrono::Local::now().format("%Y%m%dT%H%M%S"),
+            uuid::Uuid::new_v4()
+        ));
+        fs::rename(&path, &conflict).with_context(|| {
+            format!("Failed to preserve invalid edit at {}", conflict.display())
+        })?;
+        return Err(e).with_context(|| {
+            format!(
+                "Validation failed; live config was not changed. Edited version saved to {}.",
+                conflict.display()
+            )
+        });
+    }
+
+    let _ = fs::remove_file(&path);
+    Ok(EditedConfig { base, edited })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
     use tempfile::TempDir;
-
-    #[test]
-    fn config_backup_restores_on_drop() {
-        let dir = TempDir::new().unwrap();
-        let original = dir.path().join("profiles.json");
-
-        let mut file = std::fs::File::create(&original).unwrap();
-        file.write_all(b"valid content").unwrap();
-        drop(file);
-
-        {
-            let _backup = ConfigBackup::create(&original).unwrap();
-            std::fs::write(&original, "modified content").unwrap();
-            // _backup drops here, should restore original
-        }
-
-        let content = std::fs::read_to_string(&original).unwrap();
-        assert_eq!(content, "valid content");
-    }
-
-    #[test]
-    fn config_backup_commits_successfully() {
-        let dir = TempDir::new().unwrap();
-        let original = dir.path().join("profiles.json");
-
-        std::fs::write(&original, "old content").unwrap();
-
-        {
-            let mut backup = ConfigBackup::create(&original).unwrap();
-            std::fs::write(&original, "new content").unwrap();
-            backup.commit();
-            // backup drops here but should NOT restore
-        }
-
-        let content = std::fs::read_to_string(&original).unwrap();
-        assert_eq!(content, "new content");
-        assert!(!original.with_extension("json.bak").exists());
-    }
 
     #[test]
     fn find_profile_line_first_profile() {
@@ -611,30 +541,5 @@ mod tests {
                 None => env::remove_var("EDITOR"),
             }
         }
-    }
-
-    // ---- ensure_profiles_file ----
-
-    #[test]
-    fn ensure_profiles_file_is_noop_when_present() {
-        let dir = TempDir::new().unwrap();
-        let path = dir.path().join("profiles.json");
-        fs::write(&path, "{\"profiles\":[]}").unwrap();
-        let before = fs::read_to_string(&path).unwrap();
-        ensure_profiles_file(&path).unwrap();
-        let after = fs::read_to_string(&path).unwrap();
-        assert_eq!(before, after);
-    }
-
-    #[test]
-    fn ensure_profiles_file_creates_default_when_missing() {
-        let dir = TempDir::new().unwrap();
-        let path = dir.path().join("profiles.json");
-        assert!(!path.exists());
-        ensure_profiles_file(&path).unwrap();
-        assert!(path.exists());
-        // The created file must round-trip into a Config.
-        let cfg = crate::config::load_config_at(&path).unwrap();
-        assert!(cfg.profiles.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Prevent malformed, stale, or concurrently modified configuration data from being silently overwritten.

Configuration changes from the TUI, editor, CLI, and plugin now pass through daemon-owned transactional persistence with validation, structural merging, and revision checks.

## Changes

- edit isolated configuration snapshots instead of writing directly to `profiles.json`
- merge concurrent profile and subscription changes by UUID and settings by field
- preserve conflicting or invalid edits in dedicated conflict files
- validate duplicate IDs and cross-entity references before persistence
- commit configuration changes atomically only when the on-disk revision is unchanged
- roll back in-memory state and dependent effects when persistence fails
- prevent fallback configuration from overwriting an unreadable file
- add interactive `config reset` and read-only `config recover` commands
- archive the existing configuration before reset or recovery
