### PR TITLE
chore(config): normalize and restrict tun interface names

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,7 @@ A subscription contains `id`, `name`, `url`, `auto_update`, and an optional
 | Field | Default | Description |
 |-------|---------|-------------|
 | `default_profile` | `null` | UUID of the selected default profile |
-| `tun_interface` | `kvn0` | Name of the sing-box TUN interface |
+| `tun_interface` | `kvn0` | Name of the sing-box TUN interface; must start with `kvn` |
 | `dns` | Cloudflare DoH | DNS servers, rules, strategy, and fake-IP state |
 | `geo_routing` | no region | Country modes, rule-set updates, and service overrides |
 | `auto_connect` | `false` | Connect to `last_connected_profile` at startup |

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,9 +24,10 @@ pub fn load_config_at(path: &Path) -> Result<Config> {
     config
         .migrate()
         .with_context(|| format!("Failed to migrate {:?}", path))?;
-    if config.schema_version != loaded_schema_version && config.validate().is_ok() {
+    let normalized = config.normalize();
+    if (config.schema_version != loaded_schema_version || normalized) && config.validate().is_ok() {
         save_config_at_revision(path, &config, Some(contents.as_bytes()))
-            .with_context(|| format!("Failed to persist migration for {:?}", path))?;
+            .with_context(|| format!("Failed to persist normalized config for {:?}", path))?;
     }
 
     Ok(config)
@@ -53,6 +54,7 @@ pub(crate) fn load_config_bytes_read_only(contents: &[u8], path: &Path) -> Resul
     config
         .migrate()
         .with_context(|| format!("Failed to migrate {:?}", path))?;
+    config.normalize();
     Ok(config)
 }
 
@@ -69,13 +71,14 @@ pub fn save_config_at(path: &Path, config: &Config) -> Result<()> {
 }
 
 fn serialized_config(config: &Config) -> Result<String> {
-    config
+    let mut serializable = config.clone();
+    serializable.normalize();
+    serializable
         .validate()
         .context("Refusing to save invalid config")?;
 
     // Mirror `dns.strategy` into the legacy `dns_strategy` field so configs
     // remain readable by older kvn-tui builds during the deprecation window.
-    let mut serializable = config.clone();
     serializable.settings.dns_strategy = serializable.settings.dns.strategy.clone();
 
     Ok(serde_json::to_string_pretty(&serializable)?)
@@ -196,6 +199,34 @@ mod tests {
         save_config_at(&path, &config).unwrap();
         let loaded = load_config_at(&path).unwrap();
         assert_eq!(loaded, config);
+    }
+
+    #[test]
+    fn load_config_trims_and_persists_tun_interface() {
+        let file = NamedTempFile::new().unwrap();
+        let mut config = Config::default();
+        config.settings.tun_interface = " \tkvn0\n".into();
+        fs::write(file.path(), serde_json::to_string(&config).unwrap()).unwrap();
+
+        let loaded = load_config_at(file.path()).unwrap();
+        let persisted: Config =
+            serde_json::from_str(&fs::read_to_string(file.path()).unwrap()).unwrap();
+
+        assert_eq!(loaded.settings.tun_interface, "kvn0");
+        assert_eq!(persisted.settings.tun_interface, "kvn0");
+    }
+
+    #[test]
+    fn save_config_trims_tun_interface() {
+        let file = NamedTempFile::new().unwrap();
+        let mut config = Config::default();
+        config.settings.tun_interface = " kvn-work ".into();
+
+        save_config_at(file.path(), &config).unwrap();
+
+        let persisted: Config =
+            serde_json::from_str(&fs::read_to_string(file.path()).unwrap()).unwrap();
+        assert_eq!(persisted.settings.tun_interface, "kvn-work");
     }
 
     #[test]
@@ -433,6 +464,21 @@ mod tests {
         std::fs::write(&path, original).unwrap();
         let loaded = load_config_at_read_only(&path).unwrap();
         assert_eq!(loaded.schema_version, profile::CURRENT_SCHEMA_VERSION);
+        assert_eq!(std::fs::read_to_string(path).unwrap(), original);
+    }
+
+    #[test]
+    fn read_only_load_trims_tun_interface_without_rewriting_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("recovery.json");
+        let mut config = Config::default();
+        config.settings.tun_interface = " kvn0 ".into();
+        let original = serde_json::to_string(&config).unwrap();
+        std::fs::write(&path, &original).unwrap();
+
+        let loaded = load_config_at_read_only(&path).unwrap();
+
+        assert_eq!(loaded.settings.tun_interface, "kvn0");
         assert_eq!(std::fs::read_to_string(path).unwrap(), original);
     }
 }

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -1560,6 +1560,9 @@ impl Settings {
                 self.tun_interface,
             );
         }
+        if !tun.starts_with("kvn") {
+            anyhow::bail!("settings.tun_interface must start with \"kvn\"");
+        }
 
         if self.theme != OMARCHY_THEME_SENTINEL
             && !BUNDLED_THEME_NAMES.contains(&self.theme.as_str())
@@ -1660,6 +1663,17 @@ impl Default for Config {
 }
 
 impl Config {
+    /// Canonicalize user-provided values that tolerate surrounding whitespace.
+    /// Returns whether any value changed.
+    pub(crate) fn normalize(&mut self) -> bool {
+        let tun_interface = self.settings.tun_interface.trim();
+        if tun_interface == self.settings.tun_interface {
+            return false;
+        }
+        self.settings.tun_interface = tun_interface.to_string();
+        true
+    }
+
     /// Validate semantic constraints that serde cannot enforce.
     ///
     /// Checks:
@@ -2847,6 +2861,27 @@ mod tests {
         };
         let err = s.validate().unwrap_err().to_string();
         assert!(err.contains("disallowed"), "Error was: {}", err);
+    }
+
+    #[test]
+    fn settings_validate_accepts_tun_interfaces_with_kvn_prefix() {
+        for tun_interface in ["kvn", "kvn0", "kvn-work"] {
+            let s = Settings {
+                tun_interface: tun_interface.into(),
+                ..Settings::default()
+            };
+            s.validate().unwrap();
+        }
+    }
+
+    #[test]
+    fn settings_validate_rejects_tun_interface_without_kvn_prefix() {
+        let s = Settings {
+            tun_interface: "tun0".into(),
+            ..Settings::default()
+        };
+        let err = s.validate().unwrap_err().to_string();
+        assert!(err.contains("must start with \"kvn\""), "Error was: {err}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Require configured sing-box TUN interface names to use the `kvn` prefix so they stay within the app-specific namespace expected by the kill-switch integration.

## Changes

- Trim surrounding whitespace when loading and saving `tun_interface`, atomically persisting normalized configurations.
- Reject interface names that do not start with the lowercase `kvn` prefix.
- Preserve the existing Linux interface-name length and character validation.
- Document the constraint and cover accepted, normalized, and rejected values.
