### PR TITLE
fix(ipc): restart outdated daemon after upgrades

### DIFF
--- a/src/app/msg.rs
+++ b/src/app/msg.rs
@@ -113,6 +113,10 @@ pub enum Msg {
 
     IpcCommand(IpcCommand),
     StateUpdate(Box<StateSnapshot>),
+    /// The local TUI's IPC reader stopped or received a snapshot it could not
+    /// decode. Daemon-side reducers ignore this; the TUI turns it into a
+    /// visible error instead of waiting forever with a stale screen.
+    IpcReadFailed(String),
     ConfigReloaded(Box<Result<crate::config::profile::Config, IpcError>>),
     KillSwitchApplied {
         enabled: bool,
@@ -362,6 +366,14 @@ mod tests {
 /// State snapshot pushed from the daemon to TUI clients.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct StateSnapshot {
+    /// Version of the daemon binary that produced this snapshot. An empty
+    /// value identifies daemons predating the versioned IPC handshake.
+    #[serde(default)]
+    pub daemon_version: String,
+    /// Schema epoch for daemon/client IPC. Bump when wire compatibility is
+    /// intentionally broken independently of the application version.
+    #[serde(default)]
+    pub ipc_version: u32,
     pub connection: ConnectionState,
     pub status: String,
     pub status_is_error: bool,

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -263,6 +263,7 @@ pub fn update(model: &mut Model, msg: Msg) -> Vec<Effect> {
         }
         Msg::IpcCommand(cmd) => handle_ipc_command(model, cmd),
         Msg::StateUpdate(_) => vec![],
+        Msg::IpcReadFailed(_) => vec![],
         Msg::ConfigReloaded(result) => handle_config_reloaded(model, *result),
         Msg::KillSwitchApplied { enabled, error } => {
             handle_kill_switch_applied(model, enabled, error)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1116,6 +1116,8 @@ esac
 
     fn snapshot_with_profiles() -> StateSnapshot {
         let mut snap = StateSnapshot {
+            daemon_version: env!("CARGO_PKG_VERSION").into(),
+            ipc_version: crate::ipc::IPC_VERSION,
             connection: ConnectionState::Idle,
             status: "ok".into(),
             status_is_error: false,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1257,6 +1257,8 @@ fn dns_bootstrap_endpoints(
 
 fn build_snapshot(model: &Model, log_session_offsets: LogSessionOffsets) -> StateSnapshot {
     StateSnapshot {
+        daemon_version: env!("CARGO_PKG_VERSION").to_string(),
+        ipc_version: crate::ipc::IPC_VERSION,
         connection: model.connection,
         status: model.status.text().to_string(),
         status_is_error: matches!(model.status, AppStatus::Error(_)),

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -16,6 +16,9 @@ use crate::app::msg::{IpcCommand, Msg, StateSnapshot};
 /// — anything slower than this is treated as a dead client and disconnected.
 const BROADCAST_WRITE_TIMEOUT: Duration = Duration::from_millis(200);
 
+/// Current daemon/client wire-schema epoch.
+pub const IPC_VERSION: u32 = 1;
+
 /// Return the path to the Unix domain socket used for IPC.
 pub fn socket_path() -> anyhow::Result<std::path::PathBuf> {
     let dir = dirs::runtime_dir().ok_or_else(|| {
@@ -52,6 +55,18 @@ pub fn wait_for_daemon(timeout: Duration) -> bool {
         delay = (delay * 2).min(cap);
     }
     is_daemon_running()
+}
+
+/// Wait until the daemon socket stops accepting connections.
+pub fn wait_for_daemon_exit(timeout: Duration) -> bool {
+    let start = std::time::Instant::now();
+    while start.elapsed() < timeout {
+        if !is_daemon_running() {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+    !is_daemon_running()
 }
 
 /// Daemon-side IPC server.
@@ -178,6 +193,14 @@ impl IpcClient {
     /// stream so nothing past the first `\n` is consumed — a follow-up read
     /// after sending a command still sees the daemon's next broadcast.
     pub fn read_snapshot(&mut self, timeout: Duration) -> anyhow::Result<StateSnapshot> {
+        let value = self.read_snapshot_value(timeout)?;
+        serde_json::from_value(value).context("Malformed state snapshot from the daemon")
+    }
+
+    /// Read one snapshot as untyped JSON. The TUI uses this for the initial
+    /// version handshake so it can recognize an old daemon even when the full
+    /// old snapshot no longer deserializes into the current Rust type.
+    pub fn read_snapshot_value(&mut self, timeout: Duration) -> anyhow::Result<serde_json::Value> {
         use std::io::Read;
         self.stream
             .set_read_timeout(Some(timeout))
@@ -198,7 +221,7 @@ impl IpcClient {
                 anyhow::bail!("State snapshot exceeds 16 MiB");
             }
         }
-        serde_json::from_slice(&line).context("Malformed state snapshot from the daemon")
+        serde_json::from_slice(&line).context("Malformed JSON from the daemon")
     }
 
     /// Spawn a background thread that reads state snapshots from the daemon
@@ -210,15 +233,34 @@ impl IpcClient {
             .context("Failed to clone IPC socket for snapshot reader")?;
         thread::spawn(move || {
             let reader = BufReader::new(stream);
+            let mut failure_reported = false;
             for line in reader.lines() {
                 match line {
-                    Ok(line) => {
-                        if let Ok(snapshot) = serde_json::from_str::<StateSnapshot>(&line) {
+                    Ok(line) => match serde_json::from_str::<StateSnapshot>(&line) {
+                        Ok(snapshot) => {
                             let _ = tx.send(Msg::StateUpdate(Box::new(snapshot)));
                         }
+                        Err(error) => {
+                            let _ = tx.send(Msg::IpcReadFailed(format!(
+                                "Malformed state snapshot from the daemon: {error}"
+                            )));
+                            failure_reported = true;
+                            break;
+                        }
+                    },
+                    Err(error) => {
+                        let _ = tx.send(Msg::IpcReadFailed(format!(
+                            "Lost connection to the daemon: {error}"
+                        )));
+                        failure_reported = true;
+                        break;
                     }
-                    Err(_) => break,
                 }
+            }
+            if !failure_reported {
+                let _ = tx.send(Msg::IpcReadFailed(
+                    "Daemon closed the IPC connection".to_string(),
+                ));
             }
         });
         Ok(())
@@ -247,6 +289,8 @@ mod tests {
 
     fn sample_snapshot() -> StateSnapshot {
         StateSnapshot {
+            daemon_version: env!("CARGO_PKG_VERSION").into(),
+            ipc_version: IPC_VERSION,
             connection: ConnectionState::Idle,
             status: "ok".into(),
             status_is_error: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,27 @@ pub(crate) fn start_daemon() -> Result<()> {
     spawn_daemon_process()
 }
 
+/// Start the daemon binary that corresponds to this client after an upgrade.
+///
+/// The packaged executable keeps using its systemd unit (and therefore its
+/// supervision). A source or manual build bypasses that unit so it cannot
+/// accidentally restart an older `/usr/bin/kvn-tui`.
+pub(crate) fn start_current_daemon() -> Result<()> {
+    let current = std::env::current_exe().context("Failed to determine current executable path")?;
+    if paths_refer_to_same_file(&current, std::path::Path::new("/usr/bin/kvn-tui")) {
+        start_daemon()
+    } else {
+        spawn_daemon_process()
+    }
+}
+
+fn paths_refer_to_same_file(left: &std::path::Path, right: &std::path::Path) -> bool {
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => left == right,
+    }
+}
+
 /// Re-exec ourselves as `kvn-tui --daemon` in a fresh process group so the
 /// daemon outlives the TUI when no packaged systemd unit is available.
 fn spawn_daemon_process() -> Result<()> {
@@ -126,7 +147,18 @@ fn spawn_daemon_process() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_log_filter;
+    use super::{paths_refer_to_same_file, resolve_log_filter};
+    use std::path::Path;
+
+    #[test]
+    fn executable_path_comparison_handles_identical_missing_paths() {
+        let path = Path::new("/definitely/missing/kvn-tui");
+        assert!(paths_refer_to_same_file(path, path));
+        assert!(!paths_refer_to_same_file(
+            path,
+            Path::new("/another/missing/kvn-tui")
+        ));
+    }
 
     fn with_no_rust_log<F: FnOnce() -> R, R>(f: F) -> R {
         let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();

--- a/src/tui_client.rs
+++ b/src/tui_client.rs
@@ -5,11 +5,11 @@ pub(crate) mod theme_watch;
 
 use std::io::{self, IsTerminal, Write};
 use std::sync::Arc;
-use std::sync::mpsc::{Receiver, Sender, channel};
+use std::sync::mpsc::{Sender, channel};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use crossterm::ExecutableCommand;
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
@@ -390,8 +390,7 @@ fn preview_uuid() -> String {
 
 /// Run the TUI client: connects to daemon, renders UI, forwards input.
 pub fn run() -> Result<()> {
-    let mut client = IpcClient::connect()?;
-    client.send(&IpcCommand::Attach)?;
+    let (mut client, initial_snapshot) = connect_to_current_daemon()?;
 
     let config = crate::config::load_config().unwrap_or_default();
     let mut model = Model::from_config(config.clone());
@@ -407,7 +406,7 @@ pub fn run() -> Result<()> {
         (crate::paths::app_log_path(), "[app]"),
         (crate::paths::singbox_log_path(), "[sb]"),
     ]);
-    receive_initial_state(&rx, &mut model, &mut log_tailer)?;
+    apply_initial_snapshot(&mut model, initial_snapshot, &mut log_tailer);
 
     let _terminal_session = TerminalSession::enter()?;
     apply_terminal_colors(
@@ -429,33 +428,120 @@ pub fn run() -> Result<()> {
     )
 }
 
-fn receive_initial_state(
-    rx: &Receiver<Msg>,
-    model: &mut Model,
-    log_tailer: &mut LogTailer,
-) -> Result<()> {
-    loop {
-        match rx.recv()? {
-            Msg::StateUpdate(snapshot) => {
-                if let Some(offsets) = snapshot.log_session_offsets {
-                    for line in log_tailer.load_history(
-                        &[offsets.app, offsets.singbox],
-                        crate::app::model::MAX_LOG_LINES,
-                    ) {
-                        model.push_log(line);
-                    }
-                }
-                apply_snapshot(model, *snapshot);
-                return Ok(());
-            }
-            Msg::ThemeChanged(theme)
-                if model.config.settings.theme == theme_watch::OMARCHY_SENTINEL =>
+/// Attach to a daemon built from the same package as this client. Upgrades can
+/// leave the previous daemon alive, so inspect the first response as generic
+/// JSON before attempting to decode the full (possibly changed) snapshot.
+fn connect_to_current_daemon() -> Result<(IpcClient, crate::app::msg::StateSnapshot)> {
+    let mut reconnect_profile = None;
+
+    for attempt in 0..=1 {
+        let mut client = IpcClient::connect().context("Failed to connect to kvn-tui daemon")?;
+        client.send(&IpcCommand::Attach)?;
+        let value = client
+            .read_snapshot_value(Duration::from_secs(2))
+            .context("Daemon did not provide its initial state")?;
+
+        let daemon_version = value
+            .get("daemon_version")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        let ipc_version = value
+            .get("ipc_version")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or_default();
+        let compatible = snapshot_is_compatible(&value);
+
+        if compatible {
+            let mut snapshot: crate::app::msg::StateSnapshot = serde_json::from_value(value)
+                .context("Malformed state snapshot from the daemon")?;
+            if snapshot.connection == ConnectionState::Idle
+                && let Some(profile_id) = reconnect_profile
             {
-                model.theme = theme;
+                client.send(&IpcCommand::ConnectProfile { profile_id })?;
+                snapshot = client
+                    .read_snapshot(Duration::from_secs(2))
+                    .context("Restarted daemon did not acknowledge reconnect")?;
             }
-            _ => {}
+            return Ok((client, snapshot));
+        }
+
+        anyhow::ensure!(
+            attempt == 0,
+            "daemon is still incompatible after restart (daemon version {:?}, IPC {}; client version {:?}, IPC {})",
+            daemon_version,
+            ipc_version,
+            env!("CARGO_PKG_VERSION"),
+            crate::ipc::IPC_VERSION
+        );
+
+        reconnect_profile = reconnect_profile_after_restart(&value);
+
+        if io::stderr().is_terminal() {
+            eprintln!(
+                "kvn-tui: restarting outdated daemon (version {})…",
+                if daemon_version.is_empty() {
+                    "unknown"
+                } else {
+                    daemon_version
+                }
+            );
+        }
+        client
+            .send(&IpcCommand::Quit)
+            .context("Failed to ask outdated daemon to stop")?;
+        drop(client);
+        anyhow::ensure!(
+            crate::ipc::wait_for_daemon_exit(Duration::from_secs(5)),
+            "outdated daemon did not stop within 5s"
+        );
+        crate::start_current_daemon().context("Failed to start updated daemon")?;
+        anyhow::ensure!(
+            crate::ipc::wait_for_daemon(Duration::from_secs(5)),
+            "updated daemon did not start within 5s"
+        );
+    }
+
+    unreachable!("daemon compatibility loop always returns or errors")
+}
+
+fn snapshot_is_compatible(value: &serde_json::Value) -> bool {
+    value
+        .get("daemon_version")
+        .and_then(serde_json::Value::as_str)
+        == Some(env!("CARGO_PKG_VERSION"))
+        && value.get("ipc_version").and_then(serde_json::Value::as_u64)
+            == Some(u64::from(crate::ipc::IPC_VERSION))
+}
+
+fn reconnect_profile_after_restart(value: &serde_json::Value) -> Option<uuid::Uuid> {
+    if value.get("connection").and_then(serde_json::Value::as_str) != Some("Connected") {
+        return None;
+    }
+    value
+        .get("active_profile_id")
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| {
+            value
+                .pointer("/settings/last_connected_profile")
+                .and_then(serde_json::Value::as_str)
+        })
+        .and_then(|id| uuid::Uuid::parse_str(id).ok())
+}
+
+fn apply_initial_snapshot(
+    model: &mut Model,
+    snapshot: crate::app::msg::StateSnapshot,
+    log_tailer: &mut LogTailer,
+) {
+    if let Some(offsets) = snapshot.log_session_offsets {
+        for line in log_tailer.load_history(
+            &[offsets.app, offsets.singbox],
+            crate::app::model::MAX_LOG_LINES,
+        ) {
+            model.push_log(line);
         }
     }
+    apply_snapshot(model, snapshot);
 }
 
 fn run_loop(
@@ -825,6 +911,7 @@ fn run_loop(
                 update_pointer_shape(terminal, model, mouse_position, &mut pointer_shape)?;
                 needs_redraw = true;
             }
+            Msg::IpcReadFailed(message) => anyhow::bail!(message),
             Msg::Tick => {
                 log_navigation.expire_if_idle(Instant::now());
                 let new_lines = log_tailer.tail();
@@ -989,6 +1076,51 @@ fn spawn_ticker(tx: Sender<Msg>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn snapshot_compatibility_requires_matching_binary_and_ipc_versions() {
+        let current = serde_json::json!({
+            "daemon_version": env!("CARGO_PKG_VERSION"),
+            "ipc_version": crate::ipc::IPC_VERSION,
+        });
+        assert!(snapshot_is_compatible(&current));
+        assert!(!snapshot_is_compatible(&serde_json::json!({})));
+        assert!(!snapshot_is_compatible(&serde_json::json!({
+            "daemon_version": "0.0.0",
+            "ipc_version": crate::ipc::IPC_VERSION,
+        })));
+        assert!(!snapshot_is_compatible(&serde_json::json!({
+            "daemon_version": env!("CARGO_PKG_VERSION"),
+            "ipc_version": crate::ipc::IPC_VERSION + 1,
+        })));
+    }
+
+    #[test]
+    fn restart_reconnects_only_the_profile_from_a_connected_snapshot() {
+        let id = uuid::Uuid::new_v4();
+        let connected = serde_json::json!({
+            "connection": "Connected",
+            "active_profile_id": id.to_string(),
+        });
+        assert_eq!(reconnect_profile_after_restart(&connected), Some(id));
+
+        let idle = serde_json::json!({
+            "connection": "Idle",
+            "active_profile_id": id.to_string(),
+        });
+        assert_eq!(reconnect_profile_after_restart(&idle), None);
+    }
+
+    #[test]
+    fn restart_reconnect_profile_falls_back_to_persisted_last_profile() {
+        let id = uuid::Uuid::new_v4();
+        let snapshot = serde_json::json!({
+            "connection": "Connected",
+            "active_profile_id": null,
+            "settings": { "last_connected_profile": id.to_string() },
+        });
+        assert_eq!(reconnect_profile_after_restart(&snapshot), Some(id));
+    }
 
     #[test]
     fn osc_color_formats_rgb_color_as_hex_triplet() {


### PR DESCRIPTION
## Summary

Prevent the TUI from hanging without rendering when it connects to a daemon left running from an older kvn-tui version.

## Changes

- Add application and IPC versions to daemon state snapshots.
- Detect incompatible daemons before entering the alternate screen.
- Gracefully stop an outdated daemon and start the matching replacement.
- Restore the previously active VPN profile after the restart.
- Keep packaged installations under systemd supervision while source and manual builds restart from their current executable.
- Surface malformed snapshots and IPC disconnects instead of silently ignoring them.
