### PR TITLE
feat(ui): add support development prompt

### DIFF
--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -10,6 +10,7 @@ install=kvn-tui.install
 depends=('gcc-libs' 'dbus' 'libcap' 'sing-box')
 optdepends=(
     'git: prepare Git resources required by package migrations'
+    'xdg-utils: open the project support page from the TUI'
     'wl-clipboard: clipboard integration on Wayland'
     'xclip: clipboard integration on X11 (preferred)'
     'xsel: clipboard integration on X11 (alternative)'

--- a/pkg/aur/PKGBUILD.bin
+++ b/pkg/aur/PKGBUILD.bin
@@ -10,6 +10,7 @@ install=kvn-tui.install
 depends=('gcc-libs' 'dbus' 'libcap' 'sing-box')
 optdepends=(
     'git: prepare Git resources required by package migrations'
+    'xdg-utils: open the project support page from the TUI'
     'wl-clipboard: clipboard integration on Wayland'
     'xclip: clipboard integration on X11 (preferred)'
     'xsel: clipboard integration on X11 (alternative)'

--- a/src/app/effect.rs
+++ b/src/app/effect.rs
@@ -29,6 +29,9 @@ pub enum Effect {
     ResetGeoUpdateSchedules,
     WriteState,
     SaveConfig,
+    PersistSupportPrompt {
+        previous: crate::support_prompt::SupportPromptState,
+    },
     SaveConfigConflict {
         edited: Box<Config>,
         conflicts: Vec<String>,

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -22,6 +22,7 @@ pub enum Overlay {
     DnsSettings,
     ThemeSettings,
     ServiceRouting,
+    Support,
     Migration,
 }
 
@@ -55,6 +56,7 @@ pub enum HelpContext {
     DnsSettings,
     ThemeSettings,
     ServiceRouting,
+    Support,
 }
 
 impl HelpContext {
@@ -67,6 +69,7 @@ impl HelpContext {
             Self::DnsSettings => Overlay::DnsSettings,
             Self::ThemeSettings => Overlay::ThemeSettings,
             Self::ServiceRouting => Overlay::ServiceRouting,
+            Self::Support => Overlay::Support,
         }
     }
 }
@@ -226,6 +229,11 @@ pub struct Model {
     /// Active package migration. While set, the daemon keeps the current VPN
     /// alive but rejects every user/config mutation.
     pub migration: Option<MigrationStatus>,
+    /// Persisted schedule for the optional project-support prompt.
+    pub support_prompt: crate::support_prompt::SupportPromptState,
+    /// TUI-local cursor inside the support prompt. It is intentionally not
+    /// broadcast: opening a browser belongs to the client that pressed Enter.
+    pub support_selected: usize,
     pub selected: usize,
     pub status: AppStatus,
     /// Monotonic revision of the latest status event. TUI clients use it to
@@ -402,6 +410,10 @@ impl Model {
         };
 
         let migration = crate::migrations::load_ui_status().ok().flatten();
+        let support_prompt = crate::support_prompt::load_for_daemon(
+            config.settings.geo_routing.current_region.is_some(),
+            chrono::Utc::now(),
+        );
         let (mut connection, selected, mut status) =
             Self::resolve_startup_state(&config, default_selected);
         if stale_cleanup_failed {
@@ -464,6 +476,8 @@ impl Model {
             config,
             config_persistence_blocked,
             migration,
+            support_prompt,
+            support_selected: 0,
             selected,
             status: AppStatus::Info(String::new()),
             status_revision: 0,
@@ -575,6 +589,8 @@ impl Model {
             config,
             config_persistence_blocked: false,
             migration: None,
+            support_prompt: crate::support_prompt::SupportPromptState::default(),
+            support_selected: 0,
             selected,
             status: AppStatus::Info(String::new()),
             status_revision: 0,
@@ -803,6 +819,8 @@ impl Model {
             config,
             config_persistence_blocked: false,
             migration: None,
+            support_prompt: crate::support_prompt::SupportPromptState::default(),
+            support_selected: 0,
             selected,
             status: AppStatus::Info(String::new()),
             status_revision: 0,

--- a/src/app/msg.rs
+++ b/src/app/msg.rs
@@ -220,6 +220,9 @@ pub enum GeoResult {
 #[serde(tag = "cmd")]
 pub enum IpcCommand {
     Attach,
+    /// Ask the daemon to show the support prompt when its persisted deadline
+    /// is due. Only a fresh TUI launch sends this command.
+    CheckSupportPrompt,
     Detach,
     Key {
         code: String,
@@ -263,6 +266,9 @@ pub enum IpcCommand {
     SetAutoConnect {
         enabled: bool,
     },
+    ResolveSupportPrompt {
+        resolution: SupportPromptResolution,
+    },
     Paste {
         text: String,
     },
@@ -294,6 +300,13 @@ pub enum IpcCommand {
     ClientError {
         message: String,
     },
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SupportPromptResolution {
+    RemindLater,
+    Dismiss,
 }
 
 #[cfg(test)]
@@ -341,6 +354,7 @@ mod tests {
         };
         let cmds = vec![
             IpcCommand::Attach,
+            IpcCommand::CheckSupportPrompt,
             IpcCommand::Detach,
             IpcCommand::Key {
                 code: "Char".into(),
@@ -365,6 +379,9 @@ mod tests {
             },
             IpcCommand::SetKillSwitch { enabled: true },
             IpcCommand::SetAutoConnect { enabled: false },
+            IpcCommand::ResolveSupportPrompt {
+                resolution: SupportPromptResolution::RemindLater,
+            },
             IpcCommand::Paste {
                 text: "hello".into(),
             },

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -92,7 +92,6 @@ pub fn update(model: &mut Model, msg: Msg) -> Vec<Effect> {
             model.singbox_pid = Some(pid);
             model.connection = ConnectionState::Connected;
             model.connecting_profile_id = None;
-            model.overlay = Overlay::None;
             // Fresh sing-box → fresh counters. Drop the previous sample so the
             // first delta is computed against zero rather than a stale value.
             model.traffic = TrafficStats::default();
@@ -803,6 +802,12 @@ pub(super) fn commit_geo_region(model: &mut Model, region: GeoRegion) -> Vec<Eff
     let changed = old_region != Some(region);
     model.config.settings.geo_routing.set_region(region);
     let mut effects = vec![Effect::SaveConfig];
+    let previous_support = model.support_prompt.clone();
+    if model.support_prompt.schedule_initial(chrono::Utc::now()) {
+        effects.push(Effect::PersistSupportPrompt {
+            previous: previous_support,
+        });
+    }
     if changed {
         effects.push(Effect::RefreshGeoLastUpdated);
     }
@@ -2427,6 +2432,9 @@ mod tests {
             effects,
             vec![
                 Effect::SaveConfig,
+                Effect::PersistSupportPrompt {
+                    previous: crate::support_prompt::SupportPromptState::default(),
+                },
                 Effect::RefreshGeoLastUpdated,
                 app_log_info("Geo region: cn"),
                 app_log_info("Checking geo databases..."),
@@ -2513,6 +2521,9 @@ mod tests {
             effects,
             vec![
                 Effect::SaveConfig,
+                Effect::PersistSupportPrompt {
+                    previous: crate::support_prompt::SupportPromptState::default(),
+                },
                 Effect::RefreshGeoLastUpdated,
                 app_log_info("Geo region: global"),
                 app_log_info("Routing mode: Global")
@@ -2611,6 +2622,9 @@ mod tests {
             effects,
             vec![
                 Effect::SaveConfig,
+                Effect::PersistSupportPrompt {
+                    previous: crate::support_prompt::SupportPromptState::default(),
+                },
                 Effect::RefreshGeoLastUpdated,
                 app_log_info("Geo region: ru"),
                 app_log_info("Checking geo databases..."),
@@ -3347,6 +3361,25 @@ mod tests {
                 Effect::SaveConfig
             ]
         );
+    }
+
+    #[test]
+    fn connected_does_not_close_open_overlay() {
+        let mut model = Model::test_new(crate::config::profile::Config::default());
+        model.connection = ConnectionState::Connecting;
+        model.overlay = Overlay::ConfirmDelete;
+
+        update(
+            &mut model,
+            Msg::Connected {
+                pid: 12345,
+                profile_id: uuid::Uuid::new_v4(),
+                attempt_id: 0,
+            },
+        );
+
+        assert_eq!(model.connection, ConnectionState::Connected);
+        assert_eq!(model.overlay, Overlay::ConfirmDelete);
     }
 
     #[test]

--- a/src/app/update/key.rs
+++ b/src/app/update/key.rs
@@ -33,6 +33,9 @@ pub(super) fn handle_key(model: &mut Model, key: KeyEvent) -> Vec<Effect> {
         Overlay::DnsSettings => handle_dns_settings(model, key),
         Overlay::ThemeSettings => handle_theme_picker(model, key),
         Overlay::ServiceRouting => handle_service_routing(model, key),
+        // Navigation and activation are client-local because the selected
+        // action may need to launch a browser in that client's GUI session.
+        Overlay::Support => vec![],
         Overlay::Migration => vec![],
     }
 }
@@ -65,6 +68,7 @@ fn open_help(model: &mut Model) {
         Overlay::DnsSettings => HelpContext::DnsSettings,
         Overlay::ThemeSettings => HelpContext::ThemeSettings,
         Overlay::ServiceRouting => HelpContext::ServiceRouting,
+        Overlay::Support => HelpContext::Support,
         Overlay::Migration => return,
         Overlay::Help(_) => return,
     };
@@ -580,6 +584,16 @@ pub(super) fn handle_ipc_command(
     }
     let effects = match cmd {
         IpcCommand::Attach => vec![],
+        IpcCommand::CheckSupportPrompt => {
+            if model.overlay == Overlay::None
+                && model.config.settings.geo_routing.current_region.is_some()
+                && model.support_prompt.is_due(chrono::Utc::now())
+            {
+                model.support_selected = 0;
+                model.overlay = Overlay::Support;
+            }
+            vec![]
+        }
         IpcCommand::Detach => vec![],
         IpcCommand::Key { code, char, ctrl } => {
             let key_event = rebuild_key_event(&code, char, ctrl);
@@ -675,6 +689,23 @@ pub(super) fn handle_ipc_command(
                 effects
             }
         }
+        IpcCommand::ResolveSupportPrompt { resolution } => {
+            if model.overlay != Overlay::Support {
+                vec![]
+            } else {
+                let previous = model.support_prompt.clone();
+                match resolution {
+                    crate::app::msg::SupportPromptResolution::RemindLater => {
+                        model.support_prompt.remind_later(chrono::Utc::now());
+                    }
+                    crate::app::msg::SupportPromptResolution::Dismiss => {
+                        model.support_prompt.dismiss();
+                    }
+                }
+                model.overlay = Overlay::None;
+                vec![Effect::PersistSupportPrompt { previous }]
+            }
+        }
         IpcCommand::Paste { text } => handle_clipboard_text(model, &text),
         IpcCommand::Copied { name, count } => handle_copied_status(model, name, count),
         IpcCommand::ReloadConfig => {
@@ -730,6 +761,7 @@ fn handle_go_first(model: &mut Model) -> Vec<Effect> {
         Overlay::ServiceRouting => {
             crate::ui::nav::select_first(&mut model.service_routing_selected);
         }
+        Overlay::Support => crate::ui::nav::select_first(&mut model.support_selected),
         Overlay::Help(mut state) => {
             state.selected = crate::ui::help::first_command(&crate::ui::help::rows(state.context));
             model.overlay = Overlay::Help(state);
@@ -1228,6 +1260,7 @@ fn is_connection_affected(model: &Model) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::msg::IpcCommand;
     use crate::config::profile::{
         DnsPreset, DnsServer, DnsStrategy, Profile, Subscription, SubscriptionAutoUpdate,
     };
@@ -1235,6 +1268,64 @@ mod tests {
     use crossterm::event::{KeyCode, KeyEvent};
     use uuid::Uuid;
 
+    #[test]
+    fn support_prompt_check_requires_geo_and_due_deadline() {
+        let mut model = crate::test_helpers::model_with_profiles(vec![]);
+        model.support_prompt.next_show_at = Some(chrono::Utc::now() - chrono::Duration::seconds(1));
+
+        let effects = handle_ipc_command(&mut model, IpcCommand::CheckSupportPrompt);
+        assert_eq!(model.overlay, Overlay::None);
+        assert_eq!(effects, vec![Effect::BroadcastState]);
+
+        model
+            .config
+            .settings
+            .geo_routing
+            .set_region(crate::config::profile::GeoRegion::Global);
+        let effects = handle_ipc_command(&mut model, IpcCommand::CheckSupportPrompt);
+        assert_eq!(model.overlay, Overlay::Support);
+        assert_eq!(model.support_selected, 0);
+        assert_eq!(effects, vec![Effect::BroadcastState]);
+    }
+
+    #[test]
+    fn support_prompt_resolutions_persist_and_close() {
+        use crate::app::msg::SupportPromptResolution;
+
+        let mut model = crate::test_helpers::model_with_profiles(vec![]);
+        model.overlay = Overlay::Support;
+        model.support_prompt.next_show_at = Some(chrono::Utc::now() - chrono::Duration::days(1));
+        let previous = model.support_prompt.clone();
+        let effects = handle_ipc_command(
+            &mut model,
+            IpcCommand::ResolveSupportPrompt {
+                resolution: SupportPromptResolution::RemindLater,
+            },
+        );
+        assert_eq!(model.overlay, Overlay::None);
+        assert!(
+            model.support_prompt.next_show_at
+                > Some(chrono::Utc::now() + chrono::Duration::days(29))
+        );
+        assert_eq!(
+            effects,
+            vec![
+                Effect::PersistSupportPrompt { previous },
+                Effect::BroadcastState
+            ]
+        );
+
+        model.overlay = Overlay::Support;
+        let effects = handle_ipc_command(
+            &mut model,
+            IpcCommand::ResolveSupportPrompt {
+                resolution: SupportPromptResolution::Dismiss,
+            },
+        );
+        assert!(model.support_prompt.dismissed);
+        assert_eq!(model.support_prompt.next_show_at, None);
+        assert!(matches!(effects[0], Effect::PersistSupportPrompt { .. }));
+    }
     fn enter() -> KeyEvent {
         KeyEvent::from(KeyCode::Enter)
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -123,6 +123,7 @@ fn run_loop(
     loop {
         let msg = rx.recv()?;
         let config_before = model.config.clone();
+        let support_prompt_before = model.support_prompt.clone();
         let mut effects = update(model, msg);
         if effects
             .iter()
@@ -136,6 +137,7 @@ fn run_loop(
                 }
                 Err(error) => {
                     model.replace_config_preserving_selection(config_before);
+                    model.support_prompt = support_prompt_before;
                     let message = match crate::config::save_conflict_config(&edited) {
                         Ok(path) => format!(
                             "Failed to save config: {error:#}; unsaved version preserved at {}",
@@ -175,6 +177,7 @@ fn run_loop(
                     | Effect::ResetGeoUpdateSchedules
                     | Effect::WriteState
                     | Effect::SaveConfig
+                    | Effect::PersistSupportPrompt { .. }
                     | Effect::CommitEditedConfig { .. }
                     | Effect::UpdateSubscription { .. }
                     | Effect::BroadcastState
@@ -690,6 +693,20 @@ fn execute_daemon_effect(
             model.set_status(AppStatus::Error(
                 "Internal error: uncommitted SaveConfig effect".into(),
             ));
+        }
+        Effect::PersistSupportPrompt { previous } => {
+            let result = crate::paths::support_prompt_path()
+                .context("Failed to determine support prompt state path")
+                .and_then(|path| crate::support_prompt::save_at(&path, &model.support_prompt));
+            if let Err(error) = result {
+                model.support_prompt = previous;
+                if model.support_prompt.is_due(chrono::Utc::now()) {
+                    model.overlay = Overlay::Support;
+                }
+                let message = format!("Failed to save support prompt state: {error:#}");
+                model.set_status(AppStatus::Error(message.clone()));
+                crate::services::log_tailer::append_app_log("ERROR", &message);
+            }
         }
         Effect::SaveConfigConflict { edited, conflicts } => {
             match crate::config::save_conflict_config(&edited) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod paths;
 mod redaction;
 mod services;
 mod singbox;
+mod support_prompt;
 mod tui_client;
 mod ui;
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -42,6 +42,16 @@ pub fn config_dir() -> Option<PathBuf> {
     dirs::config_dir().map(|d| d.join("kvn-tui"))
 }
 
+/// Return the per-user application state directory.
+pub fn state_dir() -> Option<PathBuf> {
+    dirs::state_dir().map(|d| d.join("kvn-tui"))
+}
+
+/// Return the persisted support-prompt schedule.
+pub fn support_prompt_path() -> Option<PathBuf> {
+    state_dir().map(|d| d.join("support-prompt.json"))
+}
+
 /// Return the path to `profiles.json`.
 pub fn profiles_path() -> Option<PathBuf> {
     config_dir().map(|d| d.join("profiles.json"))

--- a/src/support_prompt.rs
+++ b/src/support_prompt.rs
@@ -1,0 +1,210 @@
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+
+pub const INITIAL_DELAY_DAYS: i64 = 7;
+pub const REMINDER_DELAY_DAYS: i64 = 30;
+pub const SUPPORT_URL: &str = "https://web.tribute.tg/d/QbU";
+
+/// Small, non-config UX state. Keeping it outside profiles.json avoids making
+/// an optional prompt part of the versioned VPN configuration schema.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SupportPromptState {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_show_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub dismissed: bool,
+}
+
+impl SupportPromptState {
+    pub fn schedule_initial(&mut self, now: DateTime<Utc>) -> bool {
+        if self.dismissed || self.next_show_at.is_some() {
+            return false;
+        }
+        self.next_show_at = Some(now + Duration::days(INITIAL_DELAY_DAYS));
+        true
+    }
+
+    pub fn is_due(&self, now: DateTime<Utc>) -> bool {
+        !self.dismissed && self.next_show_at.is_some_and(|deadline| now >= deadline)
+    }
+
+    pub fn remind_later(&mut self, now: DateTime<Utc>) {
+        self.dismissed = false;
+        self.next_show_at = Some(now + Duration::days(REMINDER_DELAY_DAYS));
+    }
+
+    pub fn dismiss(&mut self) {
+        self.dismissed = true;
+        self.next_show_at = None;
+    }
+}
+
+pub fn load_at(path: &Path) -> Result<Option<SupportPromptState>> {
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error).with_context(|| format!("Failed to read {path:?}")),
+    };
+    serde_json::from_str(&contents)
+        .map(Some)
+        .with_context(|| format!("Failed to parse {path:?}"))
+}
+
+pub fn save_at(path: &Path, state: &SupportPromptState) -> Result<()> {
+    let parent = path
+        .parent()
+        .with_context(|| format!("Support prompt path {path:?} has no parent"))?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("Failed to create support prompt directory {parent:?}"))?;
+    let json = serde_json::to_string_pretty(state)?;
+    crate::atomic_write::write(path, json.as_bytes())
+}
+
+pub fn load_for_daemon(geo_configured: bool, now: DateTime<Utc>) -> SupportPromptState {
+    let Some(path) = crate::paths::support_prompt_path() else {
+        tracing::warn!("Failed to determine support prompt state path");
+        return SupportPromptState::default();
+    };
+    let mut state = match load_at(&path) {
+        Ok(Some(state)) => state,
+        Ok(None) => SupportPromptState::default(),
+        Err(error) => {
+            tracing::warn!("Resetting invalid support prompt state: {error:#}");
+            SupportPromptState::default()
+        }
+    };
+    if geo_configured
+        && state.schedule_initial(now)
+        && let Err(error) = save_at(&path, &state)
+    {
+        tracing::warn!("Failed to persist support prompt schedule: {error:#}");
+    }
+    state
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn now() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 9, 10, 12, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn initial_schedule_becomes_due_after_seven_days() {
+        let now = now();
+        let mut state = SupportPromptState::default();
+        assert!(state.schedule_initial(now));
+        assert!(!state.is_due(now + Duration::days(7) - Duration::seconds(1)));
+        assert!(state.is_due(now + Duration::days(7)));
+        assert!(!state.schedule_initial(now + Duration::days(1)));
+    }
+
+    #[test]
+    fn reminder_moves_deadline_thirty_days() {
+        let now = now();
+        let mut state = SupportPromptState::default();
+        state.remind_later(now);
+        assert!(!state.is_due(now + Duration::days(30) - Duration::seconds(1)));
+        assert!(state.is_due(now + Duration::days(30)));
+    }
+
+    #[test]
+    fn dismissal_is_permanent() {
+        let now = now();
+        let mut state = SupportPromptState::default();
+        state.schedule_initial(now);
+        state.dismiss();
+        assert!(!state.is_due(now + Duration::days(3650)));
+        assert!(!state.schedule_initial(now));
+    }
+
+    #[test]
+    fn state_roundtrips_atomically() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state/support-prompt.json");
+        let mut state = SupportPromptState::default();
+        state.remind_later(now());
+        save_at(&path, &state).unwrap();
+        assert_eq!(load_at(&path).unwrap(), Some(state));
+        assert!(!path.with_extension("json.tmp").exists());
+    }
+
+    #[test]
+    fn state_io_reports_unreadable_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(load_at(dir.path()).is_err());
+
+        let parent_file = dir.path().join("not-a-directory");
+        fs::write(&parent_file, "file").unwrap();
+        assert!(
+            save_at(
+                &parent_file.join("support-prompt.json"),
+                &SupportPromptState::default()
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn absent_state_is_not_scheduled_before_geo_setup() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("support-prompt.json");
+        let state = load_at(&path).unwrap().unwrap_or_default();
+        assert_eq!(state, SupportPromptState::default());
+    }
+
+    #[test]
+    fn daemon_initializes_schedule_only_after_geo_setup() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let _state_home = crate::test_helpers::EnvVarGuard::set("XDG_STATE_HOME", dir.path());
+        let path = crate::paths::support_prompt_path().unwrap();
+
+        assert_eq!(load_for_daemon(false, now()), SupportPromptState::default());
+        assert!(!path.exists());
+
+        let state = load_for_daemon(true, now());
+        assert_eq!(
+            state.next_show_at,
+            Some(now() + Duration::days(INITIAL_DELAY_DAYS))
+        );
+        assert_eq!(load_at(&path).unwrap(), Some(state));
+    }
+
+    #[test]
+    fn daemon_replaces_corrupt_state_with_fresh_schedule() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let _state_home = crate::test_helpers::EnvVarGuard::set("XDG_STATE_HOME", dir.path());
+        let path = crate::paths::support_prompt_path().unwrap();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "not json").unwrap();
+
+        let state = load_for_daemon(true, now());
+        assert_eq!(
+            state.next_show_at,
+            Some(now() + Duration::days(INITIAL_DELAY_DAYS))
+        );
+        assert_eq!(load_at(&path).unwrap(), Some(state));
+    }
+
+    #[test]
+    fn daemon_preserves_existing_dismissal() {
+        let _guard = crate::test_helpers::ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let _state_home = crate::test_helpers::EnvVarGuard::set("XDG_STATE_HOME", dir.path());
+        let path = crate::paths::support_prompt_path().unwrap();
+        let mut dismissed = SupportPromptState::default();
+        dismissed.dismiss();
+        save_at(&path, &dismissed).unwrap();
+
+        assert_eq!(load_for_daemon(true, now()), dismissed);
+    }
+}

--- a/src/tui_client.rs
+++ b/src/tui_client.rs
@@ -1,3 +1,4 @@
+mod browser;
 mod clipboard;
 mod editor;
 mod input;
@@ -18,7 +19,7 @@ use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 
 use crate::app::model::{AppStatus, ConnectionState, Model, TrafficStats};
-use crate::app::msg::{IpcCommand, Msg};
+use crate::app::msg::{IpcCommand, Msg, SupportPromptResolution};
 use crate::ipc::IpcClient;
 use crate::services::LogTailer;
 use crate::ui::palette::to_rgb;
@@ -559,6 +560,11 @@ pub fn run() -> Result<()> {
     spawn_ticker(tx.clone());
     theme_watch::spawn_theme_watcher(tx.clone());
     client.spawn_reader(tx.clone(), 0)?;
+    // Only a normal, fresh TUI launch checks the prompt. Migration reconnects
+    // bypass this path and therefore defer it until the next invocation.
+    if initial_snapshot.migration.is_none() {
+        client.send(&IpcCommand::CheckSupportPrompt)?;
+    }
 
     let mut log_tailer = LogTailer::new(vec![
         (crate::paths::app_log_path(), "[app]"),
@@ -894,7 +900,9 @@ fn run_loop(
                 match key.code {
                     KeyCode::Char('g') => {
                         if completes_gg {
-                            if model.overlay == crate::app::model::Overlay::None
+                            if model.overlay == crate::app::model::Overlay::Support {
+                                model.support_selected = 0;
+                            } else if model.overlay == crate::app::model::Overlay::None
                                 && pane_focus == MainPaneFocus::Logs
                             {
                                 log_navigation.select_buffer_edge(
@@ -909,7 +917,11 @@ fn run_loop(
                         needs_redraw = true;
                     }
                     KeyCode::Char('q') | KeyCode::Esc => {
-                        if key.code == KeyCode::Esc
+                        if model.overlay == crate::app::model::Overlay::Support {
+                            client.send(&IpcCommand::ResolveSupportPrompt {
+                                resolution: SupportPromptResolution::RemindLater,
+                            })?;
+                        } else if key.code == KeyCode::Esc
                             && model.overlay == crate::app::model::Overlay::None
                             && pane_focus == MainPaneFocus::Logs
                             && log_navigation.is_visual()
@@ -927,6 +939,40 @@ fn run_loop(
                         let _ = client.send(&IpcCommand::Quit);
                         std::thread::sleep(Duration::from_millis(300));
                         break;
+                    }
+                    KeyCode::Char('j') | KeyCode::Down
+                        if model.overlay == crate::app::model::Overlay::Support =>
+                    {
+                        crate::ui::nav::select_next(&mut model.support_selected, 3);
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char('k') | KeyCode::Up
+                        if model.overlay == crate::app::model::Overlay::Support =>
+                    {
+                        crate::ui::nav::select_prev(&mut model.support_selected);
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char('G') if model.overlay == crate::app::model::Overlay::Support => {
+                        crate::ui::nav::select_last(&mut model.support_selected, 3);
+                        needs_redraw = true;
+                    }
+                    KeyCode::Enter if model.overlay == crate::app::model::Overlay::Support => {
+                        match model.support_selected {
+                            0 => match browser::open_support_page() {
+                                Ok(()) => client.send(&IpcCommand::ResolveSupportPrompt {
+                                    resolution: SupportPromptResolution::Dismiss,
+                                })?,
+                                Err(error) => client.send(&IpcCommand::ClientError {
+                                    message: format!("Failed to open support page: {error:#}"),
+                                })?,
+                            },
+                            1 => client.send(&IpcCommand::ResolveSupportPrompt {
+                                resolution: SupportPromptResolution::RemindLater,
+                            })?,
+                            _ => client.send(&IpcCommand::ResolveSupportPrompt {
+                                resolution: SupportPromptResolution::Dismiss,
+                            })?,
+                        }
                     }
                     KeyCode::Char('h') | KeyCode::Left
                         if model.overlay == crate::app::model::Overlay::None =>

--- a/src/tui_client/browser.rs
+++ b/src/tui_client/browser.rs
@@ -1,0 +1,19 @@
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result};
+
+pub(super) fn open_support_page() -> Result<()> {
+    let mut child = Command::new("xdg-open")
+        .arg(crate::support_prompt::SUPPORT_URL)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .context("could not start xdg-open")?;
+    // Reap the short-lived launcher without blocking the TUI. The browser
+    // itself is detached by xdg-open.
+    std::thread::spawn(move || {
+        let _ = child.wait();
+    });
+    Ok(())
+}

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -122,7 +122,8 @@ fn relevant_group(context: HelpContext) -> HelpGroup {
         | HelpContext::GeoRegions
         | HelpContext::DnsSettings
         | HelpContext::ThemeSettings
-        | HelpContext::ServiceRouting => HelpGroup::Dialogs,
+        | HelpContext::ServiceRouting
+        | HelpContext::Support => HelpGroup::Dialogs,
     }
 }
 
@@ -247,6 +248,7 @@ mod tests {
             HelpContext::DnsSettings,
             HelpContext::ThemeSettings,
             HelpContext::ServiceRouting,
+            HelpContext::Support,
         ] {
             let headings = headings(context);
             assert_eq!(headings.len(), 7);

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -792,6 +792,7 @@ fn draw_impl(
         Overlay::DnsSettings => draw_dns_settings(frame, model, area),
         Overlay::ThemeSettings => draw_theme_settings(frame, model, area),
         Overlay::ServiceRouting => draw_service_routing(frame, model, area),
+        Overlay::Support => draw_support(frame, model, area),
         Overlay::Migration => draw_migration(frame, model, area),
         Overlay::None => {}
     }
@@ -1315,6 +1316,92 @@ fn draw_selection_modal(
     lines.push(Line::from(""));
     lines.extend(footer.iter().map(|text| Line::from(*text)));
     draw_modal(frame, theme, area, lines, height_percent);
+}
+
+fn draw_support(frame: &mut Frame, model: &Model, area: Rect) {
+    const ITEMS: [&str; 3] = ["Support development", "Remind me later", "Don't show again"];
+    let width = if area.width < 80 {
+        100
+    } else {
+        POPUP_WIDTH_PERCENT
+    };
+    let horizontal_area = centered_rect(width, 100, area);
+    let row_width = horizontal_area.width.saturating_sub(2) as usize;
+    let column_width = ITEMS
+        .iter()
+        .map(|label| visual_width(label))
+        .max()
+        .unwrap_or(0)
+        .min(row_width);
+    let build_lines = |compact: bool| {
+        let mut lines = vec![Line::from(Span::styled(
+            "Support kvn 🚀",
+            model.theme.accent(),
+        ))];
+        if !compact {
+            lines.push(Line::from(""));
+        }
+        lines.push(Line::from("kvn is free, open source, and built with care."));
+        if !compact {
+            lines.push(Line::from(""));
+        }
+        lines.push(Line::from(
+            "If you find it useful, consider supporting its continued development.",
+        ));
+        if !compact {
+            lines.push(Line::from(""));
+        }
+        lines.push(Line::from(
+            "Your support helps cover AI tools, testing, bug fixes, improvements, and new features.",
+        ));
+        if !compact {
+            lines.push(Line::from(""));
+        }
+        for (index, label) in ITEMS.iter().enumerate() {
+            let style = if index == model.support_selected {
+                model.theme.selected()
+            } else {
+                model.theme.normal()
+            };
+            let text = align_in_centered_column(label, row_width, column_width);
+            lines.push(Line::from(Span::styled(text, style)));
+        }
+        if !compact {
+            lines.push(Line::from(""));
+        }
+        lines.push(Line::from("Enter confirm, q/Esc cancel, ? help"));
+        lines
+    };
+    let content_width = row_width.max(1);
+    let measure = |lines: &[Line]| -> u16 {
+        lines
+            .iter()
+            .map(|line| line.width().max(1).div_ceil(content_width) as u16)
+            .sum()
+    };
+    let mut lines = build_lines(false);
+    let mut content_height = measure(&lines);
+    if content_height.saturating_add(2) > area.height {
+        lines = build_lines(true);
+        content_height = measure(&lines);
+    }
+    let paragraph = Paragraph::new(lines)
+        .style(model.theme.normal())
+        .alignment(Alignment::Center)
+        .wrap(Wrap { trim: false });
+    let popup_height = content_height.saturating_add(2).min(area.height);
+    let popup_area = Rect::new(
+        horizontal_area.x,
+        area.y + area.height.saturating_sub(popup_height) / 2,
+        horizontal_area.width,
+        popup_height,
+    );
+    frame.render_widget(Clear, popup_area);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(model.theme.accent())
+        .style(model.theme.popup_bg());
+    frame.render_widget(paragraph.block(block), popup_area);
 }
 
 /// Draw the unified Sources list: standalone profiles and subscription trees.
@@ -2323,18 +2410,25 @@ mod tests {
         ] {
             let mut model = mouse_model();
             model.overlay = overlay;
-            let mut terminal = Terminal::new(TestBackend::new(80, 20)).unwrap();
+            let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
             terminal
                 .draw(|frame| {
                     draw_with_interaction(frame, &model, MainPaneFocus::Logs, None, None);
                 })
                 .unwrap();
 
-            let popup = centered_rect(width_percent, height_percent, Rect::new(0, 0, 80, 20));
+            let popup = centered_rect(width_percent, height_percent, Rect::new(0, 0, 80, 24));
             let corner =
                 &terminal.backend().buffer().content[popup.y as usize * 80 + popup.x as usize];
             assert_eq!(corner.style().fg, Some(Color::Cyan), "overlay: {overlay:?}");
         }
+
+        let mut model = mouse_model();
+        model.overlay = Overlay::Support;
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        terminal.draw(|frame| draw(frame, &model)).unwrap();
+        let support_corner = &terminal.backend().buffer().content[3 * 80 + 16];
+        assert_eq!(support_corner.style().fg, Some(Color::Cyan));
     }
 
     #[test]
@@ -2593,6 +2687,76 @@ mod tests {
             .position(|s| s == &model.config.settings.theme)
             .unwrap_or(0);
         insta::assert_snapshot!(snapshot_terminal(&model, 80, 32));
+    }
+
+    #[test]
+    fn support_overlay_preserves_copy_and_actions_at_supported_sizes() {
+        for (width, height, popup_height) in [(80, 24, 17), (70, 24, 17), (70, 15, 12)] {
+            let mut model = model_with_profiles(vec![]);
+            model.overlay = Overlay::Support;
+            model.support_selected = 1;
+            let rendered = snapshot_terminal(&model, width, height);
+            for expected in [
+                "Support kvn 🚀",
+                "kvn is free, open source, and built with care.",
+                "development.",
+                "Your support helps cover AI tools",
+                "and new features.",
+                "Support development",
+                "Remind me later",
+                "Don't show again",
+                "Enter confirm, q/Esc cancel, ? help",
+            ] {
+                assert!(
+                    rendered.contains(expected),
+                    "missing {expected:?} at {width}x{height}:\n{rendered}"
+                );
+            }
+            assert!(!rendered.contains("> Support development"));
+
+            let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+            terminal.draw(|frame| draw(frame, &model)).unwrap();
+            let buffer = terminal.backend().buffer();
+            let footer = find_text(buffer, "Enter confirm");
+            let footer_row = footer / width as usize;
+            let popup_y = (height - popup_height) / 2;
+            assert_eq!(footer_row, (popup_y + popup_height - 2) as usize);
+            let popup_x = if width < 80 || height < 24 {
+                0
+            } else {
+                centered_rect(POPUP_WIDTH_PERCENT, 100, Rect::new(0, 0, width, height)).x
+            };
+            assert_eq!(
+                buffer.content[(popup_y * width + popup_x) as usize].symbol(),
+                "┌"
+            );
+            assert_eq!(
+                buffer.content[((popup_y + popup_height - 1) * width + popup_x) as usize].symbol(),
+                "└"
+            );
+        }
+    }
+
+    #[test]
+    fn support_overlay_uses_standard_full_row_selection() {
+        let mut model = model_with_profiles(vec![]);
+        model.overlay = Overlay::Support;
+        model.support_selected = 1;
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        terminal.draw(|frame| draw(frame, &model)).unwrap();
+
+        let buffer = terminal.backend().buffer();
+        let selected = find_text(buffer, "Remind me later");
+        let row_start = selected / 80 * 80;
+        let popup = centered_rect(
+            POPUP_WIDTH_PERCENT,
+            POPUP_HEIGHT_PERCENT_TALL,
+            Rect::new(0, 0, 80, 24),
+        );
+        let expected = model.theme.selected().bg;
+        for x in popup.x + 1..popup.x + popup.width - 1 {
+            assert_eq!(buffer.content[row_start + x as usize].style().bg, expected);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add an unobtrusive support prompt for users who find kvn useful and want to support its continued development.

## Changes

- Show the prompt seven days after initial use once geo routing is configured.
- Open the project's Tribute page from the TUI.
- Allow users to postpone the prompt for 30 days or dismiss it permanently.
- Treat `q` and `Esc` as "Remind me later".
- Persist prompt state atomically under the XDG state directory.
- Add `xdg-utils` as an optional package dependency.
