### PR TITLE
chore(cli): rebrand kvn-tui command as kvn

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
           VERSION=${VERSION#v}
           mkdir -p "kvn-tui-${VERSION}-x86_64-linux"
           cp target/release/kvn-tui "kvn-tui-${VERSION}-x86_64-linux/"
+          ln -s kvn-tui "kvn-tui-${VERSION}-x86_64-linux/kvn"
           cp contrib/kvn-tui.service "kvn-tui-${VERSION}-x86_64-linux/"
           cp contrib/kvn-tui-sing-box-capabilities.hook "kvn-tui-${VERSION}-x86_64-linux/"
           cp LICENSE "kvn-tui-${VERSION}-x86_64-linux/"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 > Terminal VPN client for Arch Linux with vim navigation.
 
-`kvn-tui` is a keyboard-driven TUI application for managing VPN connections. It provides a fast, minimal interface for configuring profiles, connecting via the [sing-box](https://sing-box.sagernet.org/) backend, and routing traffic — all without leaving the terminal.
+`kvn-tui` is a keyboard-driven TUI application for managing VPN connections. Its canonical command is `kvn`; the legacy `kvn-tui` command remains available during the deprecation period. It provides a fast, minimal interface for configuring profiles, connecting via the [sing-box](https://sing-box.sagernet.org/) backend, and routing traffic — all without leaving the terminal.
 
 ![kvn-tui screenshot](assets/screenshot.png)
 
@@ -76,10 +76,10 @@ exported with `y`.
 
 ## First Connection
 
-After installation, launch kvn-tui:
+After installation, launch the TUI:
 
 ```bash
-kvn-tui
+kvn
 ```
 
 Choose a regional routing preset on first launch, then:
@@ -119,7 +119,7 @@ it does not grant NetworkManager permissions:
 
 ```bash
 sudo pacman -S --needed polkit
-sudo kvn-tui setup --polkit
+sudo kvn setup --polkit
 ```
 
 If setup adds you to the `kvn-tui` group, log out and back in, then restart the
@@ -135,7 +135,7 @@ not active:
 
 ```bash
 sudo pacman -S --needed nftables
-sudo kvn-tui setup --killswitch
+sudo kvn setup --killswitch
 ```
 
 The kill-switch sudoers rule uses the same dedicated `kvn-tui` group and allows
@@ -146,7 +146,7 @@ Toggle it with `K`; the status bar shows `[KS]` while it is enabled. Polkit and
 the kill switch can also be installed together:
 
 ```bash
-sudo kvn-tui setup --polkit --killswitch
+sudo kvn setup --polkit --killswitch
 ```
 
 System setup and cleanup must be run through `sudo` from a non-root user.
@@ -156,8 +156,8 @@ rejected.
 Remove either system integration with:
 
 ```bash
-sudo kvn-tui clean --polkit
-sudo kvn-tui clean --killswitch
+sudo kvn clean --polkit
+sudo kvn clean --killswitch
 ```
 
 ### Omarchy integration (optional)
@@ -169,7 +169,7 @@ Omarchy users can enable Shell/Waybar, launcher, Hyprland, and floating-window
 integration with:
 
 ```bash
-kvn-tui setup --omarchy
+kvn setup --omarchy
 ```
 
 Run Omarchy setup and cleanup without `sudo`, because they modify the current
@@ -189,7 +189,7 @@ The idempotent installer detects Omarchy 3 or 4 and creates backups before
 editing user configuration. Remove those backups after verification with:
 
 ```bash
-kvn-tui clean --omarchy
+kvn clean --omarchy
 ```
 
 This removes only the backups and leaves the active integration unchanged.
@@ -220,18 +220,21 @@ Alternatively, install only the binary from the repository root:
 ```bash
 cargo build --release --locked
 sudo install -Dm755 target/release/kvn-tui /usr/local/bin/kvn-tui
+sudo ln -s kvn-tui /usr/local/bin/kvn
 sudo setcap cap_net_admin,cap_net_raw+ep "$(command -v sing-box)"
 ```
 
 The capabilities allow sing-box to use TUN without running kvn-tui as root. The
 bundled service expects `/usr/bin/kvn-tui`; with a manual installation, use the
 automatic detached daemon or change its `ExecStart` to
-`/usr/local/bin/kvn-tui --daemon`.
+`/usr/local/bin/kvn-tui --daemon`. The legacy executable remains the real file
+so the existing service and integrations continue to work; `kvn` is its
+canonical command alias.
 
 ## Diagnostics
 
 ```bash
-kvn-tui doctor
+kvn doctor
 ```
 
 Runs a read-only check of sing-box, configuration, the daemon, clipboard, and

--- a/contrib/clean-killswitch.sh
+++ b/contrib/clean-killswitch.sh
@@ -26,7 +26,7 @@ cleanup_group_if_unused() {
 }
 
 if [[ $EUID -ne 0 ]]; then
-    echo "This cleanup must be run as root (e.g. sudo kvn-tui clean --killswitch)" >&2
+    echo "This cleanup must be run as root (e.g. sudo kvn clean --killswitch)" >&2
     exit 1
 fi
 

--- a/contrib/clean-polkit.sh
+++ b/contrib/clean-polkit.sh
@@ -22,7 +22,7 @@ cleanup_group_if_unused() {
 }
 
 if [[ $EUID -ne 0 ]]; then
-    echo "This cleanup must be run as root (e.g. sudo kvn-tui clean --polkit)" >&2
+    echo "This cleanup must be run as root (e.g. sudo kvn clean --polkit)" >&2
     exit 1
 fi
 

--- a/contrib/setup-killswitch.sh
+++ b/contrib/setup-killswitch.sh
@@ -10,7 +10,7 @@
 set -euo pipefail
 
 if [[ $EUID -ne 0 ]]; then
-    echo "This installer must be run as root (e.g. sudo kvn-tui setup --killswitch)" >&2
+    echo "This installer must be run as root (e.g. sudo kvn setup --killswitch)" >&2
     exit 1
 fi
 

--- a/contrib/setup-omarchy.sh
+++ b/contrib/setup-omarchy.sh
@@ -96,13 +96,13 @@ if [[ -f "$plugin_dir/manifest.json" ]] && command -v omarchy-shell >/dev/null 2
     exit 0
   fi
 fi
-exec omarchy-launch-or-focus-tui --app-id=org.omarchy.kvn-tui kvn-tui
+exec omarchy-launch-or-focus-tui --app-id=org.omarchy.kvn-tui kvn
 EOF
   else
     cat >"$tmp" <<'EOF'
 #!/bin/bash
 exec omarchy-launch-or-focus "org.omarchy.kvn-tui" \
-  "uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.kvn-tui -e kvn-tui"
+  "uwsm-app -- xdg-terminal-exec --app-id=org.omarchy.kvn-tui -e kvn"
 EOF
   fi
   chmod 0755 "$tmp"
@@ -122,8 +122,8 @@ Type=Application
 Name=kvn-tui
 GenericName=VPN Client
 Comment=Terminal VPN client powered by sing-box
-Exec=omarchy-launch-or-focus-tui --app-id=org.omarchy.kvn-tui kvn-tui
-TryExec=kvn-tui
+Exec=omarchy-launch-or-focus-tui --app-id=org.omarchy.kvn-tui kvn
+TryExec=kvn
 Terminal=false
 Icon=kvn-tui
 Categories=Network;Utility;
@@ -191,7 +191,7 @@ install_omarchy_v3() {
         sed -i '$ s/[[:space:]]*$/,/' "$tmp"
         cat >>"$tmp" <<'EOF'
   "custom/kvn-tui": {
-    "exec": "kvn-tui --waybar-status",
+    "exec": "kvn --waybar-status",
     "return-type": "json",
     "interval": 5,
     "on-click": "omarchy-launch-kvn-tui",
@@ -460,7 +460,7 @@ EOF
   elif (( plugin_status == 2 )); then
     return 1
   else
-    module='{"id":"kvn-tui","type":"command","exec":"kvn-tui --waybar-status","interval":5,"tooltip":"kvn-tui VPN client","onClick":"omarchy-launch-kvn-tui"}'
+    module='{"id":"kvn-tui","type":"command","exec":"kvn --waybar-status","interval":5,"tooltip":"kvn-tui VPN client","onClick":"omarchy-launch-kvn-tui"}'
   fi
   tmp=$(mktemp "${shell_config}.tmp.XXXXXX")
   jq --argjson module "$module" '

--- a/contrib/setup-polkit.sh
+++ b/contrib/setup-polkit.sh
@@ -5,7 +5,7 @@ RULE_FILE="/etc/polkit-1/rules.d/49-kvn-tui.rules"
 GROUP_NAME="kvn-tui"
 
 if [[ $EUID -ne 0 ]]; then
-    echo "This installer must be run as root (e.g. sudo kvn-tui setup --polkit)" >&2
+    echo "This installer must be run as root (e.g. sudo kvn setup --polkit)" >&2
     exit 1
 fi
 

--- a/docs/system-integration.md
+++ b/docs/system-integration.md
@@ -11,6 +11,7 @@ The Arch package installs:
 | Path | Mode | Purpose |
 |------|------|---------|
 | `/usr/bin/kvn-tui` | `0755` | Application binary |
+| `/usr/bin/kvn` | symlink | Canonical command pointing to `kvn-tui` |
 | `/usr/lib/systemd/user/kvn-tui.service` | `0644` | Per-user daemon service |
 | `/usr/share/libalpm/hooks/kvn-tui-sing-box-capabilities.hook` | `0644` | Restores sing-box capabilities after package updates |
 | `/usr/share/licenses/kvn-tui/LICENSE` | `0644` | MIT license for the source package |
@@ -44,7 +45,7 @@ Do not revoke them while another TUN client relies on the same sing-box binary.
 ## Polkit setup
 
 ```bash
-sudo kvn-tui setup --polkit
+sudo kvn setup --polkit
 ```
 
 System integration setup and cleanup must be run through `sudo` from a
@@ -72,7 +73,7 @@ and back in and restart `kvn-tui.service`.
 To remove the rule:
 
 ```bash
-sudo kvn-tui clean --polkit
+sudo kvn clean --polkit
 ```
 
 Cleanup preserves the group while the kill switch still uses it. If neither
@@ -84,7 +85,7 @@ changing it manually.
 ## Kill switch setup
 
 ```bash
-sudo kvn-tui setup --killswitch
+sudo kvn setup --killswitch
 ```
 
 The command requires `nftables`, adds the invoking user to the dedicated
@@ -124,7 +125,7 @@ Toggling the kill switch with `K` runs `systemctl enable --now` or
 Use the cleanup command, which stops the active unit before deleting any files:
 
 ```bash
-sudo kvn-tui clean --killswitch
+sudo kvn clean --killswitch
 ```
 
 If the active unit cannot be stopped, cleanup aborts before removing its files.
@@ -136,7 +137,7 @@ persisted state is reconciled.
 ## Omarchy setup
 
 ```bash
-kvn-tui setup --omarchy
+kvn setup --omarchy
 ```
 
 This command runs without sudo and changes only the current user's files.
@@ -176,7 +177,7 @@ The installer updates:
   `SetRoutingMode`, `SetGeoRegion`, `SetKillSwitch`, `SetAutoConnect`) out.
   Existing embedded copies are migrated automatically. Without the plugin
   registry or when a fresh remote install fails, the installer falls back to
-  a `command` bar module running `kvn-tui --waybar-status`;
+  a `command` bar module running `kvn --waybar-status`;
 - `~/.config/omarchy/shell.json` — the `yarikov.omakvn` bar entry (or the legacy
   `kvn-tui` command module on fallback), inserted before `omarchy.bluetooth`;
 - `~/.config/hypr/bindings.lua` — optional launcher binding;
@@ -223,7 +224,7 @@ After confirming the active configuration no longer needs the backups, delete
 only the backups created by kvn-tui with:
 
 ```bash
-kvn-tui clean --omarchy
+kvn clean --omarchy
 ```
 
 `clean --omarchy` removes only these backups. It does not remove the plugin,

--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -27,6 +27,7 @@ build() {
 package() {
     cd "$startdir/../../"
     install -Dm755 "target/release/$pkgname" "$pkgdir/usr/bin/$pkgname"
+    ln -s kvn-tui "$pkgdir/usr/bin/kvn"
     install -Dm644 contrib/kvn-tui.service "$pkgdir/usr/lib/systemd/user/kvn-tui.service"
     install -Dm644 contrib/kvn-tui-sing-box-capabilities.hook \
         "$pkgdir/usr/share/libalpm/hooks/kvn-tui-sing-box-capabilities.hook"

--- a/pkg/aur/PKGBUILD.bin
+++ b/pkg/aur/PKGBUILD.bin
@@ -21,6 +21,7 @@ sha256sums=('{{SHA256SUM}}')
 package() {
     cd "kvn-tui-{{VERSION}}-x86_64-linux"
     install -Dm755 kvn-tui "$pkgdir/usr/bin/kvn-tui"
+    ln -s kvn-tui "$pkgdir/usr/bin/kvn"
     install -Dm644 kvn-tui.service "$pkgdir/usr/lib/systemd/user/kvn-tui.service"
     install -Dm644 kvn-tui-sing-box-capabilities.hook \
         "$pkgdir/usr/share/libalpm/hooks/kvn-tui-sing-box-capabilities.hook"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use clap::{ArgGroup, Parser, Subcommand};
-use std::io::{BufRead, Write};
+use std::ffi::{OsStr, OsString};
+use std::io::{BufRead, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use uuid::Uuid;
@@ -14,8 +15,11 @@ use crate::services::waybar;
 /// state snapshot before giving up.
 const SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(5);
 
+const LEGACY_COMMAND_WARNING: &str = "Warning: `kvn-tui` is a legacy command and will be removed in a future release.\nUse `kvn` instead.\n\n";
+const LEGACY_COMMAND_WARNING_YELLOW: &str = "\x1b[33mWarning: `kvn-tui` is a legacy command and will be removed in a future release.\nUse `kvn` instead.\x1b[0m\n\n";
+
 #[derive(Parser)]
-#[command(version, about)]
+#[command(name = "kvn", bin_name = "kvn", version, about)]
 pub struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
@@ -30,6 +34,42 @@ pub struct Cli {
     pub daemon: bool,
 }
 
+/// Warn when the legacy executable name is used for a CLI invocation.
+///
+/// A plain TUI launch and the systemd-compatible daemon invocation stay quiet.
+pub fn warn_if_legacy_invocation(args: &[OsString]) {
+    if !should_warn_for_legacy_invocation(args) {
+        return;
+    }
+
+    // A deprecation notice must never turn an otherwise successful command
+    // into a failure when stderr is unavailable.
+    let stderr = std::io::stderr();
+    let warning = legacy_command_warning(stderr.is_terminal());
+    let _ = stderr.lock().write_all(warning.as_bytes());
+}
+
+fn legacy_command_warning(use_color: bool) -> &'static str {
+    if use_color {
+        LEGACY_COMMAND_WARNING_YELLOW
+    } else {
+        LEGACY_COMMAND_WARNING
+    }
+}
+
+fn should_warn_for_legacy_invocation(args: &[OsString]) -> bool {
+    let Some(executable) = args.first() else {
+        return false;
+    };
+    let is_legacy = Path::new(executable)
+        .file_name()
+        .is_some_and(|name| name == OsStr::new("kvn-tui"));
+    let is_quiet_invocation =
+        args.len() == 1 || (args.len() == 2 && args.get(1).is_some_and(|arg| arg == "--daemon"));
+
+    is_legacy && !is_quiet_invocation
+}
+
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Render a side-effect-free fixture used to capture documentation images.
@@ -40,7 +80,7 @@ enum Command {
         theme: String,
     },
 
-    /// Check whether kvn-tui and its runtime dependencies are ready.
+    /// Check whether kvn and its runtime dependencies are ready.
     Doctor,
 
     /// Show the daemon's current status as a summary line.
@@ -71,7 +111,7 @@ enum Command {
         command: ConfigCommand,
     },
 
-    /// Set up one or more optional kvn-tui integrations.
+    /// Set up one or more optional kvn integrations.
     #[command(group(
         ArgGroup::new("targets")
             .required(true)
@@ -295,14 +335,14 @@ fn validate_integration_privileges(
 ) -> Result<()> {
     if omarchy && effective_uid == 0 {
         anyhow::bail!(
-            "Omarchy integration changes user files; run `kvn-tui {action} --omarchy` without sudo"
+            "Omarchy integration changes user files; run `kvn {action} --omarchy` without sudo"
         );
     }
 
     if system {
         if effective_uid != 0 {
             anyhow::bail!(
-                "system integration requires root privileges; run `sudo kvn-tui {action} --polkit` and/or `sudo kvn-tui {action} --killswitch`"
+                "system integration requires root privileges; run `sudo kvn {action} --polkit` and/or `sudo kvn {action} --killswitch`"
             );
         }
         if !matches!(sudo_user, Some(user) if !user.is_empty() && user != "root") {
@@ -339,7 +379,7 @@ fn validate_current_integration_privileges(
 /// silently spawning a daemon would be surprising.
 fn attach_client() -> Result<IpcClient> {
     IpcClient::connect().context(
-        "Cannot reach the kvn-tui daemon. Start it with `kvn-tui` or \
+        "Cannot reach the kvn-tui daemon. Start it with `kvn` or \
          `systemctl --user start kvn-tui.service`.",
     )
 }
@@ -420,7 +460,7 @@ fn run_toggle() -> Result<()> {
         return Ok(());
     }
     let Some(id) = snap.settings.last_connected_profile else {
-        anyhow::bail!("no previous profile to connect — run `kvn-tui connect <name>` first");
+        anyhow::bail!("no previous profile to connect — run `kvn connect <name>` first");
     };
     let snap = send_command(&mut client, IpcCommand::ConnectProfile { profile_id: id })?;
     println!("{}", format_status_line(&snap));
@@ -775,6 +815,73 @@ esac
     }
 
     #[test]
+    fn canonical_clap_name_is_kvn() {
+        use clap::CommandFactory;
+
+        let mut command = Cli::command();
+        assert_eq!(command.get_name(), "kvn");
+        let help = command.render_long_help().to_string();
+        assert!(help.contains("Usage: kvn"));
+    }
+
+    #[test]
+    fn legacy_warning_invocation_matrix() {
+        fn warns(args: &[&str]) -> bool {
+            let args = args.iter().map(OsString::from).collect::<Vec<_>>();
+            should_warn_for_legacy_invocation(&args)
+        }
+
+        for args in [
+            &["kvn"][..],
+            &["kvn", "doctor"],
+            &["kvn", "--daemon"],
+            &["kvn", "--help"],
+            &["kvn", "--version"],
+            &["kvn-tui"],
+            &["kvn-tui", "--daemon"],
+        ] {
+            assert!(!warns(args), "unexpected warning for {args:?}");
+        }
+
+        for args in [
+            &["kvn-tui", "doctor"][..],
+            &["kvn-tui", "setup"],
+            &["kvn-tui", "status"],
+            &["kvn-tui", "--help"],
+            &["kvn-tui", "--version"],
+        ] {
+            assert!(warns(args), "missing warning for {args:?}");
+        }
+    }
+
+    #[test]
+    fn legacy_warning_uses_executable_basename() {
+        let legacy = vec![
+            OsString::from("/usr/local/bin/kvn-tui"),
+            OsString::from("doctor"),
+        ];
+        let canonical = vec![
+            OsString::from("/usr/local/bin/kvn"),
+            OsString::from("doctor"),
+        ];
+
+        assert!(should_warn_for_legacy_invocation(&legacy));
+        assert!(!should_warn_for_legacy_invocation(&canonical));
+    }
+
+    #[test]
+    fn legacy_warning_is_yellow_only_for_terminals_and_has_a_blank_line() {
+        assert_eq!(
+            legacy_command_warning(false),
+            "Warning: `kvn-tui` is a legacy command and will be removed in a future release.\nUse `kvn` instead.\n\n"
+        );
+        assert_eq!(
+            legacy_command_warning(true),
+            "\x1b[33mWarning: `kvn-tui` is a legacy command and will be removed in a future release.\nUse `kvn` instead.\x1b[0m\n\n"
+        );
+    }
+
+    #[test]
     fn waybar_status_flag_detected() {
         let cli = Cli::parse_from(["kvn-tui", "--waybar-status"]);
         assert!(cli.waybar_status);
@@ -894,7 +1001,7 @@ esac
         let system_as_user = validate_integration_privileges(false, true, 1000, None, "clean")
             .unwrap_err()
             .to_string();
-        assert!(system_as_user.contains("sudo kvn-tui clean"));
+        assert!(system_as_user.contains("sudo kvn clean"));
     }
 
     #[test]
@@ -1293,8 +1400,8 @@ esac
             "Type=Application",
             "Name=kvn-tui",
             "GenericName=VPN Client",
-            "Exec=omarchy-launch-or-focus-tui --app-id=org.omarchy.kvn-tui kvn-tui",
-            "TryExec=kvn-tui",
+            "Exec=omarchy-launch-or-focus-tui --app-id=org.omarchy.kvn-tui kvn",
+            "TryExec=kvn",
             "Terminal=false",
             "Icon=kvn-tui",
             "Categories=Network;Utility;",
@@ -1346,7 +1453,7 @@ esac
             .iter()
             .find(|entry| entry["id"] == "kvn-tui")
             .expect("legacy command module entry");
-        assert_eq!(entry["exec"], "kvn-tui --waybar-status");
+        assert_eq!(entry["exec"], "kvn --waybar-status");
         assert!(!home.join(".config/omarchy/plugins/yarikov.omakvn").exists());
     }
 
@@ -1708,7 +1815,7 @@ esac
 
         let config = fs::read_to_string(waybar.join("config.jsonc")).unwrap();
         assert!(config.contains(r#""custom/kvn-tui""#));
-        assert!(config.contains(r#""exec": "kvn-tui --waybar-status""#));
+        assert!(config.contains(r#""exec": "kvn --waybar-status""#));
         assert!(
             fs::read_to_string(waybar.join("style.css"))
                 .unwrap()

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -74,10 +74,7 @@ pub fn run() -> Result<()> {
 }
 
 fn collect() -> Vec<Check> {
-    let mut checks = vec![Check::pass(format!(
-        "kvn-tui {}",
-        env!("CARGO_PKG_VERSION")
-    ))];
+    let mut checks = vec![Check::pass(format!("kvn {}", env!("CARGO_PKG_VERSION")))];
 
     match find_singbox() {
         Some(path) => {
@@ -165,7 +162,7 @@ fn check_singbox_version(path: &Path) -> Check {
     if !output.status.success() {
         return Check::failure(
             format!("sing-box found at {display}, but `version` failed"),
-            "Reinstall sing-box and run `kvn-tui doctor` again.",
+            "Reinstall sing-box and run `kvn doctor` again.",
         );
     }
 
@@ -222,7 +219,7 @@ fn check_capabilities(path: &Path) -> Check {
     let Ok(output) = output else {
         return Check::warning(
             "could not inspect sing-box capabilities because `getcap` is unavailable",
-            "Install `libcap` and run `kvn-tui doctor` again.",
+            "Install `libcap` and run `kvn doctor` again.",
         );
     };
     let text = String::from_utf8_lossy(&output.stdout).to_ascii_lowercase();
@@ -282,7 +279,7 @@ fn check_daemon() -> Vec<Check> {
     match crate::ipc::socket_path() {
         Err(error) => checks.push(Check::failure(
             format!("daemon IPC path is unavailable: {error}"),
-            "Run kvn-tui from a desktop user session with XDG_RUNTIME_DIR set.",
+            "Run kvn from a desktop user session with XDG_RUNTIME_DIR set.",
         )),
         Ok(path) if crate::ipc::is_daemon_running() => checks.push(Check::pass(format!(
             "daemon IPC socket is reachable: {}",
@@ -290,7 +287,7 @@ fn check_daemon() -> Vec<Check> {
         ))),
         Ok(_) => checks.push(Check::warning(
             "daemon IPC socket is not reachable",
-            "Start it with `systemctl --user start kvn-tui.service`; kvn-tui can also start it on demand.",
+            "Start it with `systemctl --user start kvn-tui.service`; kvn can also start it on demand.",
         )),
     }
     checks
@@ -343,7 +340,7 @@ fn check_killswitch() -> Check {
     let Ok(metadata) = path.metadata() else {
         return Check::warning(
             "kill switch helper metadata could not be read",
-            "Reinstall it with `sudo kvn-tui setup --killswitch`.",
+            "Reinstall it with `sudo kvn setup --killswitch`.",
         );
     };
     let mode = metadata.permissions().mode() & 0o777;
@@ -354,7 +351,7 @@ fn check_killswitch() -> Check {
                 metadata.uid(),
                 mode
             ),
-            "Reinstall it with `sudo kvn-tui setup --killswitch`.",
+            "Reinstall it with `sudo kvn setup --killswitch`.",
         );
     }
 
@@ -367,11 +364,11 @@ fn check_killswitch() -> Check {
         }
         Ok(_) => Check::warning(
             "kill switch helper is installed but passwordless authorization is unavailable",
-            "Run `sudo kvn-tui setup --killswitch`, then log out and back in.",
+            "Run `sudo kvn setup --killswitch`, then log out and back in.",
         ),
         Err(_) => Check::warning(
             "kill switch helper is installed but `sudo` could not be executed",
-            "Install sudo and run `sudo kvn-tui setup --killswitch`.",
+            "Install sudo and run `sudo kvn setup --killswitch`.",
         ),
     }
 }
@@ -380,7 +377,7 @@ fn check_polkit() -> Check {
     let Some(identity) = polkit_process_identity() else {
         return Check::warning(
             "polkit authorization could not be checked",
-            "Run `kvn-tui doctor` again or inspect polkit with `sudo kvn-tui setup --polkit`.",
+            "Run `kvn doctor` again or inspect polkit with `sudo kvn setup --polkit`.",
         );
     };
     for action in POLKIT_DNS_ACTIONS {
@@ -390,7 +387,7 @@ fn check_polkit() -> Check {
         let Ok(output) = output else {
             return Check::warning(
                 "`pkcheck` is unavailable, so polkit authorization could not be checked",
-                "Install the `polkit` package and run `kvn-tui doctor` again.",
+                "Install the `polkit` package and run `kvn doctor` again.",
             );
         };
 
@@ -401,7 +398,7 @@ fn check_polkit() -> Check {
             Some(1 | 2) => {
                 return Check::warning(
                     format!("passwordless polkit authorization is missing for {action}"),
-                    "Run `sudo kvn-tui setup --polkit`, then log out and back in.",
+                    "Run `sudo kvn setup --polkit`, then log out and back in.",
                 );
             }
             _ => {
@@ -411,7 +408,7 @@ fn check_polkit() -> Check {
                         "polkit authorization for {action} could not be checked: {}",
                         error.trim()
                     ),
-                    "Verify that polkit is running, then run `kvn-tui doctor` again.",
+                    "Verify that polkit is running, then run `kvn doctor` again.",
                 );
             }
         }
@@ -441,7 +438,7 @@ fn check_omarchy() -> Check {
     match crate::omarchy::detect_omarchy_theme() {
         Some(_) if omarchy_v4_detected() && !omakvn_plugin_installed() => Check::warning(
             format!("Omarchy 4 detected; {OMAKVN_PLUGIN_ID} plugin is not installed"),
-            "Run `kvn-tui setup --omarchy` to install the Omarchy Shell plugin.",
+            "Run `kvn setup --omarchy` to install the Omarchy Shell plugin.",
         ),
         Some(theme) => Check::pass(format!("Omarchy detected; active theme: {theme}")),
         None => Check::optional("Omarchy was not detected (optional)"),
@@ -689,7 +686,7 @@ mod tests {
         assert!(missing.message.contains(OMAKVN_PLUGIN_ID));
         assert_eq!(
             missing.remedy.as_deref(),
-            Some("Run `kvn-tui setup --omarchy` to install the Omarchy Shell plugin.")
+            Some("Run `kvn setup --omarchy` to install the Omarchy Shell plugin.")
         );
 
         let plugin = config.path().join("omarchy/plugins").join(OMAKVN_PLUGIN_ID);
@@ -718,7 +715,7 @@ mod tests {
         assert_eq!(check.level, Level::Warning);
         assert_eq!(
             check.remedy.as_deref(),
-            Some("Run `sudo kvn-tui setup --polkit`, then log out and back in.")
+            Some("Run `sudo kvn setup --polkit`, then log out and back in.")
         );
         executable(dir.path(), "pkcheck", "echo unavailable >&2; exit 127");
         assert_eq!(check_polkit().level, Level::Warning);

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -189,7 +189,7 @@ impl IpcClient {
     }
 
     /// Read a single state snapshot line, for one-shot CLI clients
-    /// (`kvn-tui status`, `kvn-tui connect`). Reads byte-wise from the raw
+    /// (`kvn status`, `kvn connect`). Reads byte-wise from the raw
     /// stream so nothing past the first `\n` is consumed — a follow-up read
     /// after sending a command still sees the daemon's next broadcast.
     pub fn read_snapshot(&mut self, timeout: Duration) -> anyhow::Result<StateSnapshot> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,9 @@ use crate::paths::ensure_config_dirs;
 
 /// Entry point for the TUI VPN client.
 fn main() -> Result<()> {
-    let cli = cli::Cli::parse();
+    let args = std::env::args_os().collect::<Vec<_>>();
+    cli::warn_if_legacy_invocation(&args);
+    let cli = cli::Cli::parse_from(args);
 
     if let Some(result) = cli::try_run_from_parsed(&cli) {
         return result;

--- a/src/services/killswitch.rs
+++ b/src/services/killswitch.rs
@@ -7,7 +7,7 @@
 //! exceptions while sing-box is establishing the VPN tunnel.
 //!
 //! See `contrib/setup-killswitch.sh` for the one-time setup that the user
-//! runs as `sudo kvn-tui setup --killswitch`.
+//! runs as `sudo kvn setup --killswitch`.
 
 use anyhow::{Context, Result, bail};
 use std::net::{SocketAddr, ToSocketAddrs};
@@ -23,7 +23,7 @@ fn helper_present() -> bool {
 fn run_helper(args: &[&str]) -> Result<()> {
     if !helper_present() {
         bail!(
-            "kill switch helper not installed at {} — run `sudo kvn-tui setup --killswitch`",
+            "kill switch helper not installed at {} — run `sudo kvn setup --killswitch`",
             HELPER
         );
     }

--- a/tests/cli_invocation.rs
+++ b/tests/cli_invocation.rs
@@ -1,0 +1,44 @@
+use std::os::unix::fs::symlink;
+use std::process::{Command, Output};
+
+const LEGACY_WARNING: &str = "Warning: `kvn-tui` is a legacy command and will be removed in a future release.\nUse `kvn` instead.\n\n";
+
+fn invoke_through_symlink(name: &str, argument: &str) -> Output {
+    let root = tempfile::tempdir().unwrap();
+    let executable = root.path().join(name);
+    symlink(env!("CARGO_BIN_EXE_kvn-tui"), &executable).unwrap();
+    Command::new(&executable).arg(argument).output().unwrap()
+}
+
+#[test]
+fn help_is_identical_except_for_the_legacy_stderr_warning() {
+    let canonical = invoke_through_symlink("kvn", "--help");
+    let legacy = invoke_through_symlink("kvn-tui", "--help");
+
+    assert!(canonical.status.success());
+    assert_eq!(canonical.status, legacy.status);
+    assert_eq!(canonical.stdout, legacy.stdout);
+    assert!(canonical.stderr.is_empty());
+    assert_eq!(String::from_utf8(legacy.stderr).unwrap(), LEGACY_WARNING);
+    assert!(
+        String::from_utf8(canonical.stdout)
+            .unwrap()
+            .contains("Usage: kvn")
+    );
+}
+
+#[test]
+fn version_is_identical_except_for_the_legacy_stderr_warning() {
+    let canonical = invoke_through_symlink("kvn", "--version");
+    let legacy = invoke_through_symlink("kvn-tui", "--version");
+
+    assert!(canonical.status.success());
+    assert_eq!(canonical.status, legacy.status);
+    assert_eq!(canonical.stdout, legacy.stdout);
+    assert_eq!(
+        String::from_utf8(canonical.stdout).unwrap(),
+        format!("kvn {}\n", env!("CARGO_PKG_VERSION"))
+    );
+    assert!(canonical.stderr.is_empty());
+    assert_eq!(String::from_utf8(legacy.stderr).unwrap(), LEGACY_WARNING);
+}


### PR DESCRIPTION
## Summary

Make `kvn` the canonical command while preserving `kvn-tui` as a legacy compatibility entrypoint without breaking existing installations.

Existing configuration, runtime, systemd, kill-switch, and Omarchy identifiers remain unchanged.

## Changes

- install `kvn` as a symlink to the existing `kvn-tui` executable in Arch, AUR, and release packaging
- detect legacy CLI invocations through `argv[0]` and print a yellow deprecation warning to stderr
- keep plain `kvn-tui` TUI launches and `kvn-tui --daemon` silent
- use `kvn` in CLI help, version output, diagnostics, documentation, and newly generated Omarchy commands
